### PR TITLE
DB-11941 Fix optimizer selectivity issues with db2varchars

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/StoreCostController.java
@@ -163,7 +163,7 @@ public interface StoreCostController extends RowCountable{
                           boolean includeStart,
                           DataValueDescriptor stop,
                           boolean includeStop,
-                          boolean useExtrapolation);
+                          boolean useExtrapolation) throws StandardException;
 
     /**
      * @return the total number of rows in the store (including null and non-null)

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -1305,11 +1305,12 @@ public interface TransactionController
      *
      * @param requestedSplits The number of input splits requested via the splits query hint, or 0 for no hint.
      *
-     * @exception  StandardException  Standard exception policy.
+     * @param useDb2CompatibleVarchars
+	 * @exception  StandardException  Standard exception policy.
      *
      * @see StoreCostController
      **/
-    StoreCostController openStoreCost(TableDescriptor td, ConglomerateDescriptor conglomerateDescriptor, boolean skipDictionaryStats, long defaultRowcount, int requestedSplits) throws StandardException;
+    StoreCostController openStoreCost(TableDescriptor td, ConglomerateDescriptor conglomerateDescriptor, boolean skipDictionaryStats, long defaultRowcount, int requestedSplits, boolean useDb2CompatibleVarchars) throws StandardException;
 
     /**
      * Return a string with debug information about opened congloms/scans/sorts.

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/SQLChar.java
@@ -2931,8 +2931,6 @@ public class SQLChar extends DataType implements StringDataValue, StreamStorable
     }
 
     /**
-     * This function public for testing purposes.
-     *
      * @param trimType  Type of trim (LEADING, TRAILING, or BOTH)
      * @param trimChar  Character to trim
      * @param source    String from which to trim trimChar

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
@@ -84,7 +84,9 @@ public abstract class AbstractSelectivityHolder implements SelectivityHolder {
         s.append("'phase': ").append(phase).append(',');
         s.append("'colNum': ").append(colNum).append(',');
         s.append("'selectivity': ").append(selectivity).append(',');
-        s.append("'predicate': ").append(p.binaryRelOpColRefsToString());
+        if (p != null) {
+            s.append("'predicate': ").append(p.binaryRelOpColRefsToString());
+        }
         s.append("}");
         return s.toString();
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/AbstractSelectivityHolder.java
@@ -76,4 +76,16 @@ public abstract class AbstractSelectivityHolder implements SelectivityHolder {
         else
             return p.getNumReferencedTables();
     }
+
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append(this.getClass().getName());
+        s.append("{");
+        s.append("'phase': ").append(phase).append(',');
+        s.append("'colNum': ").append(colNum).append(',');
+        s.append("'selectivity': ").append(selectivity).append(',');
+        s.append("'predicate': ").append(p.binaryRelOpColRefsToString());
+        s.append("}");
+        return s.toString();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -628,7 +628,7 @@ public class CompilerContextImpl extends ContextImpl
         /*
         ** Not found, so get a StoreCostController from the store.
         */
-        StoreCostController retval = lcc.getTransactionCompile().openStoreCost(td,cd,skipStats, defaultRowCount, requestedSplits);
+        StoreCostController retval = lcc.getTransactionCompile().openStoreCost(td,cd,skipStats, defaultRowCount, requestedSplits, getVarcharDB2CompatibilityMode());
 
         /* Put it in the array */
         storeCostControllers.put(pairedKey, retval);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListSelectivity.java
@@ -67,7 +67,7 @@ public class InListSelectivity extends AbstractSelectivityHolder {
         this.useExtrapolation = isExtrapolationEnabled();
     }
     
-    private double multiplySelectivity(ValueNode vn, int columnNumber, double localSelectivity, boolean useExtrapolation) {
+    private double multiplySelectivity(ValueNode vn, int columnNumber, double localSelectivity, boolean useExtrapolation) throws StandardException {
         if (vn instanceof ConstantNode) {
             ConstantNode cn = (ConstantNode)vn;
             if (localSelectivity == -1.0d)
@@ -81,7 +81,7 @@ public class InListSelectivity extends AbstractSelectivityHolder {
         return localSelectivity;
     }
 
-    private double addSelectivity(ValueNode vn, int columnNumber, double localSelectivity, boolean useExtrapolation) {
+    private double addSelectivity(ValueNode vn, int columnNumber, double localSelectivity, boolean useExtrapolation) throws StandardException {
         double tempSel = -1.0d;
         if (vn instanceof ListValueNode) {
             ListValueNode lvn = (ListValueNode)vn;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1471,7 +1471,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 ** Is it just one more than the previous position?
                 */
                 if((thisIndexPosition-currentStartPosition)> numColsInStartPred ||
-                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate()){
+                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate() ||
+                        thisIndexPosition > varcharRangeKeyPos){
                     /*
                     ** There's a gap in the start positions.  Don't mark any
                     ** more predicates as start predicates.
@@ -1480,7 +1481,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                         !rowIdScan                  &&
                         currentStartPosition == (firstColumnIdx - 1) &&
                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
-                         (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1) {
+                         (thisIndexPosition-currentStartPosition) == numColsInStartPred + 1 &&
+                        thisIndexPosition <= varcharRangeKeyPos) {
                         accessPath.setNumUnusedLeadingIndexFields(1);
                     }
                     else
@@ -1525,7 +1527,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
             /* Same as above, except for stop keys */
             if(currentStopPosition + numColsInStopPred <= thisIndexPosition || thisIndexPosition == -1){
                 if((thisIndexPosition-currentStopPosition)> numColsInStopPred ||
-                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate()){
+                        !considerJoinPredicateAsKey && thisPred.isHashableJoinPredicate() ||
+                        thisIndexPosition > varcharRangeKeyPos){
                     /*
                     ** There's a gap in the start positions.  Don't mark any
                     ** more predicates as start predicates.
@@ -1534,7 +1537,8 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                         !rowIdScan                  &&
                         currentStopPosition == (firstColumnIdx - 1) &&
                         (!thisPred.isHashableJoinPredicate() || considerJoinPredicateAsKey) &&
-                         (thisIndexPosition-currentStopPosition) == numColsInStopPred + 1) {
+                         (thisIndexPosition-currentStopPosition) == numColsInStopPred + 1 &&
+                        thisIndexPosition <= varcharRangeKeyPos) {
                         accessPath.setNumUnusedLeadingIndexFields(1);
                     }
                     else

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ScanCostFunction.java
@@ -424,7 +424,8 @@ public class ScanCostFunction{
         scanCost.setParallelism(scc.getParallelism() != 0 ? scc.getParallelism() : 1);
         scanCost.setLocalCostPerParallelTask(scanCost.localCost(), scanCost.getParallelism());
         scanCost.setRemoteCostPerParallelTask(scanCost.remoteCost(), scanCost.getParallelism());
-            LOG.info(String.format("%n" +
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(String.format("%n" +
                             "============= generateOneRowCost() for table: %s =============%n" +
                             "Conglomerate:               %s, %n" +
                             "totalRowCount:              %.1f, %n" +
@@ -449,7 +450,8 @@ public class ScanCostFunction{
                     scanCost.getFromBaseTableCost(), scanCost.getRemoteCost(),
                     scanCost.getIndexLookupRows(), scanCost.getIndexLookupCost(),
                     scanCost.getProjectionRows(), scanCost.getProjectionCost(),
-                    scanCost.getLocalCost(), scc.getNumPartitions(), scanCost.getLocalCost()/scc.getNumPartitions()));
+                    scanCost.getLocalCost(), scc.getNumPartitions(), scanCost.getLocalCost() / scc.getNumPartitions()));
+        }
     }
 
 
@@ -462,15 +464,17 @@ public class ScanCostFunction{
 
     public void generateCost(long numFirstIndexColumnProbes) throws StandardException {
 
-        LOG.info(String.format("Generate cost for %s", cd));
         double baseTableSelectivity = computePhaseSelectivity(scanSelectivityHolder, topSelectivityHolder, QualifierPhase.BASE);
-        LOG.info(String.format("Base Table Selectivity %s", baseTableSelectivity));
         double filterBaseTableSelectivity = computePhaseSelectivity(scanSelectivityHolder, topSelectivityHolder,QualifierPhase.BASE,QualifierPhase.FILTER_BASE);
-        LOG.info(String.format("Filter Base Table Selectivity %s", filterBaseTableSelectivity));
         double projectionSelectivity = computePhaseSelectivity(scanSelectivityHolder, topSelectivityHolder,QualifierPhase.FILTER_PROJECTION);
-        LOG.info(String.format("projection Selectivity %s", projectionSelectivity));
         double totalSelectivity = computeTotalSelectivity(scanSelectivityHolder, topSelectivityHolder);
-        LOG.info(String.format("total Selectivity %s", totalSelectivity));
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(String.format("Generate cost for %s", cd));
+            LOG.trace(String.format("Base Table Selectivity %s", baseTableSelectivity));
+            LOG.trace(String.format("Filter Base Table Selectivity %s", filterBaseTableSelectivity));
+            LOG.trace(String.format("projection Selectivity %s", projectionSelectivity));
+            LOG.trace(String.format("total Selectivity %s", totalSelectivity));
+        }
 
         assert filterBaseTableSelectivity >= 0 && filterBaseTableSelectivity <= 1.0:"filterBaseTableSelectivity Out of Bounds -> " + filterBaseTableSelectivity;
         assert baseTableSelectivity >= 0 && baseTableSelectivity <= 1.0:"baseTableSelectivity Out of Bounds -> " + baseTableSelectivity;
@@ -571,7 +575,8 @@ public class ScanCostFunction{
         scanCost.setLocalCostPerParallelTask((baseCost + lookupCost + projectionCost), scanCost.getParallelism());
         scanCost.setRemoteCostPerParallelTask(scanCost.remoteCost(), scanCost.getParallelism());
 
-            LOG.info(String.format("%n" +
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(String.format("%n" +
             "============= generateCost() for table: %s =============%n" +
             "Conglomerate:               %s, %n" +
             "baseTableSelectivity:       %.18f, %n" +
@@ -602,7 +607,8 @@ public class ScanCostFunction{
             scanCost.getFromBaseTableCost(), scanCost.getRemoteCost(),
             scanCost.getIndexLookupRows(), scanCost.getIndexLookupCost(),
             scanCost.getProjectionRows(), scanCost.getProjectionCost(),
-            scanCost.getLocalCost(), scc.getNumPartitions(), scanCost.getLocalCost()/scc.getNumPartitions()));
+            scanCost.getLocalCost(), scc.getNumPartitions(), scanCost.getLocalCost() / scc.getNumPartitions()));
+        }
     }
 
     /**
@@ -700,7 +706,9 @@ public class ScanCostFunction{
     public static double computeSqrtLevel(double selectivity, int level, SelectivityHolder holder) throws StandardException {
         if (level ==0) {
             selectivity *= holder.getSelectivity();
-            LOG.info(String.format("Holder: %s, computedSelectivity: %s", holder, selectivity));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(String.format("Holder: %s, computedSelectivity: %s", holder, selectivity));
+            }
             return selectivity;
         }
         double incrementalSelectivity = 0.0d;
@@ -708,7 +716,9 @@ public class ScanCostFunction{
         for (int i =1;i<=level;i++)
             incrementalSelectivity=Math.sqrt(incrementalSelectivity);
         selectivity*=incrementalSelectivity;
-        LOG.info(String.format("Holder: %s, computedSelectivity: %s", holder, selectivity));
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(String.format("Holder: %s, computedSelectivity: %s", holder, selectivity));
+        }
         return selectivity;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/stats/StoreCostControllerImpl.java
@@ -17,13 +17,13 @@ import com.splicemachine.EngineDriver;
 import com.splicemachine.access.api.FileInfo;
 import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.sql.compile.CostEstimate;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.stats.*;
 import com.splicemachine.db.iapi.store.access.StoreCostController;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.RowLocation;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.catalog.SYSTABLESTATISTICSRowFactory;
 import com.splicemachine.db.impl.sql.compile.FirstColumnOfIndexStats;
@@ -57,18 +57,14 @@ public class StoreCostControllerImpl implements StoreCostController {
 
     private static Logger LOG = Logger.getLogger(StoreCostControllerImpl.class);
 
-    private static final Function<? super Partition,? extends String> partitionNameTransform = new Function<Partition, String>(){
-        @Override public String apply(Partition hRegionInfo) {
-            assert hRegionInfo != null : "regionInfo cannot be null!";
-            return hRegionInfo.getName();
-        }
+    private static final Function<? super Partition,? extends String> partitionNameTransform = (Function<Partition, String>) hRegionInfo -> {
+        assert hRegionInfo != null : "regionInfo cannot be null!";
+        return hRegionInfo.getName();
     };
 
-    private static final Function<PartitionStatisticsDescriptor,String> partitionStatisticsTransform = new Function<PartitionStatisticsDescriptor, String>(){
-        @Override public String apply(PartitionStatisticsDescriptor desc){
-            assert desc!=null: "Descriptor cannot be null!";
-            return desc.getPartitionId();
-        }
+    private static final Function<PartitionStatisticsDescriptor,String> partitionStatisticsTransform = desc -> {
+        assert desc!=null: "Descriptor cannot be null!";
+        return desc.getPartitionId();
     };
 
     private final double openLatency;
@@ -90,7 +86,8 @@ public class StoreCostControllerImpl implements StoreCostController {
     private double sampleFraction;
     private boolean isMergedStats;
     private int requestedSplits;
-	private FirstColumnOfIndexStats firstColumnStats;
+    private FirstColumnOfIndexStats firstColumnStats;
+    private boolean useDb2CompatibleVarchars;
 
     // The number of parallel Spark tasks that would run concurrently
     // to access this table.
@@ -102,7 +99,8 @@ public class StoreCostControllerImpl implements StoreCostController {
                                    List<PartitionStatisticsDescriptor> tablePartitionStatistics,
                                    List<PartitionStatisticsDescriptor> exprIndexPartitionStatistics,
                                    long defaultRowCount,
-                                   int requestedSplits) throws StandardException {
+                                   int requestedSplits,
+                                   boolean useDb2CompatibleVarchars) throws StandardException {
         SConfiguration config = EngineDriver.driver().getConfiguration();
         this.requestedSplits = requestedSplits;
         openLatency = config.getFallbackOpencloseLatency();
@@ -111,6 +109,7 @@ public class StoreCostControllerImpl implements StoreCostController {
         extraQualifierMultiplier = config.getOptimizerExtraQualifierMultiplier();
         fallbackLocalLatency =config.getFallbackLocalLatency();
         fallbackRemoteLatencyRatio =config.getFallbackRemoteLatencyRatio();
+        this.useDb2CompatibleVarchars = useDb2CompatibleVarchars;
 
         baseTableRow = td.getEmptyExecRow();
         if (conglomerateDescriptor.getIndexDescriptor() != null &&
@@ -349,8 +348,8 @@ public class StoreCostControllerImpl implements StoreCostController {
         cost.setOpenCost(openLatency);
         cost.setCloseCost(closeLatency);
         if (LOG.isTraceEnabled())
-            SpliceLogUtils.trace(LOG,"getFetchFromFullKeyCost={columnSizeFactor=%f, cost=%s" +
-                    "cost=%s",columnSizeFactor,cost);
+            SpliceLogUtils.trace(LOG,"getFetchFromFullKeyCost={columnSizeFactor=%f, cost=%s}",
+                    columnSizeFactor,cost);
 
 
     }
@@ -360,8 +359,37 @@ public class StoreCostControllerImpl implements StoreCostController {
         return null;
     }
 
+    private StringDataValue trimKey(StringDataValue key) throws StandardException {
+        if (key == null || key.getString() == null) {
+            return key;
+        }
+        return key.ansiTrim(StringDataValue.TRAILING, new SQLChar(" "), null);
+    }
+
+    private StringDataValue padKey(StringDataValue key, int length) throws StandardException {
+        if (key == null || key.getString() == null) {
+            return key;
+        }
+        SQLChar newStopKey = new SQLChar(key.getString());
+        newStopKey.setWidth(length, -1, true);
+        return newStopKey;
+    }
+
     @Override
-    public double getSelectivity(boolean fromExprIndex, int columnNumber, DataValueDescriptor start, boolean includeStart, DataValueDescriptor stop, boolean includeStop, boolean useExtrapolation) {
+    public double getSelectivity(boolean fromExprIndex, int columnNumber, DataValueDescriptor start, boolean includeStart, DataValueDescriptor stop, boolean includeStop, boolean useExtrapolation) throws StandardException {
+        if (useDb2CompatibleVarchars && baseTableRow.getColumn(columnNumber).getTypeName().equals(TypeId.VARCHAR_NAME)) {
+            int varcharLength = ((SQLVarchar)baseTableRow.getColumn(columnNumber)).getSqlCharSize();
+            if (includeStart) {
+                start = trimKey((StringDataValue)start);
+            } else {
+                start = padKey((StringDataValue) start, varcharLength);
+            }
+            if (includeStop) {
+                stop = padKey((StringDataValue)stop, varcharLength);
+            } else {
+                stop = trimKey((StringDataValue) stop);
+            }
+        }
         if (fromExprIndex) {
             return exprIndexStatistics.rangeSelectivity(start, stop, includeStart, includeStop, columnNumber - 1, useExtrapolation);
         } else {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
@@ -1018,12 +1018,13 @@ public class SpliceTransactionManager implements XATransactionController,
      *
      * @param cd  The descriptor of the conglomerate to open.
      *
+     * @param useDb2CompatibleVarchars
      * @exception StandardException Standard exception policy.
      *
      * @see StoreCostController
      **/
     @Override
-    public StoreCostController openStoreCost(TableDescriptor td, ConglomerateDescriptor cd, boolean skipDictionaryStats, long defaultRowCount, int requestedSplits) throws StandardException {
+    public StoreCostController openStoreCost(TableDescriptor td, ConglomerateDescriptor cd, boolean skipDictionaryStats, long defaultRowCount, int requestedSplits, boolean useDb2CompatibleVarchars) throws StandardException {
         List<PartitionStatisticsDescriptor> tablePartitionStatistics = new ArrayList<>();
         List<PartitionStatisticsDescriptor> exprIndexPartitionStatistics = new ArrayList<>();
         if (!skipDictionaryStats) {
@@ -1035,7 +1036,7 @@ public class SpliceTransactionManager implements XATransactionController,
                 exprIndexPartitionStatistics = dd.getPartitionStatistics(cd.getConglomerateNumber(), this);
             }
         }
-        return new StoreCostControllerImpl(td, cd, tablePartitionStatistics, exprIndexPartitionStatistics, skipDictionaryStats?defaultRowCount:0, requestedSplits);
+        return new StoreCostControllerImpl(td, cd, tablePartitionStatistics, exprIndexPartitionStatistics, skipDictionaryStats?defaultRowCount:0, requestedSplits, useDb2CompatibleVarchars);
     }
      /**
      * @see TransactionController#getProperty

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -439,6 +439,11 @@ public class SpliceUnitTest {
     }
 
     protected void testQueryContains(String sqlText, String containedString,
+                                     SpliceWatcher methodWatcher) throws Exception {
+        testQueryContains(sqlText, containedString, methodWatcher, true);
+    }
+
+    protected void testQueryContains(String sqlText, String containedString,
                                      SpliceWatcher methodWatcher,
                                      boolean caseInsensitive) throws Exception {
         ResultSet rs = null;


### PR DESCRIPTION
## Short Description
This PR fixes two selectivity issues with db2 compatible SQLVarchar

## Long Description
DB2 strings lookup in sketches:
To estimate selectivity, we lookup the key from a predicate in statistics sketches. If that key is Varchar and DB2 strings compatibility mode is enabled, we should not search for that precise key in the sketches, but for a range of equivalent keys. Luckily, we already support a startKey and a stopKey when probing sketches, so instead of passing the same value twice, we need to pass a trimmed version of the key as a startKey, and a padded version of the key as a stopKey

Multi-column indexes cannot be used beyond a DB2 varchar column with startKey/stopKey
Say we have an index on three columns (VARCHAR, INT, INT)
If DB2 strings are not used, the first three predicates of that index can have startKey and stopKey.
However, given the fact that the first column of that index is a DB2Varchar, its startKey and stopKey will cover an entire range, and subsequent columns would fraction that range in separate subranges instead of refining it.