### PR TITLE
DB-11973 Fix bindTimezoneOperation's static call to SpliceDateFunctions

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -249,7 +249,7 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
 
         MethodCallNode methodNode = new StaticMethodCallNode(
                 functionName,
-                "com.splicemachine.derby.utils.SpliceDateFunctions",
+                "com.splicemachine.derby.procedures.SpliceDateFunctions",
                 getContextManager());
         Vector<ValueNode> parameterList = new Vector<>();
         parameterList.addElement(getLeftOperand());

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -1564,11 +1564,9 @@ public class SpliceDateFunctionsIT extends SpliceUnitTest {
     @Test
     public void testBindTimezoneOperation() throws Exception {
         // See DB-11973
-        testQuery(
+        testQueryContains(
                 "select timestamp(trim('2016-08-05-07.12.59.000000')) + current timezone from sysibm.sysdummy1",
-                "1           |\n" +
-                        "-----------------------\n" +
-                        "2016-08-05 08:12:59.0 |",
+                "2016-08-05",
                 methodWatcher);
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceDateFunctionsIT.java
@@ -1560,4 +1560,15 @@ public class SpliceDateFunctionsIT extends SpliceUnitTest {
             assertEquals("22007", e.getSQLState());
         }
     }
+
+    @Test
+    public void testBindTimezoneOperation() throws Exception {
+        // See DB-11973
+        testQuery(
+                "select timestamp(trim('2016-08-05-07.12.59.000000')) + current timezone from sysibm.sysdummy1",
+                "1           |\n" +
+                        "-----------------------\n" +
+                        "2016-08-05 08:12:59.0 |",
+                methodWatcher);
+    }
 }


### PR DESCRIPTION
## Short Description

Fix regression introduced by DB-11668

## Long Description

DB-11668 moved SpliceDateFunctions to another package without changing the reference in BinaryArithmeticOperatorNode. This PR fixes that.

## How to test

select timestamp(trim('2016-08-05-07.12.59.000000')) + current timezone from sysibm.sysdummy1;

does not fail anymore