### PR TITLE
DB-11966: set selectivityEstimationIncludingSkewedDefault for all servers

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/services/property/PropertyUtil.java
@@ -94,8 +94,7 @@ public class PropertyUtil {
             Property.LOCKS_ESCALATION_THRESHOLD,
             Property.DATABASE_PROPERTIES_ONLY,
             Property.DEFAULT_CONNECTION_MODE_PROPERTY,
-            PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM,
-            Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED
+            PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM
     };
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -579,8 +579,8 @@ public class GenericStatement implements Statement{
 
     private void setSelectivityEstimationIncludingSkewedDefault(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
         /* get the selectivity estimation property so that we know what strategy to use to estimate selectivity */
-        String selectivityEstimationString = PropertyUtil.getServiceProperty(lcc.getTransactionCompile(),
-        Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
+        String selectivityEstimationString = PropertyUtil.getCachedDatabaseProperty(lcc,
+                Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
         Boolean selectivityEstimationIncludingSkewedDefault = Boolean.parseBoolean(selectivityEstimationString);
 
         cc.setSelectivityEstimationIncludingSkewedDefault(selectivityEstimationIncludingSkewedDefault);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -533,7 +533,6 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
                     }
                 }
             }
-            startParams.setProperty("catalogVersion", dictionaryVersion.toString());
             assert authorizationDatabaseOwner!=null:"Failed to get Database Owner authorization";
 
             // Update (or create) the system stored procedures if requested.

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 
 import com.splicemachine.access.HConfiguration;
@@ -93,11 +94,11 @@ public class ZkPropertyManager implements PropertyManager{
     }
 
     @Override
-    public void removeProperty(String propertyName) throws StandardException {
+    public void removeProperty(String propertyName){
         try {
             ZkUtils.safeDelete(zkSpliceDerbyPropertyPath + "/" + propertyName, -1);
-        } catch (Exception e) {
-            throw StandardException.plainWrapException(e);
+        } catch (KeeperException | InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
@@ -67,8 +67,14 @@ public class ZkPropertyManager implements PropertyManager{
 
     @Override
     public void addProperty(String propertyName,String propertyValue) throws StandardException{
+        String path = zkSpliceDerbyPropertyPath + "/" + propertyName;
         try{
-            ZkUtils.safeCreate(zkSpliceDerbyPropertyPath+"/"+propertyName,Bytes.toBytes(propertyValue),ZooDefs.Ids.OPEN_ACL_UNSAFE,CreateMode.PERSISTENT);
+            if (ZkUtils.getRecoverableZooKeeper().exists(path, false) == null) {
+                ZkUtils.safeCreate(path, Bytes.toBytes(propertyValue), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            }
+            else {
+                ZkUtils.setData(path, Bytes.toBytes(propertyValue), -1);
+            }
         }catch(Exception e){
             throw Exceptions.parseException(e);
         }

--- a/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/impl/sql/ZkPropertyManager.java
@@ -85,4 +85,13 @@ public class ZkPropertyManager implements PropertyManager{
             throw Exceptions.parseException(e);
         }
     }
+
+    @Override
+    public void removeProperty(String propertyName) throws StandardException {
+        try {
+            ZkUtils.safeDelete(zkSpliceDerbyPropertyPath + "/" + propertyName, -1);
+        } catch (Exception e) {
+            throw StandardException.plainWrapException(e);
+        }
+    }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
@@ -54,4 +54,9 @@ public class DirectPropertyManager implements PropertyManager{
     public void clearProperties() throws StandardException{
         properties.clear();
     }
+
+    @Override
+    public void removeProperty(String propertyName) throws StandardException {
+        properties.remove(propertyName);
+    }
 }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/DirectPropertyManager.java
@@ -56,7 +56,7 @@ public class DirectPropertyManager implements PropertyManager{
     }
 
     @Override
-    public void removeProperty(String propertyName) throws StandardException {
+    public void removeProperty(String propertyName) {
         properties.remove(propertyName);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
@@ -35,4 +35,6 @@ public interface PropertyManager{
     void addProperty(String propertyName, String propertyValue) throws StandardException;
 
     void clearProperties() throws StandardException;
+
+    void removeProperty(String propertyName) throws StandardException;
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManager.java
@@ -36,5 +36,5 @@ public interface PropertyManager{
 
     void clearProperties() throws StandardException;
 
-    void removeProperty(String propertyName) throws StandardException;
+    void removeProperty(String propertyName);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManagerService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/iapi/sql/PropertyManagerService.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.derby.iapi.sql;
 
+import com.splicemachine.db.iapi.reference.Property;
+
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -24,7 +26,7 @@ import java.util.ServiceLoader;
 public class PropertyManagerService{
     private static volatile PropertyManager propertyManager;
 
-    public static PropertyManager loadPropertyManager(){
+    public static PropertyManager loadPropertyManager() {
         PropertyManager pm = propertyManager;
         if(pm==null){
             pm = loadPropertyManagerSync();
@@ -32,7 +34,7 @@ public class PropertyManagerService{
         return pm;
     }
 
-    private static synchronized PropertyManager loadPropertyManagerSync(){
+    private static synchronized PropertyManager loadPropertyManagerSync() {
         PropertyManager pm = propertyManager;
         if(pm==null){
             ServiceLoader<PropertyManager> load=ServiceLoader.load(PropertyManager.class);
@@ -43,6 +45,7 @@ public class PropertyManagerService{
             //TODO -sf- initialize if needed
             if(iter.hasNext())
                 throw new IllegalStateException("Only one PropertyManager service is allowed!");
+            propertyManager.removeProperty(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED);
         }
         return pm;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
@@ -61,8 +61,10 @@ public class SpliceService implements PersistentService {
 			Set<String> properties = propertyManager.listProperties();
 //			List<String> children = ZkUtils.getChildren(zkSpliceDerbyPropertyPath, false);
 			for (String property: properties) {
-				String value = propertyManager.getProperty(property);
-				service.setProperty(property, value);
+				if (!property.equals(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED)) {
+					String value = propertyManager.getProperty(property);
+					service.setProperty(property, value);
+				}
 			}
 		} catch (Exception e) {
             SpliceLogUtils.logAndThrow(LOG, "getServiceProperties Failed", Exceptions.parseException(e));

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
@@ -38,10 +38,9 @@ public class SpliceService implements PersistentService {
 	private static Logger LOG = Logger.getLogger(SpliceService.class);
 	private PropertyManager propertyManager;
 
-	public SpliceService() {
+	public SpliceService() throws StandardException {
 		SpliceLogUtils.trace(LOG,"instantiated");
 		propertyManager = PropertyManagerService.loadPropertyManager();
-//	    Thread.currentThread().setContextClassLoader(HBaseConfiguration.class.getClassLoader());
 	}
 	
 	public String getType() {
@@ -60,24 +59,17 @@ public class SpliceService implements PersistentService {
 		Properties service = new Properties(defaultProperties);
 		try {
 			Set<String> properties = propertyManager.listProperties();
-//			List<String> children = ZkUtils.getChildren(zkSpliceDerbyPropertyPath, false);
 			for (String property: properties) {
-				if (!property.equals(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED)) {
-					String value = propertyManager.getProperty(property);
-					service.setProperty(property, value);
-				}
+				String value = propertyManager.getProperty(property);
+				service.setProperty(property, value);
 			}
 		} catch (Exception e) {
             SpliceLogUtils.logAndThrow(LOG, "getServiceProperties Failed", Exceptions.parseException(e));
 		}
 		SpliceLogUtils.trace(LOG,"getServiceProperties serviceName: %s, defaultProperties %s",serviceName, defaultProperties);
-//		Properties service = new Properties(SpliceUtils.getAllProperties(defaultProperties));
 
 		service.setProperty(Property.SERVICE_PROTOCOL,"com.splicemachine.db.database.Database");
 		service.setProperty(EngineType.PROPERTY,Integer.toString(getEngineType()));
-		//service.setProperty(DataDictionary.CORE_DATA_DICTIONARY_VERSION,"10.9");
-//		service.setProperty(Property.REQUIRE_AUTHENTICATION_PARAMETER, "true");
-//		service.setProperty("derby.language.logQueryPlan", "true"); // unclear of this...
 		if (LOG.isTraceEnabled()) {
 			LOG.trace("getServiceProperties actual properties serviceName" + serviceName + ", properties " + service);
 		}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/SpliceService.java
@@ -29,6 +29,7 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -85,9 +86,17 @@ public class SpliceService implements PersistentService {
 
 	public void saveServiceProperties(String serviceName, StorageFactory storageFactory, Properties properties, boolean replace) throws StandardException {
 		SpliceLogUtils.trace(LOG,"saveServiceProperties with storageFactory serviceName: %s, properties %s, replace %s",serviceName, properties, replace);
-		for (Object key :properties.keySet()) {
-			if (!propertyManager.propertyExists((String)key)) {
-				propertyManager.addProperty((String)key,properties.getProperty((String)key));
+		for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+			String key = (String)entry.getKey();
+			String value = (String)properties.get(key);
+			String v = null;
+			try {
+				v = propertyManager.getProperty((String) key);
+			} catch (Exception e) {
+				//Ignore exceptions
+			}
+			if (v == null || !v.equals(value)) {
+				propertyManager.addProperty((String) key, value);
 			}
 		}
 	}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -118,10 +118,6 @@ public class PropertyConglomerate {
         try {
             Set<String> props = propertyManager.listProperties();
             for (String child: props) {
-                if (child.equals(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED)) {
-                    propertyManager.removeProperty(child);
-                    continue;
-                }
                 String value = startParams != null ? startParams.getProperty(child) : null;
                 if (value == null) {
                     value = propertyManager.getProperty(child);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/PropertyConglomerate.java
@@ -110,7 +110,6 @@ public class PropertyConglomerate {
             serviceProperties.put(Property.DATABASE_PROPERTIES_ONLY, "false");
             serviceProperties.put(Property.DEFAULT_CONNECTION_MODE_PROPERTY, "fullAccess");
             serviceProperties.put(PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM, PropertyHelper.AUTHENTICATION_BUILTIN_ALGORITHM_DEFAULT);
-            serviceProperties.put(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED, "false");
             for (Object key: serviceProperties.keySet()) {
                 propertyManager.addProperty((String)key,serviceProperties.getProperty((String)key));
             }
@@ -119,6 +118,10 @@ public class PropertyConglomerate {
         try {
             Set<String> props = propertyManager.listProperties();
             for (String child: props) {
+                if (child.equals(Property.SELECTIVITY_ESTIMATION_INCLUDING_SKEWED)) {
+                    propertyManager.removeProperty(child);
+                    continue;
+                }
                 String value = startParams != null ? startParams.getProperty(child) : null;
                 if (value == null) {
                     value = propertyManager.getProperty(child);

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
@@ -18,11 +18,15 @@ import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.derby.test.framework.TestConnection;
 import com.splicemachine.test.SerialTest;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
 
 /**
  *
@@ -58,4 +62,20 @@ public class GlobalDatabasePropertyIT extends SpliceUnitTest {
         }
     }
 
+    @Test
+    public void testSelectivityEstimationIncludingSkewed() throws Exception {
+        String sql = "call syscs_util.syscs_get_global_database_property('derby.database.selectivityEstimationIncludingSkewedDefault')";
+        try (TestConnection conn = methodWatcher.getOrCreateConnection()) {
+            setProperty("derby.database.selectivityEstimationIncludingSkewedDefault", "true");
+            try(Statement s = conn.createStatement();
+                ResultSet rs = s.executeQuery(sql)) {
+                while(rs.next()) {
+                    String result = rs.getString("PROPERTY_VALUE");
+                    Assert.assertTrue(result.compareToIgnoreCase("true") == 0);
+                }
+            }
+        } finally {
+            setProperty("derby.database.selectivityEstimationIncludingSkewedDefault", "NULL");
+        }
+    }
 }


### PR DESCRIPTION
## Short Description
`selectivityEstimationIncludingSkewedDefault` was defined as a service property, which cannot be set globally by `syscs_set_global_database_property`.

## Long Description
`selectivityEstimationIncludingSkewedDefault` was defined as a service property, which cannot be set globally by `syscs_set_global_database_property`. To fix it, remove it from service properties, and fix the code to retrieve it from service property.

## How to test

Run 

`call syscs_util.syscs_set_global_database_property('derby.database.selectivityEstimationIncludingSkewedDefault', 'true');`

to set it to true. Verify it is set for all servers

```
call syscs_util.syscs_get_global_database_property('derby.database.selectivityEstimationIncludingSkewedDefault');
HOST_NAME                     |PROPERTY_VALUE
-----------------------------------------------
Juns-MacBook-Pro-2.local:1527 | true  
Juns-MacBook-Pro-2.local:1528 | true

2 rows selected
```






