### PR TITLE
DB-11985 Improve ZK DDL Refresh logging

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLWatchChecker.java
+++ b/hbase_sql/src/main/java/com/splicemachine/ddl/ZooKeeperDDLWatchChecker.java
@@ -17,6 +17,7 @@ package com.splicemachine.ddl;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.primitives.Bytes;
@@ -120,8 +121,10 @@ public class ZooKeeperDDLWatchChecker implements DDLWatchChecker{
         } catch (IOException e) {
             if (e.getCause() instanceof KeeperException.NoNodeException) {
                 // the node doesn't exit, return null
+                LOG.warn(String.format("Cannot find a node for change with id %s", changeId));
                 return null;
             }
+            LOG.error(String.format("Cannot get a node for change with id %s", changeId), e);
             throw e;
         }
         return DDLMessage.DDLChange.newBuilder()
@@ -155,12 +158,15 @@ public class ZooKeeperDDLWatchChecker implements DDLWatchChecker{
                 else{
                     OpResult.ErrorResult err = (OpResult.ErrorResult)result;
                     KeeperException.Code code = KeeperException.Code.get(err.getErr());
+                    String errorMessage = String.format("Cannot create a node for change with id %s, code %s", changeList.get(i).getChangeId(), code.toString());
                     switch(code){
                         case NODEEXISTS: //we may have already set the value, so ignore node exists issues
                         case NONODE: // someone already removed the notification, it's obsolete
                             // ignore
+                            LOG.warn(errorMessage);
                             break;
                         default:
+                            LOG.error(errorMessage);
                             throw Exceptions.getIOException(KeeperException.create(code));
                     }
                 }
@@ -168,12 +174,16 @@ public class ZooKeeperDDLWatchChecker implements DDLWatchChecker{
         } catch (InterruptedException e) {
             throw Exceptions.getIOException(e);
         } catch (KeeperException e) {
+            String changeIds = String.join(",", changeList.stream().map(c -> c.getChangeId()).collect(Collectors.toList()));
+            String errorMessage = String.format("Could not execute multiple ZooKeeper operations for changes with ids %s, code %s", changeIds, e.code().toString());
             switch(e.code()) {
                 case NODEEXISTS: //we may have already set the value, so ignore node exists issues
                 case NONODE: // someone already removed the notification, it's obsolete
+                    LOG.warn(errorMessage);
                     // ignore
                     break;
                 default:
+                    LOG.error(errorMessage, e);
                     throw Exceptions.getIOException(e);
             }
         }

--- a/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/ddl/DDLWatchRefresher.java
@@ -98,6 +98,7 @@ public class DDLWatchRefresher{
             ongoingDDLChangeIds = watchChecker.getCurrentChangeIds();
         }
         catch (IOException e) {
+            LOG.error(String.format("Could not get current change ids during clearing of change with id %s", changeId));
             throw StandardException.plainWrapException(e);
         }
         clearFinishedChange(ongoingDDLChangeIds, changeId, ddlListeners);
@@ -164,7 +165,7 @@ public class DDLWatchRefresher{
                     seenDDLChanges.add(changeId);
                     newChanges.add(new Pair<DDLChange, String>(change,null));
                 } catch (Exception e) {
-                    LOG.error("Encountered an exception processing DDL change",e);
+                    LOG.error(String.format("Encountered an exception processing DDL change with id %s", changeId), e);
                     newChanges.add(new Pair<>(change,e.getLocalizedMessage()));
                 }
             }
@@ -288,7 +289,7 @@ public class DDLWatchRefresher{
                 watchChecker.assignDDLDemarcationPoint(ddlChange.getTxnId());
             }
         } catch (Exception e) {
-            LOG.error("Couldn't create ddlFilter", e);
+            LOG.error(String.format("Couldn't create ddlFilter for change with id %s", ddlChange.getChangeId()), e);
         }
 
     }
@@ -347,6 +348,7 @@ public class DDLWatchRefresher{
             DDLFilter filter = ddlDemarcationPoint.get();
             return filter == null || filter.isVisibleBy(((SpliceTransactionManager)xact_mgr).getActiveStateTxn());
         } catch (IOException e) {
+            LOG.warn("Could not get the demarcation point", e);
             // Stay on the safe side, assume it's not visible
             return false;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
The log improvements are done to have better understanding of issues, described in DB-11505.
Improve log statements in classes, which are responsible for ddl synchronisation between nodes, adding information about change id, when problem occuers.

## Long Description
For example, currently when max waiting time is reached, the log statement has no information for which change id it happens: 

2021-02-18 18:19:01,636 ERROR [DRDAConnThread_418] ddl.AsynchronousDDLController: Maximum wait for all servers exceeded. Missing response from [pjx-bml-hdpw032.clearsense.local,16020,1613665268935]

new format will be

Maximum wait for change with id spliceconnection0000000000 for all servers exceeded. Missing response from spliceconnection0000000000

Change id is added also to other log statements.

## How to test
The log statements will be visible only when errors or timeouts occure
