### PR TITLE
DB-11756 Add sketch size as global property

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSRowFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/SYSCOLUMNSRowFactory.java
@@ -35,8 +35,12 @@ import com.splicemachine.db.catalog.TypeDescriptor;
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.catalog.types.DefaultInfoImpl;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.Property;
+import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.services.uuid.UUIDFactory;
+import com.splicemachine.db.iapi.sql.conn.ConnectionUtil;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
@@ -45,6 +49,7 @@ import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import splice.com.google.common.collect.Lists;
 
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -203,7 +208,15 @@ public class SYSCOLUMNSRowFactory extends CatalogRowFactory {
             collectStats = column.collectStatistics();
             partitionPosition = column.getPartitionPosition();
             useExtrapolation = column.getUseExtrapolation();
-            sketchSize = column.getSketchSize();
+            try{
+                LanguageConnectionContext lcc= ConnectionUtil.getCurrentLCC();
+                String sketchSizeStr =
+                        PropertyUtil.getDatabaseProperty(lcc.getTransactionExecute(), Property.FREQUENCY_SKETCH_SIZE);
+                if (sketchSizeStr == null) sketchSize = Property.DEFAULT_FREQUENCY_SKETCH_SIZE;
+                else sketchSize = Integer.parseInt(sketchSizeStr);
+            }catch(SQLException t){
+                t.printStackTrace();
+            }
         }
 
 		/* Insert info into syscolumns */
@@ -216,7 +229,8 @@ public class SYSCOLUMNSRowFactory extends CatalogRowFactory {
 		    /* Build the row to insert  */
         row = getExecutionFactory().getValueRow(SYSCOLUMNS_COLUMN_COUNT);
         setRowColumns(row, colName, defaultID, tabID, colID, storageNumber, typeDesc, defaultSerializable, autoincStart,
-                autoincInc, autoincValue, partitionPosition, autoinc_create_or_modify_Start_Increment, collectStats, useExtrapolation, sketchSize);
+                autoincInc, autoincValue, partitionPosition, autoinc_create_or_modify_Start_Increment,
+                collectStats, useExtrapolation, sketchSize);
 
         return row;
     }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1287,5 +1287,10 @@ public interface Property {
     String ENTERPRISE_ENABLE = "splicemachine.enterprise.enable";
 
     String SPLICE_OLAP_PARALLEL_PARTITIONS = "splice.olapParallelPartitions";
+
+    /** The property is used to get the default value for default frequency sketch size of a column.
+     */
+    String FREQUENCY_SKETCH_SIZE = "splice.statistics.defaultFrequencySketchSize";
+    int DEFAULT_FREQUENCY_SKETCH_SIZE = 1024;
 }
 


### PR DESCRIPTION
<!--- Create new global database property splice.statistics.defaultFrequencySketchSize-->

## Short Description
We need a new global database property that should set the default value for frequency sketch sizes. 

Once that new property is set (for example to 8192), a new entry in sys.syscolumns should have its frequencySketchSize set to 8192

This new property should be set via 

`call syscs_util.syscs_set_global_database_property('splice.statistics.defaultFrequencySketchSize', '8192');`


## How to test
```
SPLICE* - 	jdbc:splice://localhost:1527/splicedb
* = current connection
splice> select * from sys.syscolumns where sketchsize != 0;
REFERENCEID                         |COLUMNNAME                                                                                                                      |COLUMNNUMB&|STORAGENUM&|COLUMNDATATYPE |COLUMNDEFAULT  |COLUMNDEFAULTID                     |AUTOINCREMENTVALUE  |AUTOINCREMENTSTART  |AUTOINCREMENTINC    |COLL&|PARTITIONP&|USEEX&|SKETCHSIZE 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

0 rows selected
ELAPSED TIME = 525 milliseconds
splice> create table tableX (colX int);
0 rows inserted/updated/deleted
ELAPSED TIME = 343 milliseconds
splice> select * from sys.syscolumns where sketchsize != 0;
REFERENCEID                         |COLUMNNAME                                                                                                                      |COLUMNNUMB&|STORAGENUM&|COLUMNDATATYPE |COLUMNDEFAULT  |COLUMNDEFAULTID                     |AUTOINCREMENTVALUE  |AUTOINCREMENTSTART  |AUTOINCREMENTINC    |COLL&|PARTITIONP&|USEEX&|SKETCHSIZE 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
f18e829c-0179-391d-6546-00000c99dc88|COLX                                                                                                                            |1          |1          |INTEGER        |NULL           |NULL                                |NULL                |NULL                |NULL                |true |-1         |0     |1024       

1 row selected
ELAPSED TIME = 205 milliseconds
splice> call syscs_util.syscs_set_global_database_property('splice.statistics.defaultFrequencySketchSize', '8192');
name                |value                                                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PROPERTY_NAME       |splice.statistics.defaultFrequencySketchSize                                                                                                          
NEW VALUE           |8192                                                                                                                                                  
PREVIOUS VALUE      |NULL                                                                                                                                                  
INFO                |                                                                                                                                                      

4 rows selected
ELAPSED TIME = 219 milliseconds
splice> values syscs_util.syscs_get_database_property('splice.statistics.defaultFrequencySketchSize');
1                                                                                                                                                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8192                                                                                                                                                                                                                                                            

1 row selected
ELAPSED TIME = 57 milliseconds
splice> create table tableY (coly1 int, coly2 int);
0 rows inserted/updated/deleted
ELAPSED TIME = 185 milliseconds
splice> select * from sys.syscolumns where sketchsize != 0;
REFERENCEID                         |COLUMNNAME                                                                                                                      |COLUMNNUMB&|STORAGENUM&|COLUMNDATATYPE |COLUMNDEFAULT  |COLUMNDEFAULTID                     |AUTOINCREMENTVALUE  |AUTOINCREMENTSTART  |AUTOINCREMENTINC    |COLL&|PARTITIONP&|USEEX&|SKETCHSIZE 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
f18e829c-0179-391d-6546-00000c99dc88|COLX                                                                                                                            |1          |1          |INTEGER        |NULL           |NULL                                |NULL                |NULL                |NULL                |true |-1         |0     |1024       
e21d02a9-0179-391d-6546-00000c99dc88|COLY1                                                                                                                           |1          |1          |INTEGER        |NULL           |NULL                                |NULL                |NULL                |NULL                |true |-1         |0     |8192       
e21d02a9-0179-391d-6546-00000c99dc88|COLY2                                                                                                                           |2          |2          |INTEGER        |NULL           |NULL                                |NULL                |NULL                |NULL                |true |-1         |0     |8192       

3 rows selected
ELAPSED TIME = 49 milliseconds
```