### PR TITLE
[DRAFT] Redo "DB-9656 better error output for nonmatching parameters in CALL"

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/RoutineAliasInfo.java
@@ -47,12 +47,14 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.ProtobufUtils;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.impl.sql.CatalogMessage;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Describe a routine (procedure or function) alias.
  *
  * @see com.splicemachine.db.catalog.AliasInfo
  */
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class RoutineAliasInfo extends MethodAliasInfo
 {
 
@@ -480,6 +482,34 @@ public class RoutineAliasInfo extends MethodAliasInfo
 	 */
 	public	int	getTypeFormatId()	{ return StoredFormatIds.ROUTINE_INFO_V01_ID; }
 
+	public void toStringParameters(StringBuilder sb)
+	{
+		sb.append(getMethodName());
+		sb.append('(');
+		for (int i = 0; i < parameterCount; i++) {
+			if (i != 0)
+				sb.append(", ");
+
+			if (returnType == null) {
+				// This is a PROCEDURE.  We only want to print the
+				// parameter mode (ex. "IN", "OUT", "INOUT") for procedures--
+				// we don't do it for functions since use of the "IN" keyword
+				// is not part of the FUNCTION syntax.
+				sb.append(RoutineAliasInfo.parameterMode(parameterModes[i]));
+				sb.append(' ');
+			}
+			sb.append(IdUtil.normalToDelimited(parameterNames[i]));
+			sb.append(' ');
+			sb.append(parameterTypes[i].getSQLstring());
+		}
+		sb.append(')');
+
+		if (returnType != null) {
+			// this a FUNCTION, so syntax requires us to append the return type.
+			sb.append(" RETURNS ").append(returnType.getSQLstring());
+		}
+	}
+
 	/**
 	 * Get this alias info as a string.  NOTE: The "ALIASINFO" column
 	 * in the SYSALIASES table will return the result of this method
@@ -491,67 +521,44 @@ public class RoutineAliasInfo extends MethodAliasInfo
 	 */
 	public String toString() {
 
-		StringBuilder sb = new StringBuilder(100);
-		sb.append(getMethodName());
-		sb.append('(');
-		for (int i = 0; i < parameterCount; i++) {
-			if (i != 0)
-				sb.append(',');
+        StringBuilder sb = new StringBuilder(100);
+        toStringParameters(sb);
 
-			if (returnType == null) {
-			// This is a PROCEDURE.  We only want to print the
-			// parameter mode (ex. "IN", "OUT", "INOUT") for procedures--
-			// we don't do it for functions since use of the "IN" keyword
-			// is not part of the FUNCTION syntax.
-				sb.append(RoutineAliasInfo.parameterMode(parameterModes[i]));
-				sb.append(' ');
-			}
-			sb.append(IdUtil.normalToDelimited(parameterNames[i]));
-			sb.append(' ');
-			sb.append(parameterTypes[i].getSQLstring());
-		}
-		sb.append(')');
+        sb.append(" LANGUAGE ");
+        sb.append(this.language);	// Language can now be Python
+        sb.append(" PARAMETER STYLE " );
 
-		if (returnType != null) {
-		// this a FUNCTION, so syntax requires us to append the return type.
-			sb.append(" RETURNS ").append(returnType.getSQLstring());
-		}
+        switch( parameterStyle )
+        {
+            case PS_JAVA:                   sb.append( "JAVA " ); break;
+            case PS_SPLICE_JDBC_RESULT_SET: sb.append( "SPLICE_JDBC_RESULT_SET " ); break;
+            default: break;
+        }
 
-		sb.append(" LANGUAGE ");
-		sb.append(this.language);	// Language can now be Python
-		sb.append(" PARAMETER STYLE " );
-
-		switch( parameterStyle )
-		{
-		    case PS_JAVA:    sb.append( "JAVA " ); break;
-		    case PS_SPLICE_JDBC_RESULT_SET:    sb.append( "SPLICE_JDBC_RESULT_SET " ); break;
-			default:
-		}
-        
         if ( isDeterministic() )
         { sb.append( " DETERMINISTIC " ); }
 
         if ( hasDefinersRights())
         { sb.append( " EXTERNAL SECURITY DEFINER " ); }
 
-		sb.append(RoutineAliasInfo.SQL_CONTROL[getSQLAllowed()]);
-		if ((returnType == null) &&
-			(dynamicResultSets != 0))
-		{ // Only print dynamic result sets if this is a PROCEDURE
-		  // because it's not valid syntax for FUNCTIONs.
-			sb.append(" DYNAMIC RESULT SETS ");
-			sb.append(dynamicResultSets);
-		}
+        sb.append(RoutineAliasInfo.SQL_CONTROL[getSQLAllowed()]);
+        if ((returnType == null) &&
+            (dynamicResultSets != 0))
+        { // Only print dynamic result sets if this is a PROCEDURE
+          // because it's not valid syntax for FUNCTIONs.
+            sb.append(" DYNAMIC RESULT SETS ");
+            sb.append(dynamicResultSets);
+        }
 
-		if (returnType != null) {
-		// this a FUNCTION, so append the syntax telling what to
-		// do with a null parameter.
-			sb.append(calledOnNullInput ? " CALLED " : " RETURNS NULL ");
-			sb.append("ON NULL INPUT");
-		}
-		
-		return sb.toString();
-	}
+        if (returnType != null) {
+        // this a FUNCTION, so append the syntax telling what to
+        // do with a null parameter.
+            sb.append(calledOnNullInput ? " CALLED " : " RETURNS NULL ");
+            sb.append("ON NULL INPUT");
+        }
+
+        return sb.toString();
+    }
 
 	public static String parameterMode(int parameterMode) {
 		switch (parameterMode) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/StaticMethodCallNode.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.catalog.types.TypeDescriptorImpl;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 
+import com.splicemachine.db.iapi.services.i18n.MessageService;
 import com.splicemachine.db.iapi.services.io.StoredFormatIds;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
@@ -223,6 +224,7 @@ public class StaticMethodCallNode extends MethodCallNode {
             // look for a routine
 
             String schemaName = procedureName.getSchemaName();
+            StringBuilder errorList = new StringBuilder(100);
             Object candidateSchemasProperty = getLanguageConnectionContext()
                     .getSessionProperties()
                     .getProperty(SessionProperties.PROPERTYNAME.CURRENTFUNCTIONPATH);
@@ -235,7 +237,8 @@ public class StaticMethodCallNode extends MethodCallNode {
                         throw StandardException.newException(SQLState.LANG_CURRENT_FUNCTION_PATH_SCHEMA_DOES_NOT_EXIST,
                                                              Arrays.toString(candidateSchemas), candidateSchema);
                     }
-                    sd = setAliasDescriptor(fromList, subqueryList, aggregateVector, sd, candidateSchema == null);
+                    sd = setAliasDescriptor(fromList, subqueryList, aggregateVector, sd, candidateSchema == null,
+                            errorList);
                     if (ad != null) { // resolution complete
                         break;
                     }
@@ -243,7 +246,8 @@ public class StaticMethodCallNode extends MethodCallNode {
             }
             if(ad == null) { // couldn't resolve with candidate schemas (if any), try with current one.
                 sd = getSchemaDescriptor(schemaName, schemaName != null);
-                sd = setAliasDescriptor(fromList, subqueryList, aggregateVector, sd, schemaName == null);
+                sd = setAliasDescriptor(fromList, subqueryList, aggregateVector, sd, schemaName == null,
+                        errorList);
             }
 
             if (handleAggregate()) {
@@ -253,8 +257,13 @@ public class StaticMethodCallNode extends MethodCallNode {
             /* Throw exception if no routine found */
             if (ad == null)
             {
-                throw StandardException.newException(
-                        SQLState.LANG_NO_SUCH_METHOD_ALIAS, procedureName);
+                if( errorList.length() > 0 ) {
+                    throw StandardException.newException(SQLState.LANG_NO_SUCH_PROCEDURE2, procedureName,
+                            "\n" + errorList.toString());
+                }
+                else {
+                    throw StandardException.newException(SQLState.LANG_NO_SUCH_PROCEDURE, procedureName);
+                }
             }
 
             if ( !routineInfo.isDeterministic() )
@@ -390,13 +399,14 @@ public class StaticMethodCallNode extends MethodCallNode {
                                                 SubqueryList subqueryList,
                                                 List<AggregateNode> aggregateVector,
                                                 SchemaDescriptor sd,
-                                                boolean noSchema) throws StandardException {
+                                                boolean noSchema,
+                                                StringBuilder errorList) throws StandardException {
 
         SchemaDescriptor result = sd;
 
         // The field methodName is used by resolveRoutine and
         // is set to the name of the routine (procedureName.getTableName()).
-        resolveRoutine(fromList, subqueryList, aggregateVector, sd);
+        resolveRoutine(fromList, subqueryList, aggregateVector, sd, errorList);
 
         // (Splice) This logic, to implicitly check for routine using SYSFUN schema,
         // was moved here from a few lines down, so that it has a chance to find
@@ -413,7 +423,7 @@ public class StaticMethodCallNode extends MethodCallNode {
             // an in-memory table, set up in DataDictionaryImpl.
             result = getSchemaDescriptor("SYSFUN", true);
 
-            resolveRoutine(fromList, subqueryList, aggregateVector, result);
+            resolveRoutine(fromList, subqueryList, aggregateVector, result, errorList);
             setIsSystemFunction(true);
         }
         return result;
@@ -508,12 +518,13 @@ public class StaticMethodCallNode extends MethodCallNode {
      * @param subqueryList
      * @param aggregateVector
      * @param sd
+     * @param errorList for printing out detailed information if we can't find the correct function
      * @throws StandardException
      */
     private void resolveRoutine(FromList fromList,
                                 SubqueryList subqueryList,
                                 List<AggregateNode> aggregateVector,
-                                SchemaDescriptor sd) throws StandardException {
+                                SchemaDescriptor sd, StringBuilder errorList) throws StandardException {
         if (sd.getUUID() == null) {
             return;
         }
@@ -524,13 +535,21 @@ public class StaticMethodCallNode extends MethodCallNode {
         );
 
         for (int i = list.size() - 1; i >= 0; i--) {
-
             AliasDescriptor proc = list.get(i);
 
             RoutineAliasInfo routineInfo = (RoutineAliasInfo) proc.getAliasInfo();
             int parameterCount = routineInfo.getParameterCount();
-            if (parameterCount != methodParms.length)
+            if (parameterCount != methodParms.length) {
+
+                StringBuilder sb = new StringBuilder();
+                routineInfo.toStringParameters(sb);
+                // - Parameter count is wrong (provided {0}, but needs {1})\n  for {2}\n
+                Object[] arguments = {  String.valueOf(methodParms.length),
+                                        String.valueOf(parameterCount),
+                                        sb.toString() };
+                errorList.append(MessageService.getCompleteMessage(SQLState.ERROR_CALL_PARAMETER_COUNT_WRONG, arguments));
                 continue;
+            }
 
             // pre-form the method signature. If it is a dynamic result set procedure
             // then we need to add in the ResultSet array
@@ -545,50 +564,26 @@ public class StaticMethodCallNode extends MethodCallNode {
             for (int p = 0; p < parameterCount; p++) {
 
                 // find the declared type.
-
                 TypeDescriptor td = parameterTypes[p];
-
                 TypeId typeId = TypeId.getTypeId(td);
-
                 TypeId parameterTypeId = typeId;
-
 
                 // if it's an OUT or INOUT parameter we need an array.
                 int parameterMode = routineInfo.getParameterModes()[p];
 
                 if (parameterMode != JDBC30Translation.PARAMETER_MODE_IN) {
-
-                    String arrayType;
-                    switch (typeId.getJDBCTypeId()) {
-                        case java.sql.Types.BOOLEAN:
-                        case java.sql.Types.SMALLINT:
-                        case java.sql.Types.INTEGER:
-                        case java.sql.Types.BIGINT:
-                        case java.sql.Types.REAL:
-                        case java.sql.Types.DOUBLE:
-                            arrayType = getTypeCompiler(typeId).getCorrespondingPrimitiveTypeName() + "[]";
-                            break;
-                        default:
-                            arrayType = typeId.getCorrespondingJavaTypeName() + "[]";
-                            break;
-                    }
-
+                    String arrayType = getJavaTypeNameFromJDBCTypeId(typeId);
                     typeId = TypeId.getUserDefinedTypeId(arrayType, false);
                 }
 
                 // this is the type descriptor of the require method parameter
                 DataTypeDescriptor methoddtd = new DataTypeDescriptor(
-                        typeId,
-                        td.getPrecision(),
-                        td.getScale(),
-                        td.isNullable(),
-                        td.getMaximumWidth()
+                        typeId, td.getPrecision(), td.getScale(), td.isNullable(), td.getMaximumWidth()
                 );
 
                 signature[p] = new JSQLType(methoddtd);
 
                 // check parameter is a ? node for INOUT and OUT parameters.
-
                 ValueNode sqlParamNode = null;
 
                 if (methodParms[p] instanceof SQLToJavaValueNode) {
@@ -614,22 +609,16 @@ public class StaticMethodCallNode extends MethodCallNode {
                     } else
                         applicationParameterNumbers[p] = ((ParameterNode) sqlParamNode).getParameterNumber();
                 }
-
                 // this is the SQL type of the procedure parameter.
                 DataTypeDescriptor paramdtd = new DataTypeDescriptor(
-                        parameterTypeId,
-                        td.getPrecision(),
-                        td.getScale(),
-                        td.isNullable(),
-                        td.getMaximumWidth()
+                        parameterTypeId, td.getPrecision(), td.getScale(), td.isNullable(), td.getMaximumWidth()
                 );
 
                 boolean needCast = false;
                 if (!isParameterMarker) {
 
                     // can only be an IN parameter.
-                    // check that the value can be assigned to the
-                    // type of the procedure parameter.
+                    // check that the value can be assigned to the type of the procedure parameter.
                     if (sqlParamNode instanceof UntypedNullConstantNode) {
                         sqlParamNode.setType(paramdtd);
                     } else {
@@ -663,10 +652,8 @@ public class StaticMethodCallNode extends MethodCallNode {
                             needCast = true;
                     }
                 } else {
-                    // any variable length type will need a cast from the
-                    // Java world (the ? parameter) to the SQL type. This
-                    // ensures values like CHAR(10) are passed into the procedure
-                    // correctly as 10 characters long.
+                    // any variable length type will need a cast from the Java world (the ? parameter) to the SQL type.
+                    // This ensures values like CHAR(10) are passed into the procedure correctly as 10 characters long.
                     if (parameterTypeId.variableLength()) {
 
                         if (parameterMode != JDBC30Translation.PARAMETER_MODE_OUT)
@@ -674,35 +661,24 @@ public class StaticMethodCallNode extends MethodCallNode {
                     }
                 }
 
-
                 if (needCast) {
-                    // push a cast node to ensure the
-                    // correct type is passed to the method
-                    // this gets tacky because before we knew
-                    // it was a procedure call we ensured all the
-                    // parameter are JavaNodeTypes. Now we need to
-                    // push them back to the SQL domain, cast them
+                    // push a cast node to ensure the correct type is passed to the method
+                    // this gets tacky because before we knew it was a procedure call we ensured all the
+                    // parameter are JavaNodeTypes. Now we need to push them back to the SQL domain, cast them
                     // and then push them back to the Java domain.
-
-                    if (sqlParamNode == null) {
-
-                            sqlParamNode = new JavaToSQLValueNode(methodParms[p], getContextManager());
-                        }
-
-                    ValueNode castNode = makeCast
-                            (
-                                    sqlParamNode,
-                                    paramdtd,
-                                    getContextManager()
-                            );
-
-
-                    methodParms[p] = (JavaValueNode) getNodeFactory().getNode(
-                            C_NodeTypes.SQL_TO_JAVA_VALUE_NODE,
-                            castNode,
-                            getContextManager());
-
-                    methodParms[p] = methodParms[p].bindExpression(fromList, subqueryList, aggregateVector);
+                    try {
+                        sqlParamNode = addCastNode(fromList, subqueryList, aggregateVector, p, sqlParamNode, paramdtd);
+                    }
+                    catch( StandardException se )
+                    {
+                        StringBuilder sb = new StringBuilder();
+                        routineInfo.toStringParameters(sb);
+                        // - ERROR for parameter {0}: {1}:\n  for {2}\n
+                        Object[] arguments = { String.valueOf(p), se.getMessage(), sb.toString() };
+                        errorList.append(MessageService.getCompleteMessage(
+                                SQLState.ERROR_CALL_PARAMETER_CAST_ERROR, arguments));
+                        return;
+                    }
                 }
 
                 // only force the type for a ? so that the correct type shows up
@@ -712,19 +688,9 @@ public class StaticMethodCallNode extends MethodCallNode {
             }
 
             if (sigParameterCount != parameterCount) {
-
                 TypeId typeId = TypeId.getUserDefinedTypeId("java.sql.ResultSet[]", false);
-
-                DataTypeDescriptor dtd = new DataTypeDescriptor(
-                        typeId,
-                        0,
-                        0,
-                        false,
-                        -1
-                );
-
+                DataTypeDescriptor dtd = new DataTypeDescriptor(typeId, 0, 0, false, -1);
                 signature[parameterCount] = new JSQLType(dtd);
-
             }
 
             this.routineInfo = routineInfo;
@@ -745,95 +711,7 @@ public class StaticMethodCallNode extends MethodCallNode {
         // The parameters, and retruen type for these two Stored Procedures are the same
         if(this.routineInfo!=null && this.routineInfo.getLanguage() != null &&this.routineInfo.getLanguage().equals("PYTHON"))
         {
-
-            // determine whether the routine is for a procedure or function
-            boolean isFunction = !forCallStatement;
-            this.methodName = isFunction?PYFUNCTION_WRAPPER_METHOD_NAME:PYPROCEDURE_WRAPPER_METHOD_NAME;
-            // need to add compiled Python code bytes into signature and methodParms
-            byte[] compiledPyCode = this.routineInfo.getCompiledPyCode();
-
-            // Update the parameterCnt ,parameterModes, parameterNames, parameterTypes
-            int origParmCnt = this.routineInfo.getParameterCount();
-            int updatedParmCnt = origParmCnt + 1;
-
-            int[] updatedParmModes = new int[updatedParmCnt];
-            String[] updatedParmNames = new String[updatedParmCnt];
-            TypeDescriptor[] updatedParmTypes = new TypeDescriptor[updatedParmCnt];
-            if(origParmCnt > 0) {
-                System.arraycopy(this.routineInfo.getParameterModes(), 0, updatedParmModes,0,origParmCnt);
-                System.arraycopy(this.routineInfo.getParameterNames(), 0, updatedParmNames,0,origParmCnt);
-                System.arraycopy(this.routineInfo.getParameterTypes(), 0, updatedParmTypes, 0, origParmCnt);
-            }
-            updatedParmModes[origParmCnt] = 1; // States the input script is an IN parameter
-            // Here Need to use a unique name
-            updatedParmNames[origParmCnt] = "PYCODE";
-            updatedParmTypes[origParmCnt] = new TypeDescriptorImpl(new BaseTypeIdImpl(StoredFormatIds.BLOB_TYPE_ID_IMPL),
-                    true,
-                    compiledPyCode.length);
-
-            // update the routineInfo and the AliasDescriptor
-            this.routineInfo = new RoutineAliasInfo(this.methodName,
-                    "JAVA",
-                    updatedParmCnt,
-                    updatedParmNames,
-                    updatedParmTypes,
-                    updatedParmModes,
-                    this.routineInfo.getMaxDynamicResultSets(),
-                    this.routineInfo.getParameterStyle(),
-                    this.routineInfo.getSQLAllowed(),
-                    this.routineInfo.isDeterministic(),
-                    this.routineInfo.hasDefinersRights(),
-                    this.routineInfo.calledOnNullInput(),
-                    this.routineInfo.getReturnType(),
-                    null);
-
-            this.ad = new AliasDescriptor(this.ad.getDataDictionary(),
-                    ad.getUUID(),
-                    ad.getName(),
-                    ad.getSchemaUUID(),
-                    PYROUTINE_WRAPPER_CLASS_NAME,
-                    ad.getAliasType(),
-                    ad.getNameSpace(),
-                    ad.getSystemAlias(),
-                    routineInfo,
-                    ad.getSpecificName());
-
-            // Update signature by adding in the script String's corresponding JSQLType
-            JSQLType pyCodeType = new JSQLType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(TypeId.BLOB_NAME));
-            JSQLType[] updatedSigs = new JSQLType[signature.length+1];
-            // Adding the Pycode parameter right before the first occurance of the ResultSet[]
-            // If no ResultSet[] exists, appending Pycode at the end of all the existing parameters
-            int j = 0;
-            for(int i = 0; i < signature.length+1; i++){
-                if(i<signature.length && signature[i].getSQLType().getTypeId().getCorrespondingJavaTypeName().equals("java.sql.ResultSet[]")){
-                    updatedSigs[i] = pyCodeType;
-                }
-                else{
-                    if(j == signature.length){
-                        updatedSigs[i] = pyCodeType;
-                    }
-                    else{
-                        updatedSigs[i] = signature[j];
-                        j++;
-                    }
-                }
-            }
-            this.signature = updatedSigs;
-            ContextManager cm = getContextManager();
-            CompilerContext cc = getCompilerContext();
-            QueryTreeNode pyCodeNode = null;
-            String hexCompiledPyCodeStr = com.splicemachine.db.iapi.util.StringUtil.toHexString(compiledPyCode,0,compiledPyCode.length);
-            try{
-
-                pyCodeNode = (QueryTreeNode) cc.getNodeFactory().getNode(C_NodeTypes.BLOB_CONSTANT_NODE,
-                        hexCompiledPyCodeStr, compiledPyCode.length,cm);
-                pyCodeNode = (QueryTreeNode) cc.getNodeFactory().getNode(C_NodeTypes.SQL_TO_JAVA_VALUE_NODE, pyCodeNode,cm);
-            } catch(Exception e){
-                // Fill in Exception Handling
-                throw StandardException.plainWrapException(e);
-            }
-            // Update methodParms by adding in the script String's corresponding JSQLType
-            addOneParm((JavaValueNode)pyCodeNode);
+            callPython();
         }
 
         if ( (ad == null) && (methodParms.length == 1) )
@@ -841,26 +719,149 @@ public class StaticMethodCallNode extends MethodCallNode {
             ad = AggregateNode.resolveAggregate( getDataDictionary(), sd, methodName );
         }
     }
-        /**
-         * Wrap a parameter in a CAST node.
-         */
-        public static ValueNode makeCast (ValueNode parameterNode,
-                                          DataTypeDescriptor targetType,
-                                          ContextManager cm)
-                throws StandardException
-        {
-            ValueNode castNode = new CastNode(parameterNode, targetType, cm);
 
-            // Argument type has the same semantics as assignment:
-            // Section 9.2 (Store assignment). There, General Rule
-            // 2.b.v.2 says that the database should raise an exception
-            // if truncation occurs when stuffing a string value into a
-            // VARCHAR, so make sure CAST doesn't issue warning only.
-            ((CastNode)castNode).setAssignmentSemantics();
-            ((CastNode)castNode).setIsFunctionArgument();
-
-            return castNode;
+    private String getJavaTypeNameFromJDBCTypeId(TypeId typeId) {
+        String arrayType;
+        switch (typeId.getJDBCTypeId()) {
+            case Types.BOOLEAN:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.REAL:
+            case Types.DOUBLE:
+                arrayType = getTypeCompiler(typeId).getCorrespondingPrimitiveTypeName() + "[]";
+                break;
+            default:
+                arrayType = typeId.getCorrespondingJavaTypeName() + "[]";
+                break;
         }
+        return arrayType;
+    }
+
+    private void callPython() throws StandardException {
+        // determine whether the routine is for a procedure or function
+        boolean isFunction = !forCallStatement;
+        this.methodName = isFunction?PYFUNCTION_WRAPPER_METHOD_NAME:PYPROCEDURE_WRAPPER_METHOD_NAME;
+        // need to add compiled Python code bytes into signature and methodParms
+        byte[] compiledPyCode = this.routineInfo.getCompiledPyCode();
+
+        // Update the parameterCnt ,parameterModes, parameterNames, parameterTypes
+        int origParmCnt = this.routineInfo.getParameterCount();
+        int updatedParmCnt = origParmCnt + 1;
+
+        int[] updatedParmModes = new int[updatedParmCnt];
+        String[] updatedParmNames = new String[updatedParmCnt];
+        TypeDescriptor[] updatedParmTypes = new TypeDescriptor[updatedParmCnt];
+        if(origParmCnt > 0) {
+            System.arraycopy(this.routineInfo.getParameterModes(), 0, updatedParmModes,0,origParmCnt);
+            System.arraycopy(this.routineInfo.getParameterNames(), 0, updatedParmNames,0,origParmCnt);
+            System.arraycopy(this.routineInfo.getParameterTypes(), 0, updatedParmTypes, 0, origParmCnt);
+        }
+        updatedParmModes[origParmCnt] = 1; // States the input script is an IN parameter
+        // Here Need to use a unique name
+        updatedParmNames[origParmCnt] = "PYCODE";
+        updatedParmTypes[origParmCnt] = new TypeDescriptorImpl(new BaseTypeIdImpl(StoredFormatIds.BLOB_TYPE_ID_IMPL),
+                true,
+                compiledPyCode.length);
+
+        // update the routineInfo and the AliasDescriptor
+        this.routineInfo = new RoutineAliasInfo(this.methodName,
+                "JAVA",
+                updatedParmCnt,
+                updatedParmNames,
+                updatedParmTypes,
+                updatedParmModes,
+                this.routineInfo.getMaxDynamicResultSets(),
+                this.routineInfo.getParameterStyle(),
+                this.routineInfo.getSQLAllowed(),
+                this.routineInfo.isDeterministic(),
+                this.routineInfo.hasDefinersRights(),
+                this.routineInfo.calledOnNullInput(),
+                this.routineInfo.getReturnType(),
+                null);
+
+        this.ad = new AliasDescriptor(this.ad.getDataDictionary(),
+                ad.getUUID(),
+                ad.getName(),
+                ad.getSchemaUUID(),
+                PYROUTINE_WRAPPER_CLASS_NAME,
+                ad.getAliasType(),
+                ad.getNameSpace(),
+                ad.getSystemAlias(),
+                routineInfo,
+                ad.getSpecificName());
+
+        // Update signature by adding in the script String's corresponding JSQLType
+        JSQLType pyCodeType = new JSQLType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(TypeId.BLOB_NAME));
+        JSQLType[] updatedSigs = new JSQLType[signature.length+1];
+        // Adding the Pycode parameter right before the first occurance of the ResultSet[]
+        // If no ResultSet[] exists, appending Pycode at the end of all the existing parameters
+        int j = 0;
+        for(int i = 0; i < signature.length+1; i++){
+            if(i<signature.length && signature[i].getSQLType().getTypeId().getCorrespondingJavaTypeName().equals("java.sql.ResultSet[]")){
+                updatedSigs[i] = pyCodeType;
+            }
+            else{
+                if(j == signature.length){
+                    updatedSigs[i] = pyCodeType;
+                }
+                else{
+                    updatedSigs[i] = signature[j];
+                    j++;
+                }
+            }
+        }
+        this.signature = updatedSigs;
+        ContextManager cm = getContextManager();
+        CompilerContext cc = getCompilerContext();
+        QueryTreeNode pyCodeNode = null;
+        String hexCompiledPyCodeStr = com.splicemachine.db.iapi.util.StringUtil.toHexString(compiledPyCode,0,compiledPyCode.length);
+        try{
+
+            pyCodeNode = (QueryTreeNode) cc.getNodeFactory().getNode(C_NodeTypes.BLOB_CONSTANT_NODE,
+                    hexCompiledPyCodeStr, compiledPyCode.length,cm);
+            pyCodeNode = (QueryTreeNode) cc.getNodeFactory().getNode(C_NodeTypes.SQL_TO_JAVA_VALUE_NODE, pyCodeNode,cm);
+        } catch(Exception e){
+            // Fill in Exception Handling
+            throw StandardException.plainWrapException(e);
+        }
+        // Update methodParms by adding in the script String's corresponding JSQLType
+        addOneParm((JavaValueNode)pyCodeNode);
+    }
+
+    private ValueNode addCastNode(FromList fromList, SubqueryList subqueryList, List<AggregateNode> aggregateVector,
+                                  int p, ValueNode sqlParamNode, DataTypeDescriptor paramdtd) throws StandardException {
+        if (sqlParamNode == null) {
+            sqlParamNode = new JavaToSQLValueNode(methodParms[p], getContextManager());
+        }
+        ValueNode castNode = makeCast(sqlParamNode, paramdtd, getContextManager());
+
+        methodParms[p] = (JavaValueNode) getNodeFactory().getNode(
+                C_NodeTypes.SQL_TO_JAVA_VALUE_NODE, castNode, getContextManager());
+        methodParms[p] = methodParms[p].bindExpression(fromList, subqueryList, aggregateVector);
+        return sqlParamNode;
+    }
+
+    /**
+     * Wrap a parameter in a CAST node.
+     */
+    public static ValueNode makeCast (ValueNode parameterNode,
+                                      DataTypeDescriptor targetType,
+                                      ContextManager cm)
+            throws StandardException
+    {
+        ValueNode castNode = new CastNode(parameterNode, targetType, cm);
+
+        // Argument type has the same semantics as assignment:
+        // Section 9.2 (Store assignment). There, General Rule
+        // 2.b.v.2 says that the database should raise an exception
+        // if truncation occurs when stuffing a string value into a
+        // VARCHAR, so make sure CAST doesn't issue warning only.
+        ((CastNode)castNode).setAssignmentSemantics();
+        ((CastNode)castNode).setIsFunctionArgument();
+
+        return castNode;
+    }
 
 
     /**
@@ -901,7 +902,7 @@ public class StaticMethodCallNode extends MethodCallNode {
         Push extra code to generate the casts within the
         arrays for the parameters passed as arrays.
     */
-    public    void generateOneParameter(ExpressionClassBuilder acb,
+    public void generateOneParameter(ExpressionClassBuilder acb,
                                             MethodBuilder mb,
                                             int parameterNumber )
             throws StandardException

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -984,6 +984,7 @@ public interface SQLState {
     String LANG_NO_SUCH_METHOD_ALIAS                                       = "42Y03.S.0";
     String LANG_NO_SUCH_PROCEDURE                                          = "42Y03.S.1";
     String LANG_NO_SUCH_FUNCTION                                           = "42Y03.S.2";
+    String LANG_NO_SUCH_PROCEDURE2                                         = "42Y03.S.3";
     String LANG_INVALID_FULL_STATIC_METHOD_NAME                            = "42Y04";
     String LANG_NO_SUCH_FOREIGN_KEY                                        = "42Y05";
     String LANG_CURRENT_FUNCTION_PATH_SCHEMA_DOES_NOT_EXIST                = "42Y06";
@@ -2102,6 +2103,8 @@ public interface SQLState {
 
     String HBASE_OPERATION_ERROR = "HO001";
 
+    String ERROR_CALL_PARAMETER_COUNT_WRONG = "44004";
+    String ERROR_CALL_PARAMETER_CAST_ERROR = "44005";
 
 }
 

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2461,6 +2461,13 @@ Guide.
             </msg>
 
             <msg>
+                <name>42Y03.S.3</name>
+                <text>Could not resolve function or procedure call '{0}':{1}</text>
+                <arg>procedureName</arg>
+                <arg>statement</arg>
+            </msg>
+
+            <msg>
                 <name>42Y04</name>
                 <text>Cannot create a procedure or function with EXTERNAL NAME '{0}' because it is not a list separated by periods. The expected format is &lt;full java path&gt;.&lt;method name&gt;.</text>
                 <arg>name</arg>
@@ -3441,6 +3448,27 @@ Guide.
                 <text>Timestamp '{0}' is out of range (~ from 21 Sep 1677 00:12:44 GMT to 11 Apr 2262 23:47:16 GMT).</text>
                 <arg>dateOrTimestamp</arg>
             </msg>
+
+            <msg>
+                <name>44004</name>
+                <text>- Parameter count is wrong (provided {0}, but needs {1})
+  for {2}
+</text>
+                <arg>providedParameterCount</arg>
+                <arg>needsParameterCount</arg>
+                <arg>routineInfo</arg>
+            </msg>
+
+            <msg>
+                <name>44005</name>
+                <text>- ERROR for parameter {0}: {1}:
+  for {2}
+</text>
+                <arg>parameterNumber</arg>
+                <arg>errorMsg</arg>
+                <arg>routineInfo</arg>
+            </msg>
+
         </family>
 
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdminIT.java
@@ -387,6 +387,36 @@ public class SpliceAdminIT extends SpliceUnitTest {
     }
 
     @Test
+    public void testCallWithWrongParameters() throws Exception {
+        // wrong parameter count
+        try {
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('hello')");
+        }
+        catch(SQLException e )
+        {
+            Assert.assertEquals(
+                    "java.sql.SQLSyntaxErrorException: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':\n" +
+                    "- Parameter count is wrong (provided 1, but needs 2)\n" +
+                    "  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN \"KEY\" VARCHAR(128), IN \"VALUE\" VARCHAR(32672))\n",
+                    e.toString());
+        }
+
+        // wrong parameter type
+        try {
+            methodWatcher.execute("call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 )");
+        }
+        catch(SQLException e )
+        {
+            Assert.assertEquals(
+                    "java.sql.SQLSyntaxErrorException: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':\n" +
+                    "- ERROR for parameter 0: Cannot convert types 'INTEGER' to 'VARCHAR'.:\n" +
+                    "  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN \"KEY\" VARCHAR(128), IN \"VALUE\" VARCHAR(32672))\n",
+                    e.toString());
+        }
+    }
+
+
+    @Test
     public void testUpdateSchemaOwner() throws Exception {
         String schemaName = "SPLICEADMINITSCHEMAFOO";
         String userName = "SPLICEADMINITUSERFRED";


### PR DESCRIPTION
DRAFT

# Description
Adding better error output for when users try to call functions with wrong parameters.

# Motivation

Users can make various mistakes when calling a function, and the error message should help solving those.
Examples of current behavior:

## parameter count wrong (old behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'a', 'b', 'c');
ERROR 42Y03: 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY' is not recognized as a function or procedure.
```

This is misleading, as there IS a function, however the parameter count is wrong.

## wrong parameter type (old behavior)

```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 );
ERROR 42846: Cannot convert types 'INTEGER' to 'VARCHAR'.
```

This is better than the behavior when having wrong parameter count. However, when calling a function with multiple parameters, it might not be clear which one of the integers is wrong.

In both cases, error output should list the parameters of the function that was found.

# How to test

New error output looks like this:

## parameter count wrong (NEW behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 'a', 'b', 'c');
ERROR 42Y03: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':
- Parameter count is wrong (provided 3, but needs 2)
  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN "KEY" VARCHAR(128), IN "VALUE" VARCHAR(32672))
```

## wrong parameter type (NEW behavior)
```
splice> call SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY( 123, 123 );
ERROR 42Y03: Could not resolve function or procedure call 'SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY':
- ERROR for parameter 0: Cannot convert types 'INTEGER' to 'VARCHAR'.:
  for SYSCS_SET_GLOBAL_DATABASE_PROPERTY(IN "KEY" VARCHAR(128), IN "VALUE" VARCHAR(32672))
```