### PR TITLE
DB-11856: upgrade SPLICE_SEQUENCE table

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -1820,7 +1820,7 @@ public interface DataDictionary{
      *
      * @see #addDescriptor
      */
-    void addDescriptorArray(TupleDescriptor[] tuple,
+    RowLocation[] addDescriptorArray(TupleDescriptor[] tuple,
                             TupleDescriptor parent,
                             int catalogNumber,
                             boolean allowsDuplicates,

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ScanController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/ScanController.java
@@ -325,4 +325,5 @@ public interface ScanController extends GenericScanController{
     boolean replace(DataValueDescriptor[] row,FormatableBitSet validColumns)
             throws StandardException;
 
+    RowLocation getCurrentRowLocation();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -1257,7 +1257,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     }
 
     @Override
-    public void addDescriptorArray(TupleDescriptor[] td,
+    public RowLocation[] addDescriptorArray(TupleDescriptor[] td,
                                    TupleDescriptor parent,
                                    int catalogNumber,
                                    boolean allowDuplicates,
@@ -1272,10 +1272,12 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             rl[index]=row;
         }
 
-        int insertRetCode=ti.insertRowList(rl,tc);
+        RowLocation[] rowLocations = new RowLocation[td.length];
+        int insertRetCode=ti.insertRowList(rl,tc, rowLocations);
         if(!allowDuplicates && insertRetCode!=TabInfoImpl.ROWNOTDUPLICATE){
             throw duplicateDescriptorException(td[insertRetCode],parent);
         }
+        return rowLocations;
     }
 
     @Override
@@ -8333,16 +8335,22 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     private RowLocation computeRowLocation(TransactionController tc,
                                            TableDescriptor td,
                                            String columnName) throws StandardException{
+
+        UUID tableUUID=td.getUUID();
+        return computeRowLocation(tc, tableUUID, columnName);
+    }
+
+    protected RowLocation computeRowLocation(TransactionController tc,
+                                             UUID tableUUID,
+                                             String columnName) throws StandardException{
         TabInfoImpl ti=coreInfo[SYSCOLUMNS_CORE_NUM];
         ExecIndexRow keyRow;
-        UUID tableUUID=td.getUUID();
 
         keyRow=exFactory.getIndexableRow(2);
         keyRow.setColumn(1,getIDValueAsCHAR(tableUUID));
         keyRow.setColumn(2,new SQLChar(columnName));
         return ti.getRowLocation(tc,keyRow,SYSCOLUMNSRowFactory.SYSCOLUMNS_INDEX1_ID);
     }
-
     /**
      * Computes the RowLocation in SYSSEQUENCES for a particular sequence. Also
      * constructs the sequence descriptor.
@@ -10892,7 +10900,7 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
             rows[i] = ti.getCatalogRowFactory().makeRow(descriptor[i], null);
         }
 
-        int insertRetCode = ti.insertRowList(rows,tc);
+        int insertRetCode = ti.insertRowList(rows,tc, null);
         if (insertRetCode != TabInfoImpl.ROWNOTDUPLICATE)
             throw StandardException.newException(SQLState.LANG_DUPLICATE_KEY_CONSTRAINT,
                     "SYSBACKUPITEMS_INDEX2", SYSBACKUPITEMSRowFactory.TABLENAME_STRING);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/TabInfoImpl.java
@@ -436,12 +436,14 @@ public class TabInfoImpl
      *
      * @exception StandardException        Thrown on failure
      */
-    int insertRowList(ExecRow[] rowList, TransactionController tc )
+    int insertRowList(ExecRow[] rowList, TransactionController tc, RowLocation[] rowLocations )
             throws StandardException
     {
-        RowLocation[]             notUsed = new RowLocation[1];
+        if (rowLocations == null) {
+            rowLocations = new RowLocation[rowList.length];
+        }
 
-        return insertRowListImpl(rowList,tc,notUsed);
+        return insertRowListImpl(rowList,tc,rowLocations);
     }
 
     /**
@@ -454,17 +456,15 @@ public class TabInfoImpl
      </OL>
      @param rowList the list of rows to insert
      @param tc    transaction controller
-     @param rowLocationOut on output rowLocationOut[0] is set to the
+     @param rowLocations on output rowLocationOut[0] is set to the
      last RowLocation inserted.
      @return row number (>= 0) if duplicate row inserted into an index
      ROWNOTDUPLICATE otherwise
      */
     private int insertRowListImpl(ExecRow[] rowList, TransactionController tc,
-                                  RowLocation[] rowLocationOut)
+                                  RowLocation[] rowLocations)
             throws StandardException
     {
-        RowLocation                    heapLocation;
-        ExecIndexRow                indexableRow;
         int                            insertRetCode;
         int                            retCode = ROWNOTDUPLICATE;
         int                            indexCount = crf.getNumIndexes();
@@ -500,10 +500,6 @@ public class TabInfoImpl
                     }
                 }
 
-                heapLocation = heapController.newRowLocationTemplate();
-                rowLocationOut[0] = heapLocation;
-
-                RowLocation[] rowLocations = new RowLocation[rowList.length];
                 for (int i = 0; i < rowLocations.length; i++) {
                     rowLocations[i] = heapController.newRowLocationTemplate();
                 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -57,16 +57,20 @@ import com.splicemachine.management.Manager;
 import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.data.TxnOperationFactory;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.storage.*;
 import com.splicemachine.tools.version.ManifestReader;
 import com.splicemachine.utils.SpliceLogUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.log4j.Logger;
 
+import java.io.IOException;
 import java.sql.Types;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author Scott Fines
@@ -1363,13 +1367,81 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         }
     }
 
+    public void rewriteColumnDescriptors(int catalogNum, long cloned_conglomerate) throws StandardException {
+        TabInfoImpl ti = getTableInfo(catalogNum);
 
-    private void addDescriptors(List<TupleDescriptor> descriptors,
+        CatalogRowFactory rf=ti.getCatalogRowFactory();
+        ExecRow outRow;
+        TransactionController tc;
+        TupleDescriptor td=null;
+
+        // Get the current transaction controller
+        tc=getTransactionCompile();
+        String snapshotName = HBaseConfiguration.SEQUENCE_TABLE_NAME + "_upgrade";
+        tc.snapshot(snapshotName, HBaseConfiguration.SEQUENCE_TABLE_NAME);
+        tc.cloneSnapshot(snapshotName, HBaseConfiguration.SEQUENCE_TABLE_NAME);
+        outRow=rf.makeEmptyRow();
+        Map<RowLocation, ColumnDescriptor> locationColumnDescriptorMap = new HashMap<>();
+        /*
+         ** Table scan
+         */
+        try (ScanController scanController=tc.openScan(
+                cloned_conglomerate,    // conglomerate to open
+                false,                        // don't hold open across commit
+                0,                            // for read
+                TransactionController.MODE_TABLE,
+                TransactionController.ISOLATION_REPEATABLE_READ,
+                null,
+                null,        // start position - first rowSpliceDataDictionary
+                0,                    // startSearchOperation - none
+                null,        // scanQualifier,
+                null,        // stop position - through last row
+                0)) {                  // stopSearchOperation - none
+
+            final int batchSize = 100;
+            List<TupleDescriptor> descriptors = Lists.newArrayList();
+            int count = 0;
+            while (scanController.fetchNext(outRow.getRowArray())) {
+                td = rf.buildDescriptor(outRow, null, this);
+                count++;
+                descriptors.add(td);
+                ColumnDescriptor cd = (ColumnDescriptor)td;
+                    long autoinc = cd.getAutoincInc();
+                    if (autoinc != 0) {
+                        RowLocation location = (RowLocation) scanController.getCurrentRowLocation().cloneValue(true);
+                        locationColumnDescriptorMap.put(location, cd);
+                    }
+
+                if (count % batchSize == 0) {
+                    RowLocation[] newLocations = addDescriptors(descriptors, catalogNum, tc);
+                    if (locationColumnDescriptorMap.size() > 0) {
+                        // The row location of a sequence is the row location of the auto increment column.
+                        // Since all column descriptors are rewritten, their row location has been changed,
+                        // SPLICE_SEQUENCE table needs to be updated accordingly
+                        upgradeSequenceTable(descriptors, newLocations, locationColumnDescriptorMap);
+                    }
+                    descriptors.clear();
+                    locationColumnDescriptorMap.clear();
+                }
+            }
+
+            if (descriptors.size() > 0) {
+                RowLocation[] newLocations = addDescriptors(descriptors, catalogNum, tc);
+                if (locationColumnDescriptorMap.size() > 0) {
+                    upgradeSequenceTable(descriptors, newLocations, locationColumnDescriptorMap);
+                }
+                descriptors.clear();
+                locationColumnDescriptorMap.clear();
+            }
+        }
+    }
+
+    private RowLocation[] addDescriptors(List<TupleDescriptor> descriptors,
                                 int catalogNum,
                                 TransactionController tc) throws StandardException{
         TupleDescriptor[] descriptorsArray = new TupleDescriptor[descriptors.size()];
         descriptorsArray = descriptors.toArray(descriptorsArray);
-        addDescriptorArray(descriptorsArray, null, catalogNum, true, tc);
+        return addDescriptorArray(descriptorsArray, null, catalogNum, true, tc);
     }
 
     public static final List<Integer> serdeUpgradedTables = Collections.unmodifiableList(Arrays.asList(
@@ -1402,10 +1474,64 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
             // truncate the table and rewrite using cloned base table
             truncateTable(tc, catalogNum);
             SpliceLogUtils.info(LOG,"Truncated conglomerate %d", conglomerate);
-            rewriteDescriptors(serdeUpgradedTables.get(i), cloned_conglomerate);
+            if (catalogNum == SYSCOLUMNS_CATALOG_NUM) {
+                rewriteColumnDescriptors(serdeUpgradedTables.get(i), cloned_conglomerate);
+            }
+            else {
+                rewriteDescriptors(serdeUpgradedTables.get(i), cloned_conglomerate);
+            }
             SpliceLogUtils.info(LOG,"Finished upgrading catalogNum %d, conglomerate %d",
                     catalogNum, conglomerate);
         }
+    }
+
+    private void upgradeSequenceTable(List<TupleDescriptor> descriptors, RowLocation[] newLocations,
+                                      Map<RowLocation, ColumnDescriptor> locationColumnDescriptorMap) throws StandardException {
+
+        // locationMap stores old row location and new row location for an auto increment column descriptor
+        Map<String, byte[]> locationMap = new HashMap<>();
+        for (Map.Entry<RowLocation, ColumnDescriptor> entry : locationColumnDescriptorMap.entrySet()) {
+            byte[] oldLocation = entry.getKey().getBytes();
+            ColumnDescriptor cd = entry.getValue();
+            int index = descriptors.indexOf(cd);
+            byte[] newLocation = newLocations[index].getBytes();
+            locationMap.put(Bytes.toHex(oldLocation), newLocation);
+        }
+
+        try(Partition table = SIDriver.driver().getTableFactory().getTable(HBaseConfiguration.SEQUENCE_TABLE_NAME)) {
+            batchUpdateSequenceTable(table, locationMap);
+        }
+        catch (IOException e) {
+            throw StandardException.plainWrapException(e);
+        }
+    }
+
+    /**
+     * Delete the row that matches old row location and rewrite it to new row location
+     * @param table SPLICE_SEQUENCES table
+     * @param locations old/new row locations
+     * @throws IOException
+     */
+    private void batchUpdateSequenceTable(Partition table,
+                                          Map<String, byte[]> locations) throws IOException{
+
+        List<byte[]> oldLocations = (new ArrayList<>(locations.keySet())).stream().map(e->Bytes.fromHex(e)).collect(Collectors.toList());
+        Iterator<DataResult>  result = table.batchGet(null, oldLocations);
+        List<DataDelete> deletes = Lists.newArrayList();
+        DataPut[] puts = new DataPut[locations.size()];
+        SIDriver driver = SIDriver.driver();
+        int i = 0;
+        while (result.hasNext()) {
+            DataResult dataResult = result.next();
+            DataCell dataCell=dataResult.latestCell(SIConstants.DEFAULT_FAMILY_BYTES,SpliceSequence.autoIncrementValueQualifier);
+            DataDelete delete=driver.baseOperationFactory().newDelete(dataCell.key());
+            deletes.add(delete);
+            DataPut put = driver.baseOperationFactory().newPut(locations.get(Bytes.toHex(dataResult.key())));
+            put.addCell(SIConstants.DEFAULT_FAMILY_BYTES,SpliceSequence.autoIncrementValueQualifier, dataCell.value());
+            puts[i++] = put;
+        }
+        table.delete(deletes);
+        table.writeBatch(puts);
     }
 
     private void snapshotTable(TransactionController tc, int catalogNum) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/sequence/SpliceSequence.java
@@ -28,7 +28,8 @@ import java.io.ObjectOutput;
 
 public class SpliceSequence extends AbstractSequence{
     protected byte[] sysColumnsRow;
-    static final byte[] autoIncrementValueQualifier=Encoding.encode(7);
+    @SuppressFBWarnings(value = "MS_MUTABLE_ARRAY", justification = "intentional")
+    public static final byte[] autoIncrementValueQualifier=Encoding.encode(7);
     private PartitionFactory partitionFactory;
     private TxnOperationFactory opFactory;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceScan.java
@@ -410,5 +410,8 @@ public class SpliceScan implements ScanManager, LazyScan{
         }
     }
 
-
+    @Override
+    public RowLocation getCurrentRowLocation() {
+        return currentRowLocation;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Identity column value reset to sequence start value after upgrading to a build later than 2003.

## Long Description
Splice stores identity column value as a sequence in SPLICE_SEQUENCES table. The row address of the sequence is the same as the address of the column descriptor stored in sys.syscolumns. DB-10410 rewrites sys.syscolumns table, which changes row address of all column descriptors. However, it does not update the address in SPLICE_SEQUENCES. If a build upgrades to 2003 or later, the relationship between sys.syscolumns and SPLICE_SEQUENCES table is lost, and all identity column's next value are reset to the sequence start value.

## How to test
To test, create a table with identity column and insert rows into it. Upgrade to a build later than 2003. Insert a couple of rows and inspect identity column value. The values should not go back to sequence start value.