### PR TITLE
DB-12033 Multiple compilations of a prepared statement due to poor cache synchronization

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -267,8 +267,7 @@ public class GenericStatement implements Statement{
                                          boolean internalSQL) throws StandardException{
         return prepMinion(lcc, cacheMe, paramDefaults, spsSchema, internalSQL, null);
     }
-    @SuppressFBWarnings(value = "ML_SYNC_ON_FIELD_TO_GUARD_CHANGING_THAT_FIELD",
-            justification = "the new object created at line 370 will not be put into cache and it cannot be referenced by other threads")
+
     private PreparedStatement prepMinion(LanguageConnectionContext lcc,
                                          boolean cacheMe,
                                          Object[] paramDefaults,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -589,6 +589,9 @@ public class DataDictionaryCache {
     }
 
     public GenericStorablePreparedStatement cacheIfAbsent(GenericStatement gs) throws StandardException {
+        if (!dd.canReadCache(null) || !dd.canWriteCache(null)) {
+            return new GenericStorablePreparedStatement(gs);
+        }
         try {
             StatementCacheValue value = statementCache.getManagedCache().get(gs, () -> new StatementCacheValue(new GenericStorablePreparedStatement(gs)));
             return value.getStatement();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryCache.java
@@ -590,16 +590,16 @@ public class DataDictionaryCache {
 
     public GenericStorablePreparedStatement cacheIfAbsent(GenericStatement gs) throws StandardException {
         if (dd.canReadCache(null)) {
-            GenericStorablePreparedStatement result = statementCache.getIfPresent(gs).getStatement();
-            if (result != null) {
-                return result;
+            StatementCacheValue value = statementCache.getIfPresent(gs);
+            if (value != null) {
+                return value.getStatement();
             }
             if (dd.canWriteCache(null)) {
                 try {
-                    StatementCacheValue value = statementCache.getManagedCache().get(gs, () -> new StatementCacheValue(new GenericStorablePreparedStatement(gs)));
+                    value = statementCache.getManagedCache().get(gs, () -> new StatementCacheValue(new GenericStorablePreparedStatement(gs)));
                     return value.getStatement();
                 } catch (ExecutionException ex) {
-                    // ignore unlikely exception 
+                    // ignore unlikely exception
                 }
             }
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -1498,11 +1498,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      */
     @Override
     public PreparedStatement lookupStatement(GenericStatement statement) throws StandardException {
-        GenericStorablePreparedStatement ps = getDataDictionary().getDataDictionaryCache().statementCacheFind(statement);
-        if (ps == null) {
-            ps = new GenericStorablePreparedStatement(statement);
-            getDataDictionary().getDataDictionaryCache().statementCacheAdd(statement, ps);
-        }
+        GenericStorablePreparedStatement ps = getDataDictionary().getDataDictionaryCache().cacheIfAbsent(statement);
         synchronized (ps) {
             if (ps.upToDate()) {
                 GeneratedClass ac = ps.getActivationClass();


### PR DESCRIPTION
## Short Description
Fixed DataDictionaryCache.statementCache to do atomic "computeIfAbsent".

## Long Description
Multiple connections compiling identical statements would check DataDictionaryCache.statementCache to see if a prepared statement is already available, create new prepared statements if not and  add them to the cache. Only one wins, others would continue with compiling the statement to eventually throw away the result.
Also fixed unnecessarily complicated synchronization around prepared statements that reference session schema.

## How to test
Run TPC-C, verify if there are multiple compilations of identical SELECT/UPDATE/DELETE statements in the same region server.
