### PR TITLE
DB-11969 Throw properly for invalid update syntax set(a,b)=(c,d).

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
@@ -600,6 +600,10 @@ class SQLGrammarImpl {
         // even more hacky code.
         // The derived table flattening logic in preprocess will be triggered to
         // flatten the subquery.
+        if (!(subQuery instanceof SubqueryNode)) {
+            throw StandardException.newException(SQLState.LANG_INVALID_UPDATE_STATEMENT,
+                                                 "Expecting RHS to be a subquery when LHS of set clause is a tuple");
+        }
         SubqueryNode subq = (SubqueryNode) subQuery;
         FromTable fromSubq = (FromTable) nodeFactory.getNode(
                 C_NodeTypes.FROM_SUBQUERY,

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.derby.test.framework.TestConnection;
@@ -204,6 +205,16 @@ public class UpdateOperationIT {
                         "-------------------\n" +
                         " 300 | 900 |63367 |",
                 TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
+    @Test
+    public void testUpdateMultipleColumnsInvalidSyntax() throws Exception {
+        try {
+            methodWatcher.execute("update LOCATION set (addr, zip) = ('900', '63367') where num=300");
+        } catch (SQLException e) {
+            assertEquals("42X67", e.getSQLState());
+            assertEquals("Invalid UPDATE statement syntax.", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Short Description
This change improves the error message when an invalid update syntax `set (a,b)=(c,d)` is used.

## Long Description
We currently have three update statement syntax:
1. `update T set a = c, b = d where ...`
2. `update T set (a, b) = (select c, d from ...)`
3. `update T set a = c, b = d from ... where ...`

When the left-hand side of a set clause is surrounded with a pair of parenthesis, right-hand side must be a subquery. This is syntax 2. Before syntax 3 is implemented, it's splice's way of allowing multi-column update from a subquery.

Currently, we don't generally have tuple assignment except for a few cases. In update statement, `set (a, b) = (c, d)` is equivalent to `set a = c, b = d`. For this reason, there is no real need at the moment to implement tuple assignment in update.

A proper error message is needed though.

## How to test
```
create table t (c1 int, c2 int);
insert into t values (1, 2);
update t set (c1, c2) = (c1 + 1, c2 + 1);
```

Before this fix, the update statement would cause the following exception:
```
ERROR XJ001: Java exception: 'java.lang.ClassCastException: com.splicemachine.db.impl.sql.compile.ValueTupleNode cannot be cast to com.splicemachine.db.impl.sql.compile.SubqueryNode'.
ERROR XJ001: Java exception: 'com.splicemachine.db.impl.sql.compile.ValueTupleNode cannot be cast to com.splicemachine.db.impl.sql.compile.SubqueryNode: java.lang.ClassCastException'.
```

After the fix, we have a proper error message:
```
ERROR 42X67: Invalid UPDATE statement syntax.
```

A new test `testUpdateMultipleColumnsInvalidSyntax` is added to `UpdateOperationIT`.