### PR TITLE
DB-11969 Throw properly for invalid update syntax set(a,b)=(c,d). (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SQLGrammarImpl.java
@@ -597,6 +597,10 @@ class SQLGrammarImpl {
         // even more hacky code.
         // The derived table flattening logic in preprocess will be triggered to
         // flatten the subquery.
+        if (!(subQuery instanceof SubqueryNode)) {
+            throw StandardException.newException(SQLState.LANG_INVALID_UPDATE_STATEMENT,
+                                                 "Expecting RHS to be a subquery when LHS of set clause is a tuple");
+        }
         SubqueryNode subq = (SubqueryNode) subQuery;
         FromTable fromSubq = (FromTable) nodeFactory.getNode(
                 C_NodeTypes.FROM_SUBQUERY,

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UpdateOperationIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.derby.test.framework.TestConnection;
@@ -204,6 +205,16 @@ public class UpdateOperationIT {
                         "-------------------\n" +
                         " 300 | 900 |63367 |",
                 TestUtils.FormattedResult.ResultFactory.toString(rs));
+    }
+
+    @Test
+    public void testUpdateMultipleColumnsInvalidSyntax() throws Exception {
+        try {
+            methodWatcher.execute("update LOCATION set (addr, zip) = ('900', '63367') where num=300");
+        } catch (SQLException e) {
+            assertEquals("42X67", e.getSQLState());
+            assertEquals("Invalid UPDATE statement syntax.", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Please see https://github.com/splicemachine/spliceengine/pull/5459.
