### PR TITLE
DB-12064 Fix NPE in code generation for index prefix iteration mode

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -3781,7 +3781,10 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
          * by (column #, selectivity) once the store does just in time
          * instantiation.
          */
+        PredicateList cloneMe = null;
         if(numberOfQualifiers>0){
+            cloneMe = (PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST, getContextManager());
+            this.copyPredicatesToOtherList(cloneMe);
             orderQualifiers();
         }
 
@@ -3976,6 +3979,11 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 qualNum++;
             }
 
+        }
+
+        if (cloneMe != null) {
+            this.removeAllPredicates();
+            cloneMe.copyPredicatesToOtherList(this);
         }
 
         //assert qualNum==numberOfQualifiers: qualNum+" Qualifiers found, "+ numberOfQualifiers+" expected.";

--- a/splice_machine/src/test/test-data/subquery/IndexPrefixIterationTestTables.sql
+++ b/splice_machine/src/test/test-data/subquery/IndexPrefixIterationTestTables.sql
@@ -33,6 +33,8 @@ COL1 CHAR(36) NOT NULL
 
 create index Table1_Idx1 on Table1 (COL2, COL5, COL3, COL8, COL9);
 
+create index Table1_Idx2 on Table1 (COL2, COL3, COL5, COL9);
+
 insert into Table1 values ('a', 'ABCDE', timestamp('2010-12-31 15:59:59.3211111'), 'b', 'c', timestamp('1969-12-31 15:59:59.000001'), 'd', 'e', 'f', 'g');
 
 analyze table Table1;


### PR DESCRIPTION
## Short Description
This change fixes a NPE in code generation related to index prefix iteration mode.

## Long Description
This is a bug happens in generating code in index prefix iteration mode when an equality predicate and a ranged predicate are both used as scan keys.

In code generation of a `FromBaseTable`, `getScanArguments()` is called with an assumption that the predicates pushed down to this table must be sorted in index column order (for PK or index conglomerates). If this is not the case, code generation is simply wrong.

However, `getScanArguments()` eventually calls `PredicateList.generateProbeQualifiers()`. This call sorts predicates according to a heuristic on selectivity:
```
if(numberOfQualifiers>0){
    orderQualifiers();
}
```
This step is fine previously because when we are here, the logic relying on the order of predicates is already finished. We are free to sort them.

With index prefix iteration mode, a new call is added after `getScanArguments()`:
```
...
int nargs=getScanArguments(acb,mb);

mb.callMethod(VMOpcode.INVOKEINTERFACE,null,
              trulyTheBestJoinStrategy.resultSetMethodName(multiProbing),
              ClassName.NoPutResultSet,nargs);
generateIndexPrefixIteratorOperation(acb, mb);
```
`generateIndexPrefixIteratorOperation()` internally calls `getScanArguments()` again. Now since predicates are sorted by the last call of `getScanArguments()`, this code generation process could be wrong.

This problem is not observed when there are only equality predicates. In that case, `orderQualifiers()` has no effect on the order because the heuristic is only that:

- = and IS NULL are most selective
- <> and IS NOT NULL are least selective
- all others are in between

As long as we have predicates from more than one category and they are all used in index prefix iteration mode, this problem occurs.

## How to test
A new test `testCodeGenerationNoNPE` is added to `IndexPrefixIterationIT`. Running the query in this test under the IT setup without the fix would throw an NPE. With the fix, the query should run through.
