### PR TITLE
DB-12077 Evaluate null constant restriction to false during execution 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -183,6 +183,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED = true;
     boolean DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST = true;
     boolean DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION = false;
+    boolean DEFAULT_DISABLE_CONSTANT_FOLDING = false;
     SparkVersion DEFAULT_SPLICE_SPARK_VERSION = new SimpleSparkVersion("2.2.0");
     NativeSparkModeType DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE = NativeSparkModeType.SYSTEM;
     boolean DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS = true;
@@ -718,6 +719,8 @@ public interface CompilerContext extends Context
     void setDisablePredicateSimplification(boolean newValue);
 
     boolean getDisablePredicateSimplification();
+
+    boolean getDisableConstantFolding();
 
     void setSparkVersion(SparkVersion newValue);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -523,18 +523,8 @@ public class GenericStatement implements Statement{
     }
 
     private void setSSQFlatteningForUpdateDisabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String ssqFlatteningForUpdateDisabledString =
-        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SSQ_FLATTENING_FOR_UPDATE_DISABLED);
-        boolean ssqFlatteningForUpdateDisabled = CompilerContext.DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED;
-        try {
-            if (ssqFlatteningForUpdateDisabledString != null)
-                ssqFlatteningForUpdateDisabled =
-                Boolean.parseBoolean(ssqFlatteningForUpdateDisabledString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setSSQFlatteningForUpdateDisabled(ssqFlatteningForUpdateDisabled);
+        boolean param = getBooleanParam(lcc, Property.SSQ_FLATTENING_FOR_UPDATE_DISABLED, CompilerContext.DEFAULT_SSQ_FLATTENING_FOR_UPDATE_DISABLED);
+        cc.setSSQFlatteningForUpdateDisabled(param);
     }
 
     private void setSparkVersion(CompilerContext cc) {
@@ -553,17 +543,8 @@ public class GenericStatement implements Statement{
     }
 
     private void setOuterJoinFlatteningDisabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String outerJoinFlatteningDisabledString =
-        PropertyUtil.getCachedDatabaseProperty(lcc, Property.OUTERJOIN_FLATTENING_DISABLED);
-        boolean outerJoinFlatteningDisabled = CompilerContext.DEFAULT_OUTERJOIN_FLATTENING_DISABLED;
-        try {
-            if (outerJoinFlatteningDisabledString != null)
-                outerJoinFlatteningDisabled = Boolean.parseBoolean(outerJoinFlatteningDisabledString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setOuterJoinFlatteningDisabled(outerJoinFlatteningDisabled);
+        boolean param = getBooleanParam(lcc, Property.OUTERJOIN_FLATTENING_DISABLED, CompilerContext.DEFAULT_OUTERJOIN_FLATTENING_DISABLED);
+        cc.setOuterJoinFlatteningDisabled(param);
     }
 
     private void setSelectivityEstimationIncludingSkewedDefault(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
@@ -610,44 +591,38 @@ public class GenericStatement implements Statement{
     }
 
     private void setMulticolumnInlistProbeOnSparkEnabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String multicolumnInlistProbeOnSparkEnabledString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED);
-        boolean multicolumnInlistProbeOnSparkEnabled = CompilerContext.DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
-        try {
-            if (multicolumnInlistProbeOnSparkEnabledString != null)
-                multicolumnInlistProbeOnSparkEnabled = Boolean.parseBoolean(multicolumnInlistProbeOnSparkEnabledString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
+        String property = Property.MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
+        boolean defaultValue = CompilerContext.DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
+        boolean multicolumnInlistProbeOnSparkEnabled = getBooleanParam(lcc, property, defaultValue);
         cc.setMulticolumnInlistProbeOnSparkEnabled(multicolumnInlistProbeOnSparkEnabled);
     }
 
-    private void setConvertMultiColumnDNFPredicatesToInList(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String convertMultiColumnDNFPredicatesToInListString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST);
-        boolean convertMultiColumnDNFPredicatesToInList = CompilerContext.DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
+    private boolean getBooleanParam(LanguageConnectionContext lcc, String property, boolean defaultValue) throws StandardException {
+        String paramString = PropertyUtil.getCachedDatabaseProperty(lcc, property);
+        boolean value = defaultValue;
         try {
-            if (convertMultiColumnDNFPredicatesToInListString != null)
-                convertMultiColumnDNFPredicatesToInList = Boolean.parseBoolean(convertMultiColumnDNFPredicatesToInListString);
+            if (paramString != null)
+                value = Boolean.parseBoolean(paramString);
         } catch (Exception e) {
             // If the property value failed to convert to a boolean, don't throw an error,
             // just use the default setting.
         }
-        cc.setConvertMultiColumnDNFPredicatesToInList(convertMultiColumnDNFPredicatesToInList);
+        return value;
+    }
+
+    private void setConvertMultiColumnDNFPredicatesToInList(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        boolean param = getBooleanParam(lcc, Property.CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST, CompilerContext.DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST);
+        cc.setConvertMultiColumnDNFPredicatesToInList(param);
     }
 
     private void setDisablePredicateSimplification(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String disablePredicateSimplificationString =
-        PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PREDICATE_SIMPLIFICATION);
-        boolean disablePredicateSimplification = CompilerContext.DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION;
-        try {
-            if (disablePredicateSimplificationString != null)
-                disablePredicateSimplification =
-                Boolean.parseBoolean(disablePredicateSimplificationString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setDisablePredicateSimplification(disablePredicateSimplification);
+        boolean param = getBooleanParam(lcc, Property.DISABLE_PREDICATE_SIMPLIFICATION, CompilerContext.DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION);
+        cc.setDisablePredicateSimplification(param);
+    }
+
+    private void setDisableConstantFolding(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        boolean param = getBooleanParam(lcc, Property.DISABLE_CONSTANT_FOLDING, CompilerContext.DEFAULT_DISABLE_CONSTANT_FOLDING);
+        cc.setDisablePredicateSimplification(param);
     }
 
     private void setNativeSparkAggregationMode(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
@@ -679,18 +654,8 @@ public class GenericStatement implements Statement{
     }
 
     private void setAllowOverflowSensitiveNativeSparkExpressions(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String allowOverflowSensitiveNativeSparkExpressionsString =
-        PropertyUtil.getCachedDatabaseProperty(lcc, Property.SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS);
-        boolean allowOverflowSensitiveNativeSparkExpressions = CompilerContext.DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS;
-        try {
-            if (allowOverflowSensitiveNativeSparkExpressionsString != null)
-                allowOverflowSensitiveNativeSparkExpressions =
-                Boolean.parseBoolean(allowOverflowSensitiveNativeSparkExpressionsString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setAllowOverflowSensitiveNativeSparkExpressions(allowOverflowSensitiveNativeSparkExpressions);
+        boolean param = getBooleanParam(lcc, Property.SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS, CompilerContext.DEFAULT_SPLICE_ALLOW_OVERFLOW_SENSITIVE_NATIVE_SPARK_EXPRESSIONS);
+        cc.setAllowOverflowSensitiveNativeSparkExpressions(param);
     }
 
     private void setNewMergeJoin(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
@@ -716,33 +681,13 @@ public class GenericStatement implements Statement{
     }
 
     private void setDisablePrefixIteratorMode(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String disablePrefixIteratorModeString =
-            PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_INDEX_PREFIX_ITERATION);
-        boolean disablePrefixIteratorMode = CompilerContext.DEFAULT_DISABLE_INDEX_PREFIX_ITERATION;
-        try {
-            if (disablePrefixIteratorModeString != null)
-                disablePrefixIteratorMode =
-                Boolean.parseBoolean(disablePrefixIteratorModeString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setDisablePrefixIteratorMode(disablePrefixIteratorMode);
+        boolean param = getBooleanParam(lcc, Property.DISABLE_INDEX_PREFIX_ITERATION, CompilerContext.DEFAULT_DISABLE_INDEX_PREFIX_ITERATION);
+        cc.setDisablePrefixIteratorMode(param);
     }
 
     private void setDisableParallelTaskJoinCosting(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String disablePerParallelTaskJoinCostingString =
-        PropertyUtil.getCachedDatabaseProperty(lcc, Property.DISABLE_PARALLEL_TASKS_JOIN_COSTING);
-        boolean disablePerParallelTaskJoinCosting = CompilerContext.DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
-        try {
-            if (disablePerParallelTaskJoinCostingString != null)
-                disablePerParallelTaskJoinCosting =
-                Boolean.parseBoolean(disablePerParallelTaskJoinCostingString);
-        } catch (Exception e) {
-            // If the property value failed to convert to a boolean, don't throw an error,
-            // just use the default setting.
-        }
-        cc.setDisablePerParallelTaskJoinCosting(disablePerParallelTaskJoinCosting);
+        boolean param = getBooleanParam(lcc, Property.DISABLE_PARALLEL_TASKS_JOIN_COSTING, CompilerContext.DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING);
+        cc.setDisablePerParallelTaskJoinCosting(param);
     }
 
     private void setCurrentTimestampPrecision(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -252,6 +252,14 @@ public class CompilerContextImpl extends ContextImpl
         return disablePredicateSimplification;
     }
 
+    public void setDisableConstantFolding(boolean newValue) {
+        disableConstantFolding = newValue;
+    }
+
+    public boolean getDisableConstantFolding() {
+        return disableConstantFolding;
+    }
+
     public void setSparkVersion(SparkVersion newValue) {
         sparkVersionInitialized = true;
         sparkVersion = newValue;
@@ -1224,6 +1232,7 @@ public class CompilerContextImpl extends ContextImpl
     private       boolean                             multicolumnInlistProbeOnSparkEnabled         = DEFAULT_MULTICOLUMN_INLIST_PROBE_ON_SPARK_ENABLED;
     private       boolean                             convertMultiColumnDNFPredicatesToInList      = DEFAULT_CONVERT_MULTICOLUMN_DNF_PREDICATES_TO_INLIST;
     private       boolean                             disablePredicateSimplification               = DEFAULT_DISABLE_PREDICATE_SIMPLIFICATION;
+    private       boolean                             disableConstantFolding                       = DEFAULT_DISABLE_CONSTANT_FOLDING;
     private       SparkVersion                        sparkVersion                                 = DEFAULT_SPLICE_SPARK_VERSION;
     private       boolean                             sparkVersionInitialized                      = false;
     private       CompilerContext.NativeSparkModeType nativeSparkAggregationMode                   = DEFAULT_SPLICE_NATIVE_SPARK_AGGREGATION_MODE;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -164,7 +164,8 @@ public abstract class DMLStatementNode extends StatementNode {
         // SelectNodes have already been visited in SelectNode.java,
         // so handle all other nodes here we might have missed,
         // skipping over SelectNodes in the tree traversal.
-        accept(new ConstantExpressionVisitor(SelectNode.class));
+        if (!getCompilerContext().getDisableConstantFolding())
+            accept(new ConstantExpressionVisitor(SelectNode.class));
 
         // prune tree based on unsat condition
         accept(new TreePruningVisitor());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -1644,9 +1644,11 @@ public class JoinNode extends TableOperatorNode{
                the top AND node with a boolean true.
              */
             if (!joinClauseNormalized) {
-                Visitor constantExpressionVisitor =
-                        new ConstantExpressionVisitor(SelectNode.class);
-                joinClause = (ValueNode) joinClause.accept(constantExpressionVisitor);
+                if (!getCompilerContext().getDisableConstantFolding()) {
+                    Visitor constantExpressionVisitor =
+                            new ConstantExpressionVisitor(SelectNode.class);
+                    joinClause = (ValueNode) joinClause.accept(constantExpressionVisitor);
+                }
 
                 if (!getCompilerContext().getDisablePredicateSimplification()) {
                     Visitor predSimplVisitor =

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/SelectNode.java
@@ -560,12 +560,14 @@ public class SelectNode extends ResultSetNode {
         // selectivity 1.0.)
         // This is also done before predicate simplification to enable
         // more predicates to be pruned away.
-        Visitor constantExpressionVisitor =
-        new ConstantExpressionVisitor(SelectNode.class);
-        if (whereClause != null)
-            whereClause = (ValueNode) whereClause.accept(constantExpressionVisitor);
-        if (havingClause != null)
-            havingClause = (ValueNode) havingClause.accept(constantExpressionVisitor);
+        if (!getCompilerContext().getDisableConstantFolding()) {
+            Visitor constantExpressionVisitor =
+                    new ConstantExpressionVisitor(SelectNode.class);
+            if (whereClause != null)
+                whereClause = (ValueNode) whereClause.accept(constantExpressionVisitor);
+            if (havingClause != null)
+                havingClause = (ValueNode) havingClause.accept(constantExpressionVisitor);
+        }
 
         // Perform predicate simplification.  Currently only
         // simple rewrites involving boolean TRUE/FALSE are done, such as:

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueNodeList.java
@@ -531,8 +531,10 @@ public class ValueNodeList extends QueryTreeNodeVector
                         prevCN.getValue();
 
                     /* Swap curr and prev if prev > curr */
-                    if ((judgeODV == null && (prevODV.compare(currODV)) > 0) ||
-                        (judgeODV != null && judgeODV.greaterThan(prevODV, currODV).equals(true))) {
+                    if (currODV == null ||
+                            prevODV != null && (
+                                (judgeODV == null && (prevODV.compare(currODV)) > 0) ||
+                                (judgeODV != null && judgeODV.greaterThan(prevODV, currODV).equals(true)))) {
                         if (multiColumn) {
                             setElementAt(lvn, index - 1);
                             setElementAt(prevLVN, index);

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/Property.java
@@ -1083,6 +1083,9 @@ public interface Property {
     String DISABLE_PREDICATE_SIMPLIFICATION =
             "derby.database.disablePredicateSimplification";
 
+    String DISABLE_CONSTANT_FOLDING =
+            "splice.database.disableConstantFolding";
+
     String BULK_IMPORT_SAMPLE_FRACTION = "splice.bulkImport.sample.fraction";
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -51,358 +51,358 @@ import static com.splicemachine.db.impl.sql.compile.ExplainNode.SparkExplainKind
 
 
 public class ProjectRestrictOperation extends SpliceBaseOperation {
-	private static Logger                            LOG                           = Logger.getLogger(ProjectRestrictOperation.class);
-	private static int                               PROJECT_RESTRICT_OPERATION_V2 = 2;
-	protected      String                            restrictionMethodName;
-	protected      String                            projectionMethodName;
-	protected      String                            constantRestrictionMethodName;
-	protected      boolean                           parameterInConstantRestriction;
-	protected      int                               mapRefItem;
-	protected      int                               cloneMapItem;
-	protected      boolean                           reuseResult;
-	protected      boolean                           doesProjection;
-	public         int[]                             projectMapping;
-	public         ExecRow                           mappedResultRow;
-	public         boolean[]                         cloneMap;
-	protected      boolean                           shortCircuitOpen;
-	public         SpliceOperation                   source;
-	private        boolean                           alwaysFalse;
-	public         SpliceMethod<DataValueDescriptor> restriction;
-	public         SpliceMethod<ExecRow>             projection;
-	private        ExecRow                           execRowDefinition;
-	private        ExecRow                           projRow;
-	private        String[]                          filterPred                    = null;
-	private        String[]                          expressions                   = null;
-	private        boolean                           hasGroupingFunction;
-	private        String                            subqueryText;
+    private static Logger                            LOG                           = Logger.getLogger(ProjectRestrictOperation.class);
+    private static int                               PROJECT_RESTRICT_OPERATION_V2 = 2;
+    protected      String                            restrictionMethodName;
+    protected      String                            projectionMethodName;
+    protected      String                            constantRestrictionMethodName;
+    protected      boolean                           parameterInConstantRestriction;
+    protected      int                               mapRefItem;
+    protected      int                               cloneMapItem;
+    protected      boolean                           reuseResult;
+    protected      boolean                           doesProjection;
+    public         int[]                             projectMapping;
+    public         ExecRow                           mappedResultRow;
+    public         boolean[]                         cloneMap;
+    protected      boolean                           shortCircuitOpen;
+    public         SpliceOperation                   source;
+    private        boolean                           alwaysFalse;
+    public         SpliceMethod<DataValueDescriptor> restriction;
+    public         SpliceMethod<ExecRow>             projection;
+    private        ExecRow                           execRowDefinition;
+    private        ExecRow                           projRow;
+    private        String[]                          filterPred                    = null;
+    private        String[]                          expressions                   = null;
+    private        boolean                           hasGroupingFunction;
+    private        String                            subqueryText;
 
-	protected static final String NAME = ProjectRestrictOperation.class.getSimpleName().replaceAll("Operation", "");
+    protected static final String NAME = ProjectRestrictOperation.class.getSimpleName().replaceAll("Operation", "");
 
-	@Override
-	public String getName() {
-		return NAME;
-	}
+    @Override
+    public String getName() {
+        return NAME;
+    }
 
-	public boolean hasExpressions() {
-		return (expressions != null && expressions.length > 0);
-	}
+    public boolean hasExpressions() {
+        return (expressions != null && expressions.length > 0);
+    }
 
-	public boolean hasFilterPred() {
-		return (filterPred != null && filterPred.length > 0);
-	}
+    public boolean hasFilterPred() {
+        return (filterPred != null && filterPred.length > 0);
+    }
 
-	public boolean hasGroupingFunction() {
-		return hasGroupingFunction;
-	}
+    public boolean hasGroupingFunction() {
+        return hasGroupingFunction;
+    }
 
-	public String getFilterPred() {
-		if (hasFilterPred())
-			return String.join("", filterPred);
-		else
-			return "true";
-	}
+    public String getFilterPred() {
+        if (hasFilterPred())
+            return String.join("", filterPred);
+        else
+            return "true";
+    }
 
-	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9844")
-	public String[] getExpressions() {
-		return expressions;
-	}
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9844")
+    public String[] getExpressions() {
+        return expressions;
+    }
 
-	@SuppressWarnings("UnusedDeclaration")
-	public ProjectRestrictOperation() {
-		super();
-	}
+    @SuppressWarnings("UnusedDeclaration")
+    public ProjectRestrictOperation() {
+        super();
+    }
 
-	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "DB-9844")
-	public ProjectRestrictOperation(SpliceOperation source,
-									Activation activation,
-									GeneratedMethod restriction,
-									GeneratedMethod projection,
-									int resultColumnTypeArrayItem,
-									int resultSetNumber,
-									GeneratedMethod cr,
-									boolean paramInCr,
-									int mapRefItem,
-									int cloneMapItem,
-									boolean reuseResult,
-									boolean doesProjection,
-									double optimizerEstimatedRowCount,
-									double optimizerEstimatedCost,
-									String[] filterPred,
-									String[] expressions,
-									boolean hasGroupingFunction,
-									String subqueryText) throws StandardException {
-		super(activation, resultColumnTypeArrayItem, resultSetNumber, optimizerEstimatedRowCount, optimizerEstimatedCost);
-		this.restrictionMethodName = (restriction == null) ? null : restriction.getMethodName();
-		this.projectionMethodName = (projection == null) ? null : projection.getMethodName();
-		this.constantRestrictionMethodName = (cr == null) ? null : cr.getMethodName();
-		this.parameterInConstantRestriction = paramInCr;
-		this.mapRefItem = mapRefItem;
-		this.cloneMapItem = cloneMapItem;
-		this.reuseResult = reuseResult;
-		this.doesProjection = doesProjection;
-		this.source = source;
-		this.filterPred = filterPred;
-		this.expressions = expressions;
-		this.hasGroupingFunction = hasGroupingFunction;
-		this.subqueryText = subqueryText;
-		init();
-	}
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "DB-9844")
+    public ProjectRestrictOperation(SpliceOperation source,
+                                    Activation activation,
+                                    GeneratedMethod restriction,
+                                    GeneratedMethod projection,
+                                    int resultColumnTypeArrayItem,
+                                    int resultSetNumber,
+                                    GeneratedMethod cr,
+                                    boolean paramInCr,
+                                    int mapRefItem,
+                                    int cloneMapItem,
+                                    boolean reuseResult,
+                                    boolean doesProjection,
+                                    double optimizerEstimatedRowCount,
+                                    double optimizerEstimatedCost,
+                                    String[] filterPred,
+                                    String[] expressions,
+                                    boolean hasGroupingFunction,
+                                    String subqueryText) throws StandardException {
+        super(activation, resultColumnTypeArrayItem, resultSetNumber, optimizerEstimatedRowCount, optimizerEstimatedCost);
+        this.restrictionMethodName = (restriction == null) ? null : restriction.getMethodName();
+        this.projectionMethodName = (projection == null) ? null : projection.getMethodName();
+        this.constantRestrictionMethodName = (cr == null) ? null : cr.getMethodName();
+        this.parameterInConstantRestriction = paramInCr;
+        this.mapRefItem = mapRefItem;
+        this.cloneMapItem = cloneMapItem;
+        this.reuseResult = reuseResult;
+        this.doesProjection = doesProjection;
+        this.source = source;
+        this.filterPred = filterPred;
+        this.expressions = expressions;
+        this.hasGroupingFunction = hasGroupingFunction;
+        this.subqueryText = subqueryText;
+        init();
+    }
 
-	public String getRestrictionMethodName() {
-		return restrictionMethodName;
-	}
+    public String getRestrictionMethodName() {
+        return restrictionMethodName;
+    }
 
-	public boolean doesProjection() {
-		return doesProjection;
-	}
+    public boolean doesProjection() {
+        return doesProjection;
+    }
 
-	@Override
-	public void init(SpliceOperationContext context) throws StandardException, IOException {
-		super.init(context);
-		source.init(context);
+    @Override
+    public void init(SpliceOperationContext context) throws StandardException, IOException {
+        super.init(context);
+        source.init(context);
 
-		GenericStorablePreparedStatement statement = context.getPreparedStatement();
-		projectMapping = ((ReferencedColumnsDescriptorImpl) statement.getSavedObject(mapRefItem)).getReferencedColumnPositions();
-		if (projectionMethodName == null) {
-			mappedResultRow = activation.getExecutionFactory().getValueRow(projectMapping.length);
-		}
-		cloneMap = ((boolean[]) statement.getSavedObject(cloneMapItem));
-		evaluateConstantRestriction();
+        GenericStorablePreparedStatement statement = context.getPreparedStatement();
+        projectMapping = ((ReferencedColumnsDescriptorImpl) statement.getSavedObject(mapRefItem)).getReferencedColumnPositions();
+        if (projectionMethodName == null) {
+            mappedResultRow = activation.getExecutionFactory().getValueRow(projectMapping.length);
+        }
+        cloneMap = ((boolean[]) statement.getSavedObject(cloneMapItem));
+        evaluateConstantRestriction();
 
-		if (restrictionMethodName != null)
-			restriction = new SpliceMethod<>(restrictionMethodName, activation);
-		if (projectionMethodName != null)
-			projection = new SpliceMethod<>(projectionMethodName, activation);
-	}
-
-
-	@Override
-	public List<SpliceOperation> getSubOperations() {
-		return Arrays.asList(source);
-	}
+        if (restrictionMethodName != null)
+            restriction = new SpliceMethod<>(restrictionMethodName, activation);
+        if (projectionMethodName != null)
+            projection = new SpliceMethod<>(projectionMethodName, activation);
+    }
 
 
-	@Override
-	public SpliceOperation getLeftOperation() {
-		return source;
-	}
+    @Override
+    public List<SpliceOperation> getSubOperations() {
+        return Arrays.asList(source);
+    }
 
-	@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "DB-9844")
-	public ExecRow doProjection(ExecRow sourceRow) throws StandardException {
-		if (reuseResult && projRow != null)
-			return projRow;
-		source.setCurrentRow(sourceRow);
-		RowLocation rl = new HBaseRowLocation(sourceRow.getKey());
-		source.setCurrentRowLocation(rl);
-			/* If source is index look-up, we need to set the current row location for the underneath TableScan operation.
-			   this is because index look-up is a batch operation, so the rowlocation from teh TableScan may be out-of-sync
-			   with the current row being processed.
-			 */
-		if (source instanceof IndexRowToBaseRowOperation)
-			source.getLeftOperation().setCurrentRowLocation(rl);
 
-		ExecRow result;
-		if (projection != null) {
-			result = projection.invoke();
-		} else {
-			result = mappedResultRow;
-		}
-		// Copy any mapped columns from the source
-		for (int index = 0; index < projectMapping.length; index++) {
-			if (projectMapping[index] != -1) {
-				DataValueDescriptor dvd = sourceRow.getColumn(projectMapping[index]);
-				// See if the column has been marked for cloning.
-				// If the value isn't a stream, don't bother cloning it.
-				if (cloneMap[index] && dvd.hasStream()) {
-					dvd = dvd.cloneValue(false);
-				}
-				result.setColumn(index + 1, dvd);
-			}
-		}
-		if (reuseResult)
-			projRow = result;
-		/* Remember the result if reusing it */
-		return result;
-	}
+    @Override
+    public SpliceOperation getLeftOperation() {
+        return source;
+    }
 
-	/**
-	 * Returns the definition of the columns in a row.  A projection will be executed to determine the columns
-	 * that are added or removed.  Default values are used for the column values.
-	 * PLEASE NOTE: Numeric columns will be ones by default.  So the delegate operation may need to reset the values
-	 * to zeroes, etc.  This is what happens in the ScalarAggregateOperation classes.
-	 *
-	 * @return the definition of the row
-	 */
-	@Override
-	public ExecRow getExecRowDefinition() throws StandardException {
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "DB-9844")
+    public ExecRow doProjection(ExecRow sourceRow) throws StandardException {
+        if (reuseResult && projRow != null)
+            return projRow;
+        source.setCurrentRow(sourceRow);
+        RowLocation rl = new HBaseRowLocation(sourceRow.getKey());
+        source.setCurrentRowLocation(rl);
+            /* If source is index look-up, we need to set the current row location for the underneath TableScan operation.
+               this is because index look-up is a batch operation, so the rowlocation from teh TableScan may be out-of-sync
+               with the current row being processed.
+             */
+        if (source instanceof IndexRowToBaseRowOperation)
+            source.getLeftOperation().setCurrentRowLocation(rl);
 
-		if (execRowDefinition == null) {
-			ExecRow def = source.getExecRowDefinition();
-			ExecRow clone = def != null ? def.getClone() : null;
-			// In case the source's ExecRow has value set to 0 which may cause trouble for division,
-			// set the value to null, the numeric data types have logic to handle null as divisor
-			if (clone != null) EngineUtils.resultValuesToNull(clone.getRowArray());
-			// Keeps Sequences from incrementing when doing an execRowDefiniton evaluation: hack
-			((BaseActivation) activation).setIgnoreSequence(true);
-			source.setCurrentRow(clone);
-			execRowDefinition = doProjection(clone);
-			((BaseActivation) activation).setIgnoreSequence(false);
-		}
-		execRowDefinition = execRowDefinition.getClone();
-		EngineUtils.resultValuesToNull(execRowDefinition.getRowArray());
-		return execRowDefinition;
-	}
+        ExecRow result;
+        if (projection != null) {
+            result = projection.invoke();
+        } else {
+            result = mappedResultRow;
+        }
+        // Copy any mapped columns from the source
+        for (int index = 0; index < projectMapping.length; index++) {
+            if (projectMapping[index] != -1) {
+                DataValueDescriptor dvd = sourceRow.getColumn(projectMapping[index]);
+                // See if the column has been marked for cloning.
+                // If the value isn't a stream, don't bother cloning it.
+                if (cloneMap[index] && dvd.hasStream()) {
+                    dvd = dvd.cloneValue(false);
+                }
+                result.setColumn(index + 1, dvd);
+            }
+        }
+        if (reuseResult)
+            projRow = result;
+        /* Remember the result if reusing it */
+        return result;
+    }
 
-	@Override
-	public String toString() {
-		return String.format("ProjectRestrictOperation {source=%s,resultSetNumber=%d}", source, resultSetNumber);
-	}
+    /**
+     * Returns the definition of the columns in a row.  A projection will be executed to determine the columns
+     * that are added or removed.  Default values are used for the column values.
+     * PLEASE NOTE: Numeric columns will be ones by default.  So the delegate operation may need to reset the values
+     * to zeroes, etc.  This is what happens in the ScalarAggregateOperation classes.
+     *
+     * @return the definition of the row
+     */
+    @Override
+    public ExecRow getExecRowDefinition() throws StandardException {
 
-	@Override
-	public int[] getRootAccessedCols(long tableNumber) throws StandardException {
-		int[] sourceCols = source.getRootAccessedCols(tableNumber);
-		if (projectMapping == null) {
-			return sourceCols;
-		}
-		int[] result = new int[projectMapping.length];
-		for (int i = 0; i < projectMapping.length; ++i) {
-			if (projectMapping[i] > 0) {
-				result[i] = sourceCols[projectMapping[i] - 1];
-			}
-		}
-		return result;
-	}
+        if (execRowDefinition == null) {
+            ExecRow def = source.getExecRowDefinition();
+            ExecRow clone = def != null ? def.getClone() : null;
+            // In case the source's ExecRow has value set to 0 which may cause trouble for division,
+            // set the value to null, the numeric data types have logic to handle null as divisor
+            if (clone != null) EngineUtils.resultValuesToNull(clone.getRowArray());
+            // Keeps Sequences from incrementing when doing an execRowDefiniton evaluation: hack
+            ((BaseActivation) activation).setIgnoreSequence(true);
+            source.setCurrentRow(clone);
+            execRowDefinition = doProjection(clone);
+            ((BaseActivation) activation).setIgnoreSequence(false);
+        }
+        execRowDefinition = execRowDefinition.getClone();
+        EngineUtils.resultValuesToNull(execRowDefinition.getRowArray());
+        return execRowDefinition;
+    }
 
-	@Override
-	public boolean isReferencingTable(long tableNumber) {
-		return source.isReferencingTable(tableNumber);
-	}
+    @Override
+    public String toString() {
+        return String.format("ProjectRestrictOperation {source=%s,resultSetNumber=%d}", source, resultSetNumber);
+    }
 
-	public SpliceOperation getSource() {
-		return this.source;
-	}
+    @Override
+    public int[] getRootAccessedCols(long tableNumber) throws StandardException {
+        int[] sourceCols = source.getRootAccessedCols(tableNumber);
+        if (projectMapping == null) {
+            return sourceCols;
+        }
+        int[] result = new int[projectMapping.length];
+        for (int i = 0; i < projectMapping.length; ++i) {
+            if (projectMapping[i] > 0) {
+                result[i] = sourceCols[projectMapping[i] - 1];
+            }
+        }
+        return result;
+    }
 
-	@Override
-	public String prettyPrint(int indentLevel) {
-		String indent = "\n" + Strings.repeat("\t", indentLevel);
+    @Override
+    public boolean isReferencingTable(long tableNumber) {
+        return source.isReferencingTable(tableNumber);
+    }
 
-		return "ProjectRestrict:" + indent
-				+ "resultSetNumber:" + resultSetNumber + indent
-				+ "restrictionMethodName:" + restrictionMethodName + indent
-				+ "projectionMethodName:" + projectionMethodName + indent
-				+ "doesProjection:" + doesProjection + indent
-				+ "source:" + source.prettyPrint(indentLevel + 1);
-	}
+    public SpliceOperation getSource() {
+        return this.source;
+    }
 
-	public Restriction getRestriction() {
-		Restriction mergeRestriction = Restriction.noOpRestriction;
-		if (restriction != null) {
-			mergeRestriction = new Restriction() {
-				@Override
-				public boolean apply(ExecRow row) throws StandardException {
-					activation.setCurrentRow(row, resultSetNumber);
-					DataValueDescriptor shouldKeep = restriction.invoke();
-					return !shouldKeep.isNull() && shouldKeep.getBoolean();
-				}
-			};
-		}
-		return mergeRestriction;
-	}
+    @Override
+    public String prettyPrint(int indentLevel) {
+        String indent = "\n" + Strings.repeat("\t", indentLevel);
 
-	private void evaluateConstantRestriction() throws StandardException {
-		if (constantRestrictionMethodName != null) {
-			SpliceMethod<DataValueDescriptor> constantRestriction = new SpliceMethod<>(constantRestrictionMethodName, activation);
-			DataValueDescriptor restrictBoolean = constantRestriction.invoke();
-			shortCircuitOpen = (restrictBoolean == null) || ((!restrictBoolean.isNull()) && restrictBoolean.getBoolean());
-			alwaysFalse = restrictBoolean != null && !restrictBoolean.isNull() && !restrictBoolean.getBoolean();
-		}
-	}
+        return "ProjectRestrict:" + indent
+                + "resultSetNumber:" + resultSetNumber + indent
+                + "restrictionMethodName:" + restrictionMethodName + indent
+                + "projectionMethodName:" + projectionMethodName + indent
+                + "doesProjection:" + doesProjection + indent
+                + "source:" + source.prettyPrint(indentLevel + 1);
+    }
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public DataSet<ExecRow> getDataSet(DataSetProcessor dsp) throws StandardException {
-		if (!isOpen)
-			throw new IllegalStateException("Operation is not open");
+    public Restriction getRestriction() {
+        Restriction mergeRestriction = Restriction.noOpRestriction;
+        if (restriction != null) {
+            mergeRestriction = new Restriction() {
+                @Override
+                public boolean apply(ExecRow row) throws StandardException {
+                    activation.setCurrentRow(row, resultSetNumber);
+                    DataValueDescriptor shouldKeep = restriction.invoke();
+                    return !shouldKeep.isNull() && shouldKeep.getBoolean();
+                }
+            };
+        }
+        return mergeRestriction;
+    }
 
-		if (parameterInConstantRestriction) {
-			evaluateConstantRestriction();
-		}
-		if (alwaysFalse) {
-			return dsp.getEmpty();
-		}
-		boolean sparkExplainWithSubquery = subqueryText != null && subqueryText.length() != 0;
-		OperationContext operationContext = dsp.createOperationContext(this);
-		dsp.incrementOpDepth();
-		ExplainNode.SparkExplainKind sparkExplainKind = NONE;
-		if (sparkExplainWithSubquery) {
-			sparkExplainKind = dsp.getSparkExplainKind();
-		}
-		DataSet<ExecRow> sourceSet = source.getDataSet(dsp);
-		DataSet<ExecRow> originalSourceDataset = sourceSet;
-		if (sparkExplainWithSubquery)
-			dsp.setSparkExplain(sparkExplainKind);
-		dsp.decrementOpDepth();
-		try {
-			operationContext.pushScope();
-			if (restrictionMethodName != null)
-				sourceSet = sourceSet.filter(new ProjectRestrictPredicateFunction<>(operationContext));
-			DataSet<ExecRow> projection = sourceSet.map(new ProjectRestrictMapFunction<>(operationContext, expressions));
+    private void evaluateConstantRestriction() throws StandardException {
+        if (constantRestrictionMethodName != null) {
+            SpliceMethod<DataValueDescriptor> constantRestriction = new SpliceMethod<>(constantRestrictionMethodName, activation);
+            DataValueDescriptor restrictBoolean = constantRestriction.invoke();
+            shortCircuitOpen = (restrictBoolean == null) || ((!restrictBoolean.isNull()) && restrictBoolean.getBoolean());
+            alwaysFalse = restrictBoolean != null && (restrictBoolean.isNull() || !restrictBoolean.getBoolean());
+        }
+    }
 
-			handleSparkExplain(projection, originalSourceDataset, dsp);
-			if (sparkExplainWithSubquery) {
-				String lines[] = subqueryText.split("\\r?\\n");
-				int increment = 0;
-				for (String str : lines) {
-					dsp.appendSpliceExplainString(str);
-					dsp.incrementOpDepth();
-					increment++;
-				}
-				for (int i = 0; i < increment; i++)
-					dsp.decrementOpDepth();
-			}
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public DataSet<ExecRow> getDataSet(DataSetProcessor dsp) throws StandardException {
+        if (!isOpen)
+            throw new IllegalStateException("Operation is not open");
 
-			return projection;
-		} finally {
-			operationContext.popScope();
-		}
-	}
+        if (parameterInConstantRestriction) {
+            evaluateConstantRestriction();
+        }
+        if (alwaysFalse) {
+            return dsp.getEmpty();
+        }
+        boolean sparkExplainWithSubquery = subqueryText != null && subqueryText.length() != 0;
+        OperationContext operationContext = dsp.createOperationContext(this);
+        dsp.incrementOpDepth();
+        ExplainNode.SparkExplainKind sparkExplainKind = NONE;
+        if (sparkExplainWithSubquery) {
+            sparkExplainKind = dsp.getSparkExplainKind();
+        }
+        DataSet<ExecRow> sourceSet = source.getDataSet(dsp);
+        DataSet<ExecRow> originalSourceDataset = sourceSet;
+        if (sparkExplainWithSubquery)
+            dsp.setSparkExplain(sparkExplainKind);
+        dsp.decrementOpDepth();
+        try {
+            operationContext.pushScope();
+            if (restrictionMethodName != null)
+                sourceSet = sourceSet.filter(new ProjectRestrictPredicateFunction<>(operationContext));
+            DataSet<ExecRow> projection = sourceSet.map(new ProjectRestrictMapFunction<>(operationContext, expressions));
 
-	@Override
-	public ExecIndexRow getStartPosition() throws StandardException {
-		return source.getStartPosition();
-	}
+            handleSparkExplain(projection, originalSourceDataset, dsp);
+            if (sparkExplainWithSubquery) {
+                String lines[] = subqueryText.split("\\r?\\n");
+                int increment = 0;
+                for (String str : lines) {
+                    dsp.appendSpliceExplainString(str);
+                    dsp.incrementOpDepth();
+                    increment++;
+                }
+                for (int i = 0; i < increment; i++)
+                    dsp.decrementOpDepth();
+            }
 
-	@Override
-	public ExecIndexRow getStopPosition() throws StandardException {
-		return source.getStopPosition();
-	}
+            return projection;
+        } finally {
+            operationContext.popScope();
+        }
+    }
 
-	@Override
-	public boolean getSameStartStopPosition() {
-		return source.getSameStartStopPosition();
-	}
+    @Override
+    public ExecIndexRow getStartPosition() throws StandardException {
+        return source.getStartPosition();
+    }
 
-	@Override
-	public String getVTIFileName() {
-		return getSubOperations().get(0).getVTIFileName();
-	}
+    @Override
+    public ExecIndexRow getStopPosition() throws StandardException {
+        return source.getStopPosition();
+    }
 
-	@Override
-	public FormatableBitSet getAccessedColumns() throws StandardException {
-		return source.getAccessedColumns();
-	}
+    @Override
+    public boolean getSameStartStopPosition() {
+        return source.getSameStartStopPosition();
+    }
 
-	@Override
-	public ScanInformation<ExecRow> getScanInformation() {
-		return source.getScanInformation();
-	}
+    @Override
+    public String getVTIFileName() {
+        return getSubOperations().get(0).getVTIFileName();
+    }
 
-	@Override
-	public TxnView getCurrentTransaction() throws StandardException {
-		return source.getCurrentTransaction();
-	}
+    @Override
+    public FormatableBitSet getAccessedColumns() throws StandardException {
+        return source.getAccessedColumns();
+    }
 
-	@Override
-	public boolean isForUpdate() {
-		return source.isForUpdate();
-	}
+    @Override
+    public ScanInformation<ExecRow> getScanInformation() {
+        return source.getScanInformation();
+    }
+
+    @Override
+    public TxnView getCurrentTransaction() throws StandardException {
+        return source.getCurrentTransaction();
+    }
+
+    @Override
+    public boolean isForUpdate() {
+        return source.isForUpdate();
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
@@ -19,32 +19,48 @@ import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.SerialTest;
 import com.splicemachine.test_tools.TableCreator;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.ImmutableList;
 import splice.com.google.common.collect.Lists;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static com.splicemachine.test_tools.Rows.row;
 import static com.splicemachine.test_tools.Rows.rows;
 
 /**
- * Test predicate with tuples
+ * Test predicate with nulls
  */
 @RunWith(Parameterized.class)
+@Category(SerialTest.class)
 public class NullPredicateIT extends SpliceUnitTest {
 
     private Boolean useSpark;
+    private Boolean disablePredicateSimpification;
+    private Boolean disableConstantFolding;
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
-        params.add(new Object[]{true});
-        params.add(new Object[]{false});
+        List<Boolean> values = Arrays.asList(true, false);
+        for (boolean useSpark: values) {
+            for (boolean disablePredicateSimplification: values) {
+                for (boolean disableConstantFolding: values) {
+                    params.add(new Object[]{useSpark, disablePredicateSimplification, disableConstantFolding});
+                }
+            }
+        }
         return params;
     }
     private static final String SCHEMA = NullPredicateIT.class.getSimpleName();
@@ -57,6 +73,22 @@ public class NullPredicateIT extends SpliceUnitTest {
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+    @Parameterized.BeforeParam
+    public static void beforeParam(boolean useSpark, boolean disablePredicateSimpification, boolean disableConstantFolding) throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute(format("call syscs_util.syscs_set_global_database_property('derby.database.disablePredicateSimplification', '%s')", disablePredicateSimpification));
+        classWatcher.execute(format("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', '%s')", disableConstantFolding));
+    }
+
+    @Parameterized.AfterParam
+    public static void afterParam() throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute("call syscs_util.syscs_set_global_database_property('derby.database.disablePredicateSimplification', null)");
+        classWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', null)");
+    }
 
     public static void createData(Connection conn, String schemaName) throws Exception {
         new TableCreator(conn)
@@ -74,8 +106,10 @@ public class NullPredicateIT extends SpliceUnitTest {
         createData(classWatcher.getOrCreateConnection(), schemaWatcher.toString());
     }
 
-    public NullPredicateIT(Boolean useSpark) {
+    public NullPredicateIT(Boolean useSpark, Boolean disablePredicateSimpification, Boolean disableConstantFolding) {
         this.useSpark = useSpark;
+        this.disablePredicateSimpification = disablePredicateSimpification;
+        this.disableConstantFolding = disableConstantFolding;
     }
 
     @Test
@@ -249,7 +283,7 @@ public class NullPredicateIT extends SpliceUnitTest {
     @Test
     public void testInListWithNullInJoinCondition() throws Exception {
         String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
-                                      " inner join T on cast(null as boolean) in (42)", useSpark);
+                                      " inner join T on cast(null as integer) in (42)", useSpark);
 
         String expected = "1 |\n" +
                 "----\n" +
@@ -263,7 +297,7 @@ public class NullPredicateIT extends SpliceUnitTest {
     @Test
     public void testNotWithInListWithNullInJoinCondition() throws Exception {
         String query = format("select count(*) from T --SPLICE-PROPERTIES useSpark=%s\n" +
-                                      " inner join T on cast(null as boolean) not in (42)", useSpark);
+                                      " inner join T on cast(null as integer) not in (42)", useSpark);
 
         String expected = "1 |\n" +
                 "----\n" +
@@ -279,7 +313,15 @@ public class NullPredicateIT extends SpliceUnitTest {
         String res = "A | B  |\n" +
                 "---------\n" +
                 " 1 |aaa |";
-        methodWatcher.assertStrResult(res, "select * from t where case when a < 0 then null else 2 end > 0", false);
-        methodWatcher.assertStrResult(res, "select * from t where case when a > 0 then 2 else null end > 0", false);
+        methodWatcher.assertStrResult(res, "select * from t --splice-properties useSpark=%s\n where case when a < 0 then null else 2 end > 0", false);
+        methodWatcher.assertStrResult(res, "select * from t --splice-properties useSpark=%s\n where case when a > 0 then 2 else null end > 0", false);
+    }
+
+    @Test
+    public void testNullBehindFunction() throws Exception {
+        testQuery("select * from t --splice-properties useSpark=%s\n where cast(null as integer) not in (3,4)", "", methodWatcher);
+        testQuery("select * from t --splice-properties useSpark=%s\n where upper(cast(null as varchar(10))) = 'a'", "", methodWatcher);
+        testQuery("select * from t --splice-properties useSpark=%s\n where days(cast(null as timestamp)) = 50", "", methodWatcher);
+        testQuery("select * from t --splice-properties useSpark=%s\n where day(cast(null as timestamp)) = 50", "", methodWatcher);
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
@@ -46,13 +46,37 @@ import static org.junit.Assert.assertTrue;
 public class PredicateSimplificationIT  extends SpliceUnitTest {
     
     private Boolean useSpark;
-    
+    private Boolean disablePredicateSimpification;
+    private Boolean disableConstantFolding;
+
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
-        params.add(new Object[]{true});
-        params.add(new Object[]{false});
+        List<Boolean> values = Arrays.asList(true, false);
+        for (boolean useSpark: values) {
+            for (boolean disablePredicateSimplification: values) {
+                for (boolean disableConstantFolding: values) {
+                    params.add(new Object[]{useSpark, disablePredicateSimplification, disableConstantFolding});
+                }
+            }
+        }
         return params;
+    }
+
+    @Parameterized.BeforeParam
+    public static void beforeParam(boolean useSpark, boolean disablePredicateSimpification, boolean disableConstantFolding) throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute(format("call syscs_util.syscs_set_global_database_property('derby.database.disablePredicateSimplification', '%s')", disablePredicateSimpification));
+        classWatcher.execute(format("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', '%s')", disableConstantFolding));
+    }
+
+    @Parameterized.AfterParam
+    public static void afterParam() throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute("call syscs_util.syscs_set_global_database_property('derby.database.disablePredicateSimplification', null)");
+        classWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', null)");
     }
     private static final String SCHEMA = PredicateSimplificationIT.class.getSimpleName();
 
@@ -80,8 +104,10 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         }
     }
 
-    public PredicateSimplificationIT(Boolean useSpark) {
+    public PredicateSimplificationIT(Boolean useSpark, Boolean disablePredicateSimpification, Boolean disableConstantFolding) {
         this.useSpark = useSpark;
+        this.disablePredicateSimpification = disablePredicateSimpification;
+        this.disableConstantFolding = disableConstantFolding;
     }
 
 
@@ -189,7 +215,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         List<String> containedStrings = Arrays.asList("MultiProbeIndexScan", "(A1[0:1] IN (1,2,3,4,5,6)");
         List<String> notContainedStrings = null;
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (a1 in (1,2,3) and false) or (a1 in (4,5,6) and (true or false and 5=5 or 4=5)) ", useSpark);
@@ -203,7 +230,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
 
         containedStrings = Arrays.asList("MultiProbeIndexScan", "(A1[0:1] IN (4,5,6)");
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (a1 in (1,2,3) and (a2 = 3 and (a3 =5 and (false or (true and (false and true))) or (a1 in (4,5,6) and (false or true and 5=4 or 5=8))))) ", useSpark);
@@ -214,20 +242,23 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("TableScan");
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (a1 in (1,2,3) and a2 in (10,20,30) and a3 in (100,200,300) and false) ", useSpark);
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (false and a1 in (1,2,3) and a2 in (10,20,30) and a3 in (100,200,300)) ", useSpark);
 
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (a1 in (1,2,3) and a2 in (10,20,30) and a3 in (100,200,300) or true) ", useSpark);
@@ -253,13 +284,15 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("MultiProbeIndexScan", "preds");
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (true or a1 in (1,2,3) and a2 in (10,20,30) and a3 in (100,200,300)) ", useSpark);
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (a1 in (4,5,6) or (false and true)) and a2 in (40,50,60) and (true or false) ", useSpark);
@@ -277,7 +310,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
             containedStrings = Arrays.asList("MultiProbeIndexScan", "[((A1[0:1],A2[0:2]) IN ((4,40),(4,50),(4,60),(5,40),(5,50),(5,60),(6,40),(6,50),(6,60)))]");
         notContainedStrings = null;
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
     }
 
     @Test
@@ -295,13 +329,19 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
                     " 1 |";
 
         // Simplifying predicates should allow Merge join to be picked.
-        String query = format("select 1 from A, B --SPLICE-PROPERTIES joinStrategy=MERGE, useSpark=%s\n" +
-            "where a1 = b1 or false ", useSpark);
 
-        List<String> containedStrings = Arrays.asList("IndexScan");
-        List<String> notContainedStrings = null;
-        testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        String query;
+        List<String> containedStrings;
+        List<String> notContainedStrings;
+        if (!disablePredicateSimpification) {
+            query = format("select 1 from A, B --SPLICE-PROPERTIES joinStrategy=MERGE, useSpark=%s\n" +
+                    "where a1 = b1 or false ", useSpark);
+
+            containedStrings = Arrays.asList("IndexScan");
+            notContainedStrings = null;
+            testQuery(query, expected);
+            testExplainContains(query, containedStrings, notContainedStrings);
+        }
 
         query = format("select count(*) from A, B --SPLICE-PROPERTIES useSpark=%s\n" +
             "where a1 = b1 or true ", useSpark);
@@ -313,7 +353,9 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("preds");;
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where a1 in (select b1 from B) and false ", useSpark);
@@ -325,7 +367,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("Join");
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where a1 in (select b1 from B) and a1 in (select c1 from C) and " +
@@ -336,7 +379,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
                 " 0 |";
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where false and a1 in (select b1 from B) and a1 in (select c1 from C) and " +
@@ -347,7 +391,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
                 " 0 |";
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where a1 in (select b1 from B) and a1 in (select c1 from C) and " +
@@ -359,14 +404,16 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("preds");;
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where true or a1 in (select b1 from B) and a1 in (select c1 from C) and " +
             "a1 in (select d1 from D) ", useSpark);
 
         testQuery(query, expected);
-        testExplainContains(query, containedStrings, notContainedStrings);
+        if (!disablePredicateSimpification)
+            testExplainContains(query, containedStrings, notContainedStrings);
     }
 
 
@@ -388,7 +435,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         List<String> notContainedStrings = null;
         List<Integer> paramList = Arrays.asList(1,2,3,4,5,6);
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("Join");
@@ -423,7 +471,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where false and TO_DEGREES(a1) > ?", useSpark);
@@ -435,7 +484,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("Scan");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where true or TO_DEGREES(?) > a1", useSpark);
@@ -447,7 +497,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where false and TO_DEGREES(?) > a1", useSpark);
@@ -459,7 +510,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("Scan");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where a1 in (select b1 from B where b2 = a2) and a1 in (select c1 from C where c2=a2) and " +
@@ -472,7 +524,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s, index=pred_simpl_a1_a2\n" +
             "where a1 in (select b1 from B --SPLICE-PROPERTIES index=pred_simpl_b1\n" +
@@ -487,7 +540,8 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("IndexLookup");
         notContainedStrings = Arrays.asList("Values");
         testPreparedQuery(query, expected, paramList);
-        testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
+        if (!disablePredicateSimpification)
+            testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
     }
 
     @Test

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
@@ -19,7 +19,9 @@ import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
 import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.SpliceWatcher;
 import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.SerialTest;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import splice.com.google.common.collect.Lists;
@@ -43,6 +45,7 @@ import static org.junit.Assert.assertTrue;
  *  (p AND FALSE) ==> (FALSE)
  */
 @RunWith(Parameterized.class)
+@Category(SerialTest.class)
 public class PredicateSimplificationIT  extends SpliceUnitTest {
     
     private Boolean useSpark;


### PR DESCRIPTION
## Short description
Fix issue with null constant restriction during execution

## Long description
We try to remove nulls during constant folding & predicate simplification phase. However, if a folding or a simplification is missing, we would end up with a null constant restriction, which was evaluated to true during the execution. 
This PR fixes the execution problem, and introduces tests that enable/disable constant folding and predicate simplification, so that they do not hide null predicate problems in the future.
We also introduce a new parameter: `splice.database.disableConstantFolding` that echoes `derby.database.disablePredicateSimplification`. Both those parameters are database level parameters for now, but they we should introduce them as session parameters as well.
We bumped junit's version to 4.13.1 in in order to use [BeforeParameter/AfterParameter](https://github.com/junit-team/junit4/pull/1435/files#diff-0f0be60a1387c68e5f84d98b8abd26814e66286d24ce2180624724128174d391) annotations.

## How to test

```
create table t (a int);
insert into t values 1,3,5;
select * from t where upper(cast(null as varchar(10))) = 'a';
```
should not return any rows.