### PR TITLE
DB-12075: null check for namespace

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
+++ b/hbase_sql/src/main/java/com/splicemachine/hbase/BackupUtils.java
@@ -254,7 +254,7 @@ public class BackupUtils {
      * @return
      */
     public static boolean isSpliceTable(String namespace) {
-        return namespace.equals("splice");
+        return namespace!= null && namespace.equals("splice");
     }
 
     public static boolean backupCanceled(long backupId) throws KeeperException, InterruptedException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
BackupEndpointObserver.postFlush crashes region server if the namespace of a table is null

## Long Description


## How to test
From hbase shell, create an hbase table with default namespace, insert data to it and flush the table
create 'guru99', {NAME=>'Edu', VERSIONS=>213423443}
put 'guru99', 'r1', 'Edu:c1', 'value', 10
put 'guru99', 'r1', 'Edu:c1', 'value', 15
put 'guru99', 'r1', 'Edu:c1', 'value', 30
flush 'guru99'
