### PR TITLE
DB-12077 Remove test with DAYS as DAYS does not exist in 3.1

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/NullPredicateIT.java
@@ -321,7 +321,6 @@ public class NullPredicateIT extends SpliceUnitTest {
     public void testNullBehindFunction() throws Exception {
         testQuery("select * from t --splice-properties useSpark=%s\n where cast(null as integer) not in (3,4)", "", methodWatcher);
         testQuery("select * from t --splice-properties useSpark=%s\n where upper(cast(null as varchar(10))) = 'a'", "", methodWatcher);
-        testQuery("select * from t --splice-properties useSpark=%s\n where days(cast(null as timestamp)) = 50", "", methodWatcher);
         testQuery("select * from t --splice-properties useSpark=%s\n where day(cast(null as timestamp)) = 50", "", methodWatcher);
     }
 }


### PR DESCRIPTION
## Description
The cherry-pick from main of DB-12077 introduced new tests for NullPredicateIT. One of those tests relied on the `DAYS` function that does not exist in 3.1, so we should remove that from the test.