### PR TITLE
DB-11523 sort merge join infeasible for correlated subq. join condition (redux + fix)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizablePredicate.java
@@ -204,4 +204,6 @@ public interface OptimizablePredicate
 	// of one of the OrNodes (OrNode chains are right-deep, with each left child being
 	// something other than an OrNode, if normalized properly).
 	List<OptimizablePredicateList> separateOredPredicates() throws StandardException;
+
+	boolean hasCorrelatedSubquery() throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Optimizer.java
@@ -43,6 +43,7 @@ import com.splicemachine.db.impl.sql.compile.FromBaseTable;
 import com.splicemachine.db.impl.sql.compile.GroupByList;
 import com.splicemachine.db.impl.sql.compile.OrderByList;
 import com.splicemachine.db.impl.sql.compile.ResultSetNode;
+import com.splicemachine.db.impl.sql.compile.PredicateList;
 
 import java.util.List;
 
@@ -439,4 +440,12 @@ public interface Optimizer{
 
     FromBaseTable getOuterBaseTable() throws StandardException;
 
+
+    void setNonPushablePredicates(PredicateList predicateList);
+
+    /**
+     * Postcondition @return != null.
+     * @return the non-pushable predicate list
+     */
+    PredicateList getNonPushablePredicates();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FullOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FullOuterJoinNode.java
@@ -139,22 +139,7 @@ public class FullOuterJoinNode extends JoinNode {
 		 * conditions only get pushed down 1 level.
 		 * We use the optimizer's logic for pushing down join clause here.
 		 */
-        // Walk joinPredicates backwards due to possible deletes
-        for(int index=joinPredicates.size()-1;index>=0;index--){
-            Predicate predicate;
-
-            predicate=joinPredicates.elementAt(index);
-            if(!predicate.getPushable()){
-                continue;
-            }
-
-            optimizeTrace(OptimizerFlag.JOIN_NODE_PREDICATE_MANIPULATION,0,0,0.0,
-                    "FullOuterJoinNode pushing predicate right.",predicate);
-            getRightPredicateList().addPredicate(predicate);
-
-			/* Remove the matching predicate from the outer list */
-            joinPredicates.removeElementAt(index);
-        }
+        movePushablePredicatesToRhs();
 
 		/* Recurse down both sides of tree */
         PredicateList noPredicates= (PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST,getContextManager());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/HalfOuterJoinNode.java
@@ -222,22 +222,7 @@ public class HalfOuterJoinNode extends JoinNode{
 		 * conditions only get pushed down 1 level.
 		 * We use the optimizer's logic for pushing down join clause here.
 		 */
-        // Walk joinPredicates backwards due to possible deletes
-        for(int index=joinPredicates.size()-1;index>=0;index--){
-            Predicate predicate;
-
-            predicate=joinPredicates.elementAt(index);
-            if(!predicate.getPushable()){
-                continue;
-            }
-
-            optimizeTrace(OptimizerFlag.JOIN_NODE_PREDICATE_MANIPULATION,0,0,0.0,
-                                     "HalfOuterJoinNode pushing predicate right.",predicate);
-            getRightPredicateList().addPredicate(predicate);
-
-			/* Remove the matching predicate from the outer list */
-            joinPredicates.removeElementAt(index);
-        }
+        movePushablePredicatesToRhs();
 
 		/* Recurse down both sides of tree */
         PredicateList noPredicates= (PredicateList)getNodeFactory().getNode(C_NodeTypes.PREDICATE_LIST,getContextManager());

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IntersectOrExceptNode.java
@@ -236,18 +236,16 @@ public class IntersectOrExceptNode extends SetOperatorNode
                           throws StandardException
     {
         leftResultSet = optimizeSource(
-                            optimizer,
-                            leftResultSet,
-                            (PredicateList) null,
-                            null,
-                            null);
+                optimizer,
+                leftResultSet,
+                null, null,
+                null, null);
 
         rightResultSet = optimizeSource(
-                            optimizer,
-                            rightResultSet,
-                            (PredicateList) null,
-                            null,
-                            null);
+                optimizer,
+                rightResultSet,
+                null, null,
+                null, null);
 
         CostEstimate costEstimate = getCostEstimate(optimizer);
         CostEstimate leftCostEstimate = leftResultSet.getCostEstimate();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/JoinNode.java
@@ -185,6 +185,23 @@ public class JoinNode extends TableOperatorNode{
 
     }
 
+    protected void movePushablePredicatesToRhs() throws StandardException {
+        // Walk joinPredicates backwards due to possible deletes
+        for(int index=joinPredicates.size()-1;index>=0;index--){
+            Predicate predicate;
+
+            predicate=joinPredicates.elementAt(index);
+            if(!predicate.getPushable()){
+                continue;
+            }
+
+            joinPredicates.removeElementAt(index);
+            optimizeTrace(OptimizerFlag.JOIN_NODE_PREDICATE_MANIPULATION,0,0,0.0,
+                                     this.getClass().getName() + " pushing predicate right.",predicate);
+            getRightPredicateList().addElement(predicate);
+        }
+    }
+
     @Override
     public CostEstimate optimizeIt(Optimizer optimizer,
                                    OptimizablePredicateList predList,
@@ -224,7 +241,7 @@ public class JoinNode extends TableOperatorNode{
         // RESOLVE: NEED TO SET ROW ORDERING OF SOURCES IN THE ROW ORDERING
         // THAT WAS PASSED IN.
 
-        leftResultSet=optimizeSource(optimizer,leftResultSet,getLeftPredicateList(),null,null);
+        leftResultSet=optimizeSource(optimizer, leftResultSet, getLeftPredicateList(), null, null, null);
 
         /* Move all joinPredicates down to the right.
          * RESOLVE - When we consider the reverse join order then
@@ -234,21 +251,7 @@ public class JoinNode extends TableOperatorNode{
          * RESOLVE - This logic needs to be looked at when we
          * implement full outer join.
          */
-        // Walk joinPredicates backwards due to possible deletes
-
-
-        for(int index=joinPredicates.size()-1;index>=0;index--){
-            Predicate predicate;
-
-            predicate=joinPredicates.elementAt(index);
-            if(!predicate.getPushable()){
-                continue;
-            }
-            joinPredicates.removeElementAt(index);
-            optimizer.tracer().trace(OptimizerFlag.JOIN_NODE_PREDICATE_MANIPULATION,0,0,0.0,
-                                     "JoinNode pushing predicate right.",predicate);
-            getRightPredicateList().addElement(predicate);
-        }
+        movePushablePredicatesToRhs();
 
         CostEstimate lrsCE = leftResultSet.getCostEstimate();
         if (this instanceof FullOuterJoinNode)
@@ -260,7 +263,7 @@ public class JoinNode extends TableOperatorNode{
         double savedAccumulatedMemory = lrsCE.getAccumulatedMemory();
         lrsCE.setAccumulatedMemory(leftOptimizer.getAccumulatedMemory());
         optimizer.setOuterTableOfJoin(leftResultSet);
-        rightResultSet=optimizeSource(optimizer,rightResultSet,getRightPredicateList(),leftResultSet.getReferencedTableMap(),lrsCE);
+        rightResultSet=optimizeSource(optimizer, rightResultSet, getRightPredicateList(), joinPredicates, leftResultSet.getReferencedTableMap(), lrsCE);
         optimizer.setOuterTableOfJoin(null);
         lrsCE.setJoinType(INNERJOIN);
         lrsCE.setAccumulatedMemory(savedAccumulatedMemory);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerImpl.java
@@ -200,6 +200,7 @@ public class OptimizerImpl implements Optimizer{
     boolean foundCompleteJoinPlan = false;
 
     private CostModel costModel;
+    private PredicateList nonPushablePredicateList;
 
     private ResultSetNode outerTableOfJoin;
 
@@ -284,6 +285,8 @@ public class OptimizerImpl implements Optimizer{
         this.bestRowOrdering=newRowOrdering();
 
         this.costModel = costModel;
+        // create empty list of non-pushable predicates.
+        this.nonPushablePredicateList = new PredicateList();
     }
 
     @Override
@@ -2868,4 +2871,16 @@ public class OptimizerImpl implements Optimizer{
        return outerBaseTable;
     }
 
+
+    @Override
+    public void setNonPushablePredicates(PredicateList predicateList) {
+        if(predicateList != null) {
+            this.nonPushablePredicateList = predicateList;
+        }
+    }
+
+    @Override
+    public PredicateList getNonPushablePredicates() {
+        return nonPushablePredicateList;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -97,6 +97,9 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
     // table number -> scan selectivity
     private HashMap<Integer, Double> scanSelectivityCache;
 
+    private boolean hasCorrelatedSubquery;
+    private boolean hasCorrelatedSubquerySet;
+
     public ReferencedColumnsMap getReferencedColumns() {
         return referencedColumns;
     }
@@ -133,6 +136,8 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
         this.referencedSet=(JBitSet)referencedSet;
         scoped=false;
         matchIndexExpression=false;
+        hasCorrelatedSubquery = false;
+        hasCorrelatedSubquerySet = false;
     }
 
 	/*
@@ -1796,5 +1801,24 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
             getReferencedSet(),
             getContextManager());
         return newPred;
+    }
+
+    @Override
+    public boolean hasCorrelatedSubquery() throws StandardException {
+        if(hasCorrelatedSubquerySet) {
+            return hasCorrelatedSubquery;
+        }
+        hasCorrelatedSubquerySet = true;
+        CollectNodesVisitor visitor= new CollectNodesVisitor(SubqueryNode.class);
+        this.accept(visitor);
+        @SuppressWarnings("unchecked") List<SubqueryNode> subqueryNodes=visitor.getList();
+        for(SubqueryNode subqueryNode : subqueryNodes) {
+            if(subqueryNode.hasCorrelatedCRs()) {
+                hasCorrelatedSubquery = true;
+                return hasCorrelatedSubquery;
+            }
+        }
+        hasCorrelatedSubquery = false;
+        return hasCorrelatedSubquery;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -757,6 +757,7 @@ public abstract class TableOperatorNode extends FromTable{
     protected ResultSetNode optimizeSource(Optimizer optimizer,
                                            ResultSetNode sourceResultSet,
                                            PredicateList predList,
+                                           PredicateList nonPushablePredicates,
                                            JBitSet otherChildReferenceMap,
                                            CostEstimate outerCost) throws StandardException{
         ResultSetNode retval;
@@ -776,6 +777,7 @@ public abstract class TableOperatorNode extends FromTable{
 
             LanguageConnectionContext lcc=getLanguageConnectionContext();
             OptimizerFactory optimizerFactory=lcc.getOptimizerFactory();
+            boolean forSpark = optimizer.isForSpark();
             optimizer=optimizerFactory.getOptimizer(optList,
                                                     predList,
                                                     getDataDictionary(),
@@ -785,6 +787,8 @@ public abstract class TableOperatorNode extends FromTable{
                                                     lcc.getCostModel());
             optimizer.prepForNextRound();
             optimizer.setAssignedTableMap(otherChildReferenceMap);
+            optimizer.setForSpark(forSpark);
+            optimizer.setNonPushablePredicates(nonPushablePredicates);
 
             if(sourceResultSet==leftResultSet){
                 leftOptimizer=optimizer;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnionNode.java
@@ -259,9 +259,9 @@ public class UnionNode extends SetOperatorNode{
         // getNextDecoratedPermutation() method.
         updateBestPlanMap(ADD_PLAN,this);
 
-        leftResultSet=optimizeSource(optimizer, leftResultSet, getLeftOptPredicateList(), null, null);
+        leftResultSet=optimizeSource(optimizer, leftResultSet, getLeftOptPredicateList(), null, null, null);
 
-        rightResultSet=optimizeSource(optimizer, rightResultSet, getRightOptPredicateList(), null, null);
+        rightResultSet=optimizeSource(optimizer, rightResultSet, getRightOptPredicateList(), null, null, null);
 
         CostEstimate leftCost = leftResultSet.getCostEstimate();
         CostEstimate rightCost = rightResultSet.getCostEstimate();

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -14,14 +14,9 @@
 
 package com.splicemachine.derby.impl.sql.compile;
 
-import com.splicemachine.EngineDriver;
-import com.splicemachine.access.api.SConfiguration;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.compile.*;
-import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.impl.sql.compile.HashableJoinStrategy;
-import com.splicemachine.db.impl.sql.compile.PredicateList;
-import com.splicemachine.db.impl.sql.compile.SelectivityUtil;
 
 public class MergeSortJoinStrategy extends HashableJoinStrategy {
 
@@ -36,17 +31,20 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
                             boolean skipKeyCheck) throws StandardException {
         if (innerTable.indexFriendlyJoinsOnly())
             return false;
-		return super.feasible(innerTable, predList, optimizer,outerCost,wasHinted,skipKeyCheck);
+		return correlatedSubqueryRestriction(optimizer, predList, outerCost.getJoinType())
+                && super.feasible(innerTable, predList, optimizer,outerCost,wasHinted,skipKeyCheck);
 	}
 
     /** @see JoinStrategy#multiplyBaseCostByOuterRows */
-	public boolean multiplyBaseCostByOuterRows() {
+    @Override
+    public boolean multiplyBaseCostByOuterRows() {
 		return true;
 	}
 
     /**
      * @see JoinStrategy#joinResultSetMethodName
      */
+    @Override
     public String joinResultSetMethodName() {
         return "getMergeSortJoinResultSet";
     }
@@ -54,10 +52,12 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
     /**
      * @see JoinStrategy#halfOuterJoinResultSetMethodName
      */
+    @Override
     public String halfOuterJoinResultSetMethodName() {
         return "getMergeSortLeftOuterJoinResultSet";
     }
 
+    @Override
     public String fullOuterJoinResultSetMethodName() {
         return "getMergeSortFullOuterJoinResultSet";
     }
@@ -73,5 +73,24 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
     @Override
     public int maxCapacity(int userSpecifiedCapacity,int maxMemoryPerTable,double perRowUsage){
         return Integer.MAX_VALUE;
+    }
+
+    private boolean correlatedSubqueryRestriction(Optimizer optimizer,
+                                                  OptimizablePredicateList predList,
+                                                  int joinType) throws StandardException {
+        if (optimizer.isForSpark()
+            && (containsCorrelatedSubquery(optimizer.getNonPushablePredicates()) || containsCorrelatedSubquery(predList))) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean containsCorrelatedSubquery(OptimizablePredicateList predList) throws StandardException {
+        for (int i = 0; i < predList.size(); i++) {
+            if(predList.getOptPredicate(i).hasCorrelatedSubquery()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/MergeSortJoinStrategy.java
@@ -86,6 +86,9 @@ public class MergeSortJoinStrategy extends HashableJoinStrategy {
     }
 
     private boolean containsCorrelatedSubquery(OptimizablePredicateList predList) throws StandardException {
+        if(predList == null) {
+            return false;
+        }
         for (int i = 0; i < predList.size(); i++) {
             if(predList.getOptPredicate(i).hasCorrelatedSubquery()) {
                 return true;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/OuterJoinIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations.joins;
 
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.utils.Pair;
 import splice.com.google.common.collect.ImmutableMap;
 import com.splicemachine.derby.test.framework.*;
@@ -50,6 +51,8 @@ public class OuterJoinIT extends SpliceUnitTest {
     private static final String TABLE_NAME_10 = "dupes";
     private static final String TABLE_NAME_11 = "t3";
     private static final String TABLE_NAME_12 = "t4";
+    private static final String TABLE_NAME_13 = "oj1";
+    private static final String TABLE_NAME_14 = "oj2";
 
 
     protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
@@ -79,6 +82,8 @@ public class OuterJoinIT extends SpliceUnitTest {
     private static SpliceTableWatcher j4 = new SpliceTableWatcher("j4", CLASS_NAME, "(a int, b int, c int, d int)");
     private static SpliceTableWatcher j5 = new SpliceTableWatcher("j5", CLASS_NAME, "(a int, b int, c int, d int)");
     private static SpliceTableWatcher j6 = new SpliceTableWatcher("j6", CLASS_NAME, "(a int, b int, c int, d int)");
+    private static SpliceTableWatcher oj1 = new SpliceTableWatcher(TABLE_NAME_13, CLASS_NAME, "(a int, b int)");
+    private static SpliceTableWatcher oj2 = new SpliceTableWatcher(TABLE_NAME_14, CLASS_NAME, "(a int, b int)");
 
 
     @ClassRule
@@ -109,6 +114,8 @@ public class OuterJoinIT extends SpliceUnitTest {
             .around(j4)
             .around(j5)
             .around(j6)
+            .around(oj1)
+            .around(oj2)
             .around(new SpliceDataWatcher() {
                 @Override
                 protected void starting(Description description) {
@@ -240,7 +247,23 @@ public class OuterJoinIT extends SpliceUnitTest {
             })
             .around(TestUtils.createFileDataWatcher(spliceClassWatcher, "small_msdatasample/startup.sql", CLASS_NAME))
             .around(TestUtils.createFileDataWatcher(spliceClassWatcher, "test_data/employee.sql", CLASS_NAME))
-            .around(TestUtils.createFileDataWatcher(spliceClassWatcher, "test_data/basic_join_dataset.sql", CLASS_NAME));
+            .around(TestUtils.createFileDataWatcher(spliceClassWatcher, "test_data/basic_join_dataset.sql", CLASS_NAME))
+            .around(new SpliceDataWatcher(){
+                @Override
+                protected void starting(Description description) {
+                    try {
+                        Statement statement = spliceClassWatcher.getStatement();
+                        statement.execute(String.format("insert into %s values (155,540)", oj1));
+                        statement.execute(String.format("insert into %s values (155,540)", oj2));
+                        statement.executeQuery(String.format("analyze table %s",oj1));
+                        statement.executeQuery(String.format("analyze table %s",oj2));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        spliceClassWatcher.closeAll();
+                    }
+                }
+            }) ;
 
     @Rule
     public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
@@ -630,6 +653,32 @@ public class OuterJoinIT extends SpliceUnitTest {
 
         try(ResultSet rs = methodWatcher.executeQuery(query)) {
             Assert.assertEquals(17, SpliceUnitTest.resultSetSize(rs));
+        }
+    }
+
+    @Test
+    public void testNonflattenableCorrelatedSubqueryAsJoinConditionForLeftOuterJoin() throws SQLException {
+        String query = "SELECT * FROM oj1 ALPHA LEFT OUTER JOIN \n" +
+                       "oj2 BETA --splice-properties useSpark=True, joinStrategy=sortmerge\n" +
+                       "ON ALPHA.b=BETA.b AND BETA.a = (SELECT MAX(A) FROM oj2 SUBQ WHERE SUBQ.b=ALPHA.b)";
+
+        try(ResultSet ignored = methodWatcher.executeQuery(query)) {
+            Assert.fail("expected optimizer to fail finding a plan");
+        } catch (SQLException sqlException) {
+            Assert.assertEquals(SQLState.LANG_NO_BEST_PLAN_FOUND, sqlException.getSQLState());
+        }
+
+        query = "SELECT * FROM oj1 ALPHA LEFT OUTER JOIN \n" +
+                "oj2 BETA --splice-properties useSpark=True, joinStrategy=nestedloop\n" +
+                "ON ALPHA.b=BETA.b AND BETA.a = (SELECT MAX(A) FROM oj2 SUBQ WHERE SUBQ.b=ALPHA.b)";
+
+        try(ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(155, rs.getInt(1));
+            Assert.assertEquals(540, rs.getInt(2));
+            Assert.assertEquals(155, rs.getInt(3));
+            Assert.assertEquals(540, rs.getInt(4));
+            Assert.assertFalse(rs.next());
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
 In this PR the sort merge join strategy is restricted from handling left and full outer joins containing a non-flattened correlated sub-query in the join condition for OLAP.

## Long Description

### 1. The bug

To understand the root cause of this issue, we should have a look at the generated code logic and the actual execution model of sort merge join in Spark.

#### Generated code
The generated code for evaluating a non-flattened correlated subquery constructs a `ScalarAggregateOperation` which performs a `ScalarAggregateFlatMapFunction` on `TableScannerIterator`, the table scanner itself defines a set of row qualifiers that filters in the rows the satisfy the correlation. For example, if the query is:

```
SELECT * FROM t1 ALPHA LEFT OUTER JOIN 
t2 BETA --splice-properties useSpark=True, joinStrategy=sortmerge
ON ALPHA.b=BETA.b AND BETA.a = (SELECT MAX(A) FROM t2 SUBQ WHERE SUBQ.b=ALPHA.b) ;
```

Then the row qualifier in the scanner will filter in rows that satisfy the condition `SUBQ.b = ALPHA.b`. The generated code assumes that the row from `ALPHA` is cached in the `Activation` itself (from a previous scan of the outer table).

#### Spark execution model for sort merge join 
Sort merge join uses internally Spark's `cogroup` operation to execute the join in OLAP mode. If we have a correlated non-flattened sub-query in the join condition, then the operation will be running into steps:

1. `cogroup` left and right tables
2. apply `flatMap` using the `CogroupFullOuterJoinRestrictionFlatMapFunction` to qualify joined rows.

Note that `cogroup` is a shuffle-inducing operation, during which, new `Activation`(s) will be created for each task doing the cogrouping and writing into their `Activation`s the result of scanning both tables which is necessary for the next step.

In `CogroupFullOuterJoinRestrictionFlatMapFunction` each worker thread will attempt to qualify the joined rows, in case of correlated non-flattened subquery, the thread will execute the sub-query, while doing so, it will qualify the rows it scanned with the outer table's current row (the correlation).

This is where the logic fails, because at step 1, due to the `cogroup` operation (and its shuffling), the worker threads have written their data into a different `Activation` instance, so in the next step, when the subquery is evaluated the worker thread will not find the outer table rows in its `Activation` causing an NPE.

### 2. The fix

Since the sort merge join relies on Spark's internal `cogroup` function to perform the actual join (in OLAP), I limited the scope of sort merge join applicability for that particular case of having correlated non-flattened subquery in join condition. To do this, I collect all the join condition predicates (pushable and non-pushable, see [1]) and check if any of these predicates has a correlated subquery, if so, we mark the sort merge join strategy as infeasible making the optimizer skip over it.

[1] I noticed that in when costing a join we don't include any non-pushable join predicate in the costing process, this seems like a bug since it might lead to underestimation of the join's true cost and it needs further investigation.

## How to test

Here is an example:

```sql
MAXIMUMDISPLAYWIDTH 0;
drop table t1 if exists;
drop table t2 if exists;

create table t1 (a int, b int);
create table t2 (a int, b int, primary key(a));
 
insert into t1 values (155,540);
insert into t2 select a, b from t1;

analyze table t1;
analyze table t2;

-- previously we got NPE when executing this statement:
SELECT * FROM t1 ALPHA LEFT OUTER JOIN 
t2 BETA --splice-properties useSpark=True, joinStrategy=sortmerge
ON ALPHA.b=BETA.b AND BETA.a = (SELECT MAX(A) FROM t2 SUBQ WHERE SUBQ.b=ALPHA.b) ;

-- with this fix, we prevent the optimizer from choosing the sort merge join strategy for this type of query:
SELECT * FROM t1 ALPHA LEFT OUTER JOIN 
t2 BETA --splice-properties useSpark=True, joinStrategy=sortmerge
ON ALPHA.b=BETA.b AND BETA.a = (SELECT MAX(A) FROM t2 SUBQ WHERE SUBQ.b=ALPHA.b) ;
ERROR 42Y69: No valid execution plan was found for this statement. This is usually because an infeasible join strategy was chosen, or because an index was chosen which prevents the chosen join strategy from being used.
```
