### PR TITLE
DB-10980 Wait for real exception when an OLAP job fails

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/RemoteQueryClientImpl.java
@@ -16,6 +16,7 @@ package com.splicemachine.stream;
 
 import com.splicemachine.db.iapi.reference.GlobalDBProperties;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import splice.com.google.common.net.HostAndPort;
 import com.splicemachine.EngineDriver;
 import com.splicemachine.access.HConfiguration;
@@ -278,6 +279,7 @@ public class RemoteQueryClientImpl implements RemoteQueryClient {
             olapFuture.cancel(false);
     }
 
+    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED", justification = "intended")
     public Exception getException() throws InterruptedException {
         olapFutureCallbackInvoked.await(5, TimeUnit.SECONDS);
         return (Exception) streamListener.getFailure();

--- a/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
+++ b/hbase_sql/src/main/java/com/splicemachine/stream/StreamListener.java
@@ -399,6 +399,10 @@ public class StreamListener<T> extends ChannelInboundHandlerAdapter implements I
             }
         }
     }
+
+    public Throwable getFailure() {
+        return failure;
+    }
 }
 
 class PartitionState {

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -114,7 +114,7 @@ public class ControlOnlyDataSetProcessorFactory implements DataSetProcessorFacto
 
             @Override
             public Exception getException() throws InterruptedException {
-                // no-op
+                return null;
             }
         };
     }

--- a/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
+++ b/mem_sql/src/main/java/com/splicemachine/derby/impl/sql/ControlOnlyDataSetProcessorFactory.java
@@ -111,6 +111,11 @@ public class ControlOnlyDataSetProcessorFactory implements DataSetProcessorFacto
             public void close() throws Exception {
                 // no-op
             }
+
+            @Override
+            public Exception getException() throws InterruptedException {
+                // no-op
+            }
         };
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -657,6 +657,17 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
                 SpliceLogUtils.trace(LOG, "getNextRowCore %s locatedRow=%s", this, locatedRow);
             return null;
         } catch(Exception e){
+            if (remoteQueryClient != null) {  // OLAP execution
+                try {
+                    Exception re = remoteQueryClient.getException();
+                    if (re != null) {
+                        e = re;
+                    }
+                } catch (InterruptedException interruptedException) {
+                    // do nothing, throw e
+                }
+            }
+
             checkInterruptedException(e);
             StandardException se = Exceptions.parseException(e);
             if (se instanceof ResubmitDistributedException) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/RemoteQueryClient.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/stream/iapi/RemoteQueryClient.java
@@ -18,9 +18,6 @@ import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 
 import java.util.Iterator;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Created by dgomezferro on 5/20/16.
@@ -32,4 +29,6 @@ public interface RemoteQueryClient extends AutoCloseable {
 
     /** Close this client forcefully, terminating any currently running query */
     void interrupt();
+
+    Exception getException() throws InterruptedException;
 }


### PR DESCRIPTION
## Short Description
This change fixes an exception propagation issue that causes test `ProjectRestrictSparkExpressionIT.testBugs` to be sporadic.

## Long Description

### Problem description
Submitting a job to OLAP is asynchronous in our system. On the very top level, this is done in `stmt.execute()` call in `DRDAConnThread.java`, around line 947. When submitting an OLAP job, we also register an handler in case the job's status is changed. This happens at `RemoteQueryClientImpl.java`, around line 132.

After submitting the OLAP job, execution in DRDA thread continues. Eventually, it blocks inside `writeQRYDTA(stmt)` (`DRDAConnThread.java`, around line 986). At this point, we need to block and wait because we are about to read the result set through the iterator. This happens at `getNextRowCore()` in `SpliceBaseOperation.java`.

When we are blocking at `execRowIterator.hasNext()`, the OLAP job could be 1) still running; 2) failed; or 3) finished. Cases 1 and 3 are not interesting in the context of DB-10980.

In case the OLAP job has failed, real exception need to be propagated from Spark to the DRDA thread. This is done through the handler we registered when submitting the job. Eventually, the exception should be stored in `failure` field of `streamListener`, a member inside `remoteQueryClientImpl`.

`execRowIterator.hasNext()` internally checks the `failure` field. If it's set, then it throws the exception directly.

Now comes the problem. Since the OLAP job has failed, the OLAP server could send a "Connection reset by peer" exception directly to the remote query client. There is a race. Whichever exception comes first is reported by client. The other is lost. However, "connection reset by peer" is too general to be useful for understanding what's going wrong. In this case, we need the actual exception thrown from Spark side.

### Solution
When an exception thrown from `execRowIterator.hasNext()` is caught and being processed, we wait until the OLAP job handler is called with a timeout (currently 5 seconds). Once we know that the OLAP job handler is already called, we replace the current caught exception with the one propagated from Spark. In case there is no exception from Spark or the wait has timed out, we continue use the current exception.

### Further question
The OLAP job handler calls `olapFuture.get()` and then sets `streamListener.completed(olapResult)`. In debugging this problem, we see that this handler can be called way later than `execRowIterator.hasNext()` has returned (and the client received something, thus also returned from this query) no matter if the job was a failure or success. In case the job failed, we have the problem described above. If the job succeeded, by the time this handler is invoked, the client has already showed the result to user and possibly already accepted another query. Between this handler and `writeQRYDTA(stmt)`, there is no synchronization at all.

## How to test
- Setup:
  ```
  create table ts_double (a double, b double, c int);
  insert into ts_double values (1.79769E+308, 1.49769E+308, 1);
  ```
- Query:
  ```
  -- query 1
  select nullif(a+a, b+b) from ts_double --splice-properties useSpark=true
  ;
  -- query 2
  select case when a is not null and a > 1 then a else a+a end from ts_double --splice-properties useSpark=true
  ;
  ```
- Before this fix, query 1 should give one of the following exceptions sporadically:
  - ERROR XJ001: Java exception: 'Connection reset by peer: java.io.IOException'.
  - ERROR 22003: The resulting value is outside the range for the data type DOUBLE.
  Query 2 should be always successful and finishes in a short amount of time.
- After this fix, query 1 should return the following exception deterministically:
  - ERROR 22003: The resulting value is outside the range for the data type DOUBLE.
  Query 2 should still be successful and finishes in a short amount of time. It should never get stuck.