### PR TITLE
DB-12108 Back out the increase of default value of splice.controlExecution.rowsLimit

### DIFF
--- a/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/configuration/SQLConfiguration.java
@@ -223,7 +223,7 @@ public class SQLConfiguration implements ConfigurationDefault {
     private static final int DEFAULT_NESTEDLOOPJOIN_BATCH_SIZE = 25;
 
     public static final String CONTROL_EXECUTION_ROWS_LIMIT = "splice.controlExecution.rowsLimit";
-    private static final int DEFAULT_CONTROL_EXECUTION_ROWS_LIMIT = 10000000;
+    private static final int DEFAULT_CONTROL_EXECUTION_ROWS_LIMIT = 1000000;
 
     public static final String MAX_CHECK_TABLE_ERRORS="splice.max.checktable.error";
     private static final int DEFAULT_MAX_CHECK_TABLE_ERRORS = 1000;

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
@@ -967,7 +967,7 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
         }
     }
 
-    // Cause trigger rows to go over 10000000, causing a
+    // Cause trigger rows to go over 1000000, causing a
     // rollback and switch to spark execution.
     @Test
     public void testNestedTriggersSwitchToSpark() throws Exception {
@@ -1014,10 +1014,7 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
             s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");
             s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");
             s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");
-            s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");  // 327680 rows
             s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");
-            s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");
-            s.execute("insert into t1 select * from t1 --splice-properties useSpark=true\n");  // 2621440 rows
 
 
             s.execute("CREATE TRIGGER mytrig\n" +
@@ -1051,9 +1048,9 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
             s.execute("insert into t2 select * from t1");
 
             String query = "select count(*) from t2";
-            String expected = "1    |\n" +
-                              "---------\n" +
-                              "2621440 |";
+            String expected = "1   |\n" +
+                              "--------\n" +
+                              "327680 |";
             testQuery(query, expected, s);
 
             query = "select count(*) from t3";
@@ -1061,8 +1058,8 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
 
             query = "select count(*) from t4";
             expected = "1    |\n" +
-                       "----------\n" +
-                       "15728640 |";
+            "---------\n" +
+            "1966080 |";
             testQuery(query, expected, s);
 
             query = "select count(*) from t5";


### PR DESCRIPTION
Back out part of DB-11580 which may be causing IT failures on Jenkins colo servers.