### PR TITLE
DB-12111 Flush dropped tables which can't be removed during VACUUM

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -195,9 +195,8 @@ public class Vacuum{
                             // Can't tell if the active transactions are using this table.
                             // Since we can't drop the conglomerate, let us at least flush
                             // it from memstore to free up memory.
-                            if (hasDroppedId)
-                                addNewFlushFuture(flushFutures, tableConglom,
-                                                  table.getTableName(), partitionFactory);
+                            addNewFlushFuture(flushFutures, tableConglom,
+                                              table.getTableName(), partitionFactory);
                             continue;
                         }
                     } else if (requiresDroppedId) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Vacuum.java
@@ -68,6 +68,23 @@ public class Vacuum{
         }
     }
 
+    private void addNewFlushFuture(List<Future> flushFutures,
+                                   long tableConglom,
+                                   String tableName,
+                                   PartitionFactory partitionFactory) {
+        flushFutures.add(SIDriver.driver().getExecutorService().submit(new Runnable() {
+            @Override
+            public void run() {
+                LOG.info("Flushing possibly-active dropped table: " + tableName);
+                try(Partition partition=partitionFactory.getTable(Long.toString(tableConglom))){
+                    partition.flush();
+                }catch(IOException e){
+                    LOG.error("Vacuum Unexpected exception", e);
+                }
+            }
+        }));
+    }
+
     public void vacuumDatabase(long oldestActiveTransaction) throws SQLException{
         //get all the conglomerates from sys.sysconglomerates
         LongHashSet activeConglomerates = new LongHashSet();
@@ -85,6 +102,7 @@ public class Vacuum{
         Set<Long> allTableConglomerates = new HashSet<>();
         Queue<Long> toDelete = new ConcurrentLinkedQueue<>();
         SIDriver driver = SIDriver.driver();
+        PartitionFactory partitionFactory = driver.getTableFactory();
         try (Partition dropped = driver.getTableFactory().getTable(HBaseConfiguration.DROPPED_CONGLOMERATES_TABLE_NAME)) {
             try (DataScanner scanner = dropped.openScanner(driver.baseOperationFactory().newScan())) {
                 while (true) {
@@ -107,6 +125,7 @@ public class Vacuum{
                 LOG.trace("Found " + Iterables.size(hTableDescriptors) + " HBase tables.");
             }
             List<Future> deletionFutures = new ArrayList<>();
+            List<Future> flushFutures = new ArrayList<>();
 
             for(TableDescriptor table:hTableDescriptors){
                 boolean restoreMode = SIDriver.driver().lifecycleManager().isRestoreMode();
@@ -130,6 +149,7 @@ public class Vacuum{
                     allTableConglomerates.add(tableConglom);
                     boolean requiresDroppedId = false;
                     boolean ignoreDroppedId = false;
+                    boolean hasDroppedId = table.getDroppedTransactionId() != null || droppedConglomerates.containsKey(tableConglom);
                     if (table.getTransactionId() != null) {
                         TxnView txn = SIDriver.driver().getTxnSupplier().getTransaction(Long.parseLong(table.getTransactionId()));
                         if (txn.getEffectiveBeginTimestamp() >= oldestActiveTransaction) {
@@ -139,6 +159,12 @@ public class Vacuum{
                             if (LOG.isInfoEnabled()) {
                                 LOG.info("Ignoring recently created table: " + table.getTableName() + " by transaction " + txn.getTxnId());
                             }
+                            // Can't tell if the active transactions are using this table.
+                            // Since we can't drop the conglomerate, let us at least flush
+                            // it from memstore to free up memory.
+                            if (hasDroppedId)
+                                addNewFlushFuture(flushFutures, tableConglom,
+                                                  table.getTableName(), partitionFactory);
                             continue;
                         }
                         IgnoreTxnSupplier ignoreTxn = SIDriver.driver().getIgnoreTxnSupplier();
@@ -150,7 +176,6 @@ public class Vacuum{
                             requiresDroppedId = true;
                         }
                     }
-                    boolean hasDroppedId = table.getDroppedTransactionId() != null || droppedConglomerates.containsKey(tableConglom);
                     if (!ignoreDroppedId && hasDroppedId) {
                         long txnId;
                         // The first case deals with conglomerates dropped before DB-7501 got merged
@@ -167,6 +192,12 @@ public class Vacuum{
                             if (LOG.isInfoEnabled()) {
                                 LOG.info("Ignoring recently dropped table: " + table.getTableName() + " by transaction " + txn.getTxnId());
                             }
+                            // Can't tell if the active transactions are using this table.
+                            // Since we can't drop the conglomerate, let us at least flush
+                            // it from memstore to free up memory.
+                            if (hasDroppedId)
+                                addNewFlushFuture(flushFutures, tableConglom,
+                                                  table.getTableName(), partitionFactory);
                             continue;
                         }
                     } else if (requiresDroppedId) {
@@ -203,6 +234,10 @@ public class Vacuum{
             }
 
             for (Future f : deletionFutures) {
+                f.get();
+            }
+
+            for (Future f : flushFutures) {
                 f.get();
             }
 


### PR DESCRIPTION
## Short Description
Flush dropped tables which can't be removed during VACUUM.

## Long Description
Currently, any old client connections which have an active transaction can prevent table conglomerates from getting removed upon VACUUM because dropped tables must be older than the oldest active transaction.  This issue can also occur due to connections which are left open in ITs.  The long-term solution would be to implement a more robust method of identifying tables which can't be dropped, for example by associating each active transaction with tables which it may write to.  
For now, this PR does an HBase flush of any dropped tables which can't be removed during VACUUM, so the memory used up by those tables in memstore can be recovered.

## How to test
Run the full suite of ITs and track memory of the main master+regionserver task with a profiler.  It should stay at a reasonable level (for example, less than 800 MB, and after GC less than 500 MB).
