### PR TITLE
DB-12085 Fix isQualifier() for index conglomerates

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -426,7 +426,7 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
 
 	/** @see IndexDescriptor#baseColumnPositions */
 	public int[] baseColumnPositions() {
-		return id.baseColumnPositions();
+		return id == null ? null : id.baseColumnPositions();
 	}
 
 	/** @see IndexDescriptor#getKeyColumnPosition */

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -884,7 +884,8 @@ public class BinaryRelationalOperatorNode
     }
 
     @Override
-    public boolean isQualifier(Optimizable optTable,boolean forPush) throws StandardException{
+    public boolean isQualifier(Optimizable optTable, ConglomerateDescriptor cd, boolean forPush)
+            throws StandardException {
         /* If this rel op is for an IN-list probe predicate then we never
          * treat it as a qualifer.  The reason is that if we treat it as
          * a qualifier then we could end up generating it as a qualifier,
@@ -897,10 +898,10 @@ public class BinaryRelationalOperatorNode
             return false;
 
         FromTable ft;
-        ValueNode otherSide=null;
-        ColumnReference cr;
-        boolean found=false;
-        boolean walkSubtree=true;
+        ValueNode otherSide = null;
+        ColumnReference cr = null;
+        boolean found = false;
+        boolean walkSubtree = true;
 
         ft=(FromTable)optTable;
 
@@ -943,7 +944,15 @@ public class BinaryRelationalOperatorNode
         ** Qualifier if the other side does not refer to the table we are
         ** optimizing.
         */
-        return !valNodeReferencesOptTable(otherSide,ft,forPush,true);
+        if (valNodeReferencesOptTable(otherSide, ft, forPush, true)) {
+            return false;
+        }
+
+        if (forPush && cd != null && cd.isIndex()) {
+            return isIndexColumn(cr, cd);
+        }
+
+        return true;
     }
 
     public boolean isQualifierForHashableJoin(Optimizable optTable,boolean forPush) throws StandardException{

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorNode.java
@@ -45,6 +45,8 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.store.access.Qualifier;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.SqlXmlUtil;
@@ -513,5 +515,18 @@ public abstract class OperatorNode extends ValueNode
         this.operands = new ArrayList<>(other.operands);
         this.interfaceTypes = new ArrayList<>(other.interfaceTypes);
         this.resultInterfaceType = other.resultInterfaceType;
+    }
+
+    protected boolean isIndexColumn(ColumnReference cr, ConglomerateDescriptor cd) {
+        IndexRowGenerator irg = cd == null ? null : cd.getIndexDescriptor();
+        if (irg != null && !irg.isOnExpression() && irg.baseColumnPositions() != null) {
+            for (int pos : irg.baseColumnPositions()) {
+                if (cr.getColumnNumber() == pos) {
+                    return true;
+                }
+            }
+        }
+        // index on expression case is handled in PredicateList.isQualifier()
+        return false;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Predicate.java
@@ -604,7 +604,7 @@ public final class Predicate extends QueryTreeNode implements OptimizablePredica
                             return false;
                         }
                     } else {
-                        if(!((RelationalOperator)or_node.getLeftOperand()).isQualifier(optTable, pushPreds)){
+                        if(!((RelationalOperator)or_node.getLeftOperand()).isQualifier(optTable, cd, pushPreds)){
                             // one of the terms is not a pushable Qualifier.
                             return false;
                         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -594,7 +594,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                 Integer position = isIndexUseful(pred, optTable, pushPreds, skipProbePreds, cd);
                 return position != null;
             } else {
-                return pred.getRelop().isQualifier(optTable, pushPreds);
+                return pred.getRelop().isQualifier(optTable, cd, pushPreds);
             }
         }
         return true;
@@ -668,7 +668,7 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
          * operator or b) it's not a qualifier, then it's not useful for
          * limiting the scan, so skip it.
          */
-        if(!isIn && !isBetween && ((relop==null) || (!isIndexOnExpr && !relop.isQualifier(optTable,pushPreds)))){
+        if(!isIn && !isBetween && ((relop==null) || (!isIndexOnExpr && !relop.isQualifier(optTable, cd, pushPreds)))){
             return null;
         }
 
@@ -1799,14 +1799,14 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
      * @param otherPL  ParameterList for non-qualifiers
      * @throws StandardException Thrown on error
      */
-    protected void transferNonQualifiers(Optimizable optTable,PredicateList otherPL) throws StandardException{
+    protected void transferNonQualifiers(Optimizable optTable, PredicateList otherPL) throws StandardException{
         //Walk list backwards since we can delete while traversing the list.
         for(int index=size()-1;index>=0;index--){
             Predicate pred=elementAt(index);
 
             // Transfer each non-qualifier
             //noinspection ConstantConditions
-            if(!pred.isRelationalOpPredicate() || !pred.getRelop().isQualifier(optTable,false)){
+            if(!pred.isRelationalOpPredicate() || !pred.getRelop().isQualifier(optTable, null, false)){
                 pred.clearScanFlags();
                 removeElementAt(index);
                 otherPL.addElement(pred);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/RelationalOperator.java
@@ -35,6 +35,7 @@ import com.splicemachine.db.catalog.IndexDescriptor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 
@@ -330,15 +331,18 @@ public interface RelationalOperator
 	 * down that subtree.  See BinaryRelationalOperatorNode for an
 	 * example of where this comes into play.
 	 *
-	 * @param optTable	The Optimizable table in question.
-	 * @param forPush	Are we asking because we're trying to push?
+	 * @param optTable  The Optimizable table in question.
+	 * @param cd        The conglomerate descriptor of optTable currently
+	 *                  in consideration. It's only used in case of
+	 *                  forPush == true.
+	 * @param forPush   Are we asking because we're trying to push?
 	 *
 	 * @return	true if this operator can be compiled into a Qualifier
 	 *			for the given Optimizable table.
 	 *
 	 * @exception StandardException		Thrown on error
 	 */
-	boolean isQualifier(Optimizable optTable, boolean forPush)
+	boolean isQualifier(Optimizable optTable, ConglomerateDescriptor cd, boolean forPush)
 		throws StandardException;
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryComparisonOperatorNode.java
@@ -36,6 +36,7 @@ import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.Optimizable;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.store.access.ScanController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
@@ -379,7 +380,7 @@ public abstract class UnaryComparisonOperatorNode extends UnaryOperatorNode impl
     public boolean orderedNulls() { return true; }
 
     @Override
-    public boolean isQualifier(Optimizable optTable, boolean forPush) {
+    public boolean isQualifier(Optimizable optTable, ConglomerateDescriptor cd, boolean forPush) {
         /*
         ** It's a Qualifier if the operand is a ColumnReference referring
         ** to a column in the given Optimizable table.
@@ -390,7 +391,15 @@ public abstract class UnaryComparisonOperatorNode extends UnaryOperatorNode impl
         ColumnReference cr = (ColumnReference) getOperand();
         FromTable ft = (FromTable) optTable;
 
-        return cr.getTableNumber()==ft.getTableNumber();
+        if (cr.getTableNumber() != ft.getTableNumber()) {
+            return false;
+        }
+
+        if (forPush && cd != null && cd.isIndex()) {
+            return isIndexColumn(cr, cd);
+        }
+
+        return true;
     }
 
     @Override

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/HashableJoinIT.java
@@ -76,6 +76,15 @@ public class HashableJoinIT extends SpliceUnitTest {
                 .withCreate("create table L (c2 int not null, e char(1) not null, foreign key (c2) references G(c2))")
                 .create();
 
+        new TableCreator(conn)
+                .withCreate("create table TA (c1 char(36))")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table TB (c2 char(36), s char(1), z char(1), hsp char(2), f char(1), pfnr char(10))")
+                .withIndex("create index XPFHSPF on TB (hsp, f, s, z, c2)")
+                .create();
+
         conn.commit();
     }
 
@@ -94,6 +103,29 @@ public class HashableJoinIT extends SpliceUnitTest {
                 "                    and L.e = 'X'))", useSpark);
 
         rowContainsQuery(new int[]{4, 6}, "explain " + sqlText, methodWatcher, "Subquery", useSpark ? "BroadcastJoin" : "NestedLoopJoin");
+
+        try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
+            assertFalse(rs.next());
+        }
+    }
+
+    // DB-12085
+    @Test
+    public void testInvalidOrListQualifierForHashableJoin() throws Exception {
+        String sqlText = String.format("select * from --splice-properties joinOrder=fixed\n" +
+                                               " TA, TB --splice-properties index=XPFHSPF, joinStrategy=sortmerge\n" +
+                                               " where TA.c1 = TB.c2" +
+                                               "   AND TB.s = '3' AND TB.z <> 'S' AND TB.hsp = 'LE'" +
+                                               "   AND NOT (TB.f = 'L' AND TB.pfnr = '12345678  ')");
+
+        // NOT (TB.f = 'L' AND TB.pfnr = '12345678  ') is transformed to
+        // (TB.f <> 'L' OR TB.pfnr <> '12345678  ')
+        // Before DB-12085, isQualifier() returns true for TB.pfnr <> '12345678  '. This is wrong because index
+        // columns of XPFHSPF do not contain pfnr.
+
+        rowContainsQuery(new int[]{4, 6}, "explain " + sqlText, methodWatcher,
+                         new String[]{"ProjectRestrict", "preds=[((TB.F[3:5] <> L) or ((TB.PFNR[3:6] <> 12345678  ) or false))]"},
+                         new String[]{"IndexScan[XPFHSPF", "keys=[(TB.HSP[3:4] = LE)],preds=[(TA.C1[5:1] = TB.C2[5:2]),(TB.S[3:2] = 3),(TB.Z[3:3] <> S)]"});
 
         try (ResultSet rs = methodWatcher.executeQuery(sqlText)) {
             assertFalse(rs.next());


### PR DESCRIPTION
## Short Description
This change prevents predicates that cannot be used to limit a table scan from being pushed down to base table wrongly and used a scan qualifier.

## Long Description
Before this fix, `isQualifier()` (`RelationalOperator` interface method) implementations simply checks if the column reference operand of this relational operator refers to a column of `optTable`. Depending on the type of relational operator, there might be other checks. But this is a necessary part of all implementations.

However, this check is not sufficient in case we want to push this predicate down to scan. For an index conglomerate, the column reference must refer to one of the index columns, too. This check is currently missing.

Note that `isQualifier()` is used in two cases, which have slightly different semantics:
1. check if a predicate can be used as a hash key
2. check if a predicate can be used as a scan qualifier

In case 1, the conglomerate columns check is not needed because we assume a predicate is on the level of a join. Down to the subtree, it can be an index scan + index lookup. But eventually, we have access to all columns referenced by predicates. Point is, we are not going to push the predicate down.

In case 2, we care about if it's possible to actually push this predicate down to the scan. In this case, the conglomerate columns check is necessary.

The two cases above are distinguished by the `forPush` argument.

One may wonder in case 2, how simple queries would even work without this check because it's very fundamental. Answer is, in `orderUsefulPredicates()`, `isQualifier()` is mostly called under a guard that the current conglomerate is the table conglomerate. If it's an index conglomerate, the code path calls `isIndexUseful()`.

But there is a missing piece. In case of a disjunction of predicates, e.g., `col1 = 2 or col2= 3`, we call `Predicate.isPushableOrClause()`, which in turns calls `isQualifier()` on each term of the disjunction without considering the current conglomerate. Consequently, the whole or-list can be pushed down to an index scan as a qualifier. However, some columns used in the predicate are not accessible during the scan, causing an ArrayIndexOutOfBound exception at run time.

The fix is to add conglomerate columns check for case 2 for index conglomerates. 

## How to test
Setup:
```
create table TA (c1 char(36));
create table TB (c2 char(36), s char(1), z char(1), hsp char(2), f char(1), pfnr char(10));
create index XPFHSPF on TB (hsp, f, s, z, c2);
```

Test query:
```
select * from --splice-properties joinOrder=fixed
 TA, TB --splice-properties index=XPFHSPF, joinStrategy=sortmerge
 where TA.c1 = TB.c2
   AND TB.s = '3' AND TB.z <> 'S' AND TB.hsp = 'LE'
   AND NOT (TB.f = 'L' AND TB.pfnr = '12345678  ')
```

Before this fix, running the test query would throw `ArrayIndexOutOfBound` exception. Note that explain this query returns a plan without any error. However, this plan is wrong because it takes `TB.f <> 'L' OR TB.pfnr <> '12345678  '` as a qualifier of index scan on `XPFHSPF`.

After this fix, the query runs correctly. Also, the explained plan should put `TB.f <> 'L' OR TB.pfnr <> '12345678  '` at the `ProjectRestrict` step on top of `IndexLookup`.