### PR TITLE
DB-12106 Fix NPE in MaxMinAggregator 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/AvgAggregator.java
@@ -58,284 +58,284 @@ import java.io.ObjectOutput;
  */
 public final class AvgAggregator extends OrderableAggregator
 {
-	private SumAggregator aggregator;
-	private long count;
-	private int scale;
+    private SumAggregator aggregator;
+    private long count;
+    private int scale;
 
-	public Class getAggregatorClass() { return aggregator.getClass();}
+    public Class getAggregatorClass() { return aggregator.getClass();}
 
-	public boolean usesLongBufferedSumAggregator() {
-		return aggregator != null && aggregator instanceof LongBufferedSumAggregator;
-	}
-	public void upgradeSumAggregator() throws StandardException {
-		if (usesLongBufferedSumAggregator()) {
-			LongBufferedSumAggregator lbsa = (LongBufferedSumAggregator) aggregator;
-			aggregator = lbsa.upgrade();
-		}
-	}
+    public boolean usesLongBufferedSumAggregator() {
+        return aggregator != null && aggregator instanceof LongBufferedSumAggregator;
+    }
+    public void upgradeSumAggregator() throws StandardException {
+        if (usesLongBufferedSumAggregator()) {
+            LongBufferedSumAggregator lbsa = (LongBufferedSumAggregator) aggregator;
+            aggregator = lbsa.upgrade();
+        }
+    }
 
-	@Override
-	public ExecAggregator setup(ClassFactory cf, String aggregateName, DataTypeDescriptor returnDataType) {
-		this.aggregator = SumAggregator.getBufferedAggregator(returnDataType);
-		if(aggregator==null)
-			aggregator = new SumAggregator();
-		switch(returnDataType.getTypeId().getTypeFormatId()){
-			case StoredFormatIds.TINYINT_TYPE_ID:
-			case StoredFormatIds.SMALLINT_TYPE_ID:
-			case StoredFormatIds.INT_TYPE_ID:
-			case StoredFormatIds.LONGINT_TYPE_ID:
-				scale = 0;
-				break;
-			case StoredFormatIds.REAL_TYPE_ID:
-			case StoredFormatIds.SQL_DOUBLE_ID:
-				scale = TypeId.DECIMAL_SCALE;
-				break;
-			default:
-				// Honor the scale of the return data type picked by the
-				// parser.  In the past, this was overridden, which may
-				// cause overflows.  For averaging DEC(38,0), 38 digits
-				// of precision is enough.  We don't want to tell the user
-				// we can't calculate the average because we require 42
-				// digits of precision in this case.
-				scale = returnDataType.getScale();
-		}
-		return this;
-	}
+    @Override
+    public ExecAggregator setup(ClassFactory cf, String aggregateName, DataTypeDescriptor returnDataType) {
+        this.aggregator = SumAggregator.getBufferedAggregator(returnDataType);
+        if(aggregator==null)
+            aggregator = new SumAggregator();
+        switch(returnDataType.getTypeId().getTypeFormatId()){
+            case StoredFormatIds.TINYINT_TYPE_ID:
+            case StoredFormatIds.SMALLINT_TYPE_ID:
+            case StoredFormatIds.INT_TYPE_ID:
+            case StoredFormatIds.LONGINT_TYPE_ID:
+                scale = 0;
+                break;
+            case StoredFormatIds.REAL_TYPE_ID:
+            case StoredFormatIds.SQL_DOUBLE_ID:
+                scale = TypeId.DECIMAL_SCALE;
+                break;
+            default:
+                // Honor the scale of the return data type picked by the
+                // parser.  In the past, this was overridden, which may
+                // cause overflows.  For averaging DEC(38,0), 38 digits
+                // of precision is enough.  We don't want to tell the user
+                // we can't calculate the average because we require 42
+                // digits of precision in this case.
+                scale = returnDataType.getScale();
+        }
+        return this;
+    }
 
-	protected void accumulate(DataValueDescriptor addend)
-			throws StandardException
-	{
+    protected void accumulate(DataValueDescriptor addend)
+            throws StandardException
+    {
 
-//				if (count == 0) {
-//						String typeName = addend.getTypeName();
-//						if (   typeName.equals(TypeId.TINYINT_NAME)
-//										|| typeName.equals(TypeId.SMALLINT_NAME)
-//										|| typeName.equals(TypeId.INTEGER_NAME)
-//										|| typeName.equals(TypeId.LONGINT_NAME)) {
-//								scale = 0;
-//						} else if (   typeName.equals(TypeId.REAL_NAME)
-//										|| typeName.equals(TypeId.DOUBLE_NAME)) {
-//								scale = TypeId.DECIMAL_SCALE;
-//						} else {
-//								// DECIMAL
-//								scale = ((NumberDataValue) addend).getDecimalValueScale();
-//								if (scale < NumberDataValue.MIN_DECIMAL_DIVIDE_SCALE)
-//										scale = NumberDataValue.MIN_DECIMAL_DIVIDE_SCALE;
-//						}
-//				}
+//                if (count == 0) {
+//                        String typeName = addend.getTypeName();
+//                        if (   typeName.equals(TypeId.TINYINT_NAME)
+//                                        || typeName.equals(TypeId.SMALLINT_NAME)
+//                                        || typeName.equals(TypeId.INTEGER_NAME)
+//                                        || typeName.equals(TypeId.LONGINT_NAME)) {
+//                                scale = 0;
+//                        } else if (   typeName.equals(TypeId.REAL_NAME)
+//                                        || typeName.equals(TypeId.DOUBLE_NAME)) {
+//                                scale = TypeId.DECIMAL_SCALE;
+//                        } else {
+//                                // DECIMAL
+//                                scale = ((NumberDataValue) addend).getDecimalValueScale();
+//                                if (scale < NumberDataValue.MIN_DECIMAL_DIVIDE_SCALE)
+//                                        scale = NumberDataValue.MIN_DECIMAL_DIVIDE_SCALE;
+//                        }
+//                }
 
-		try {
+        try {
 
-			count++;
-			aggregator.accumulate(addend);
-			return;
+            count++;
+            aggregator.accumulate(addend);
+            return;
 
-		} catch (StandardException se) {
+        } catch (StandardException se) {
 
-			// DOUBLE has the largest range, so if it overflows, there is nothing
-			// with greater range to upgrade to.
-			if (!se.getMessageId().equals(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE) ||
-					(!(aggregator instanceof LongBufferedSumAggregator)))
-				throw se;
-		}
-
-
-		/*
-			Sum is out of range so promote
-
-			TINYINT,SMALLINT -->> INTEGER
-
-			INTEGER -->> BIGINT
-
-			REAL -->> DOUBLE PRECISION
-
-			others -->> DECIMAL
-		*/
-		/*
-		 * -sf- Note: When summing scalar values, we always return a long (as of v0.6 anyway). This means
-		 * that TINYINT,SMALLINT,INTEGER,and BIGINT are all already sharing a type, which means if we overflowed,
-		 * we overflowed a long. As a result, we have the following upgrade schedule:
-		 *
-		 * SCALAR(long) -> DOUBLE
-		 * REAL					->	DOUBLE
-		 * DOUBLE				->	DECIMAL
-		 *
-		 * Note also that we don't need to re-accumulate the passed in addend if we have a BufferedSumAggregator,
-		 * because the value of addend must be present in the buffer before an overflow failure can occur. This
-		 * means that we can just call "upgrade" to move the aggregator to the correct type, but otherwise we don't
-		 * have to do anything
-		 */
-		if(aggregator instanceof LongBufferedSumAggregator){
-			aggregator = ((LongBufferedSumAggregator)aggregator).upgrade();
-		}
-		else
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE);
-
-		aggregator.accumulate(addend);
-	}
-
-	public void merge(ExecAggregator addend)
-			throws StandardException
-	{
-		if(addend==null) return; //treat null entries as zero --they do not contribute to the average
-		AvgAggregator otherAvg = (AvgAggregator) addend;
-		this.aggregator.merge(otherAvg.aggregator);
-		this.count+= otherAvg.count;
-
-		// if I haven't been used take the other.
-//				if (count == 0) {
-//						count = otherAvg.count;
-//						value = otherAvg.value;
-//						scale = otherAvg.scale;
-//						return;
-//				}
-
-		// Don't bother merging if the other is a NULL value aggregate.
-		/* Note:Beetle:5346 fix change the sort to be High, that makes
-		 * the neccessary for the NULL check because after the change
-		 * addend could have a  NULL value even on distincts unlike when
-		 * NULLs were sort order  Low, because by  sorting NULLs Low
-		 * they  happens to be always first row which makes it as
-		 * aggreagte result object instead of addends.
-		 * Query that will fail without the following check:
-		 * select avg(a) , count(distinct a) from t1;
-		 */
-//				if(otherAvg.value != null)
-//				{
-//						// subtract one here as the accumulate will add one back in
-//						count += (otherAvg.count - 1);
-//						accumulate(otherAvg.value);
-//				}
-	}
-
-	public void add(DataValueDescriptor addend) throws StandardException{
-		accumulate(addend);
-	}
-
-	/**
-	 * Return the result of the aggregation.  If the count
-	 * is zero, then we haven't averaged anything yet, so
-	 * we return null.  Otherwise, return the running
-	 * average as a double.
-	 *
-	 * @return null or the average as Double
-	 */
-	public DataValueDescriptor getResult() throws StandardException
-	{
-		if (count == 0)
-		{
-			return null;
-		}
-
-		NumberDataValue sum = (NumberDataValue)aggregator.getResult();
-		NumberDataValue avg = (NumberDataValue) sum.getNewNull();
+            // DOUBLE has the largest range, so if it overflows, there is nothing
+            // with greater range to upgrade to.
+            if (!se.getMessageId().equals(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE) ||
+                    (!(aggregator instanceof LongBufferedSumAggregator)))
+                throw se;
+        }
 
 
-		if (count > (long) Integer.MAX_VALUE)
-		{
-			// TINYINT, SMALLINT, INTEGER implement arithmetic using integers
-			// If the sum is still represented as a TINYINT, SMALLINT or INTEGER
-			// we cannot let their int based arithmetic handle it, since they
-			// will perform a getInt() on the long value which will truncate the long value.
-			// One solution would be to promote the sum to a SQLLongint, but its value
-			// will be less than or equal to Integer.MAX_VALUE, so the average will be 0.
-			String typeName = sum.getTypeName();
+        /*
+            Sum is out of range so promote
 
-			if (typeName.equals(TypeId.INTEGER_NAME) ||
-					typeName.equals(TypeId.TINYINT_NAME) ||
-					typeName.equals(TypeId.SMALLINT_NAME))
-			{
-				avg.setValue(0);
-				return avg;
-			}
-		}
+            TINYINT,SMALLINT -->> INTEGER
 
-		NumberDataValue countv = new com.splicemachine.db.iapi.types.SQLLongint(count);
-		sum.divide(sum, countv, avg, scale);
+            INTEGER -->> BIGINT
 
-		return avg;
-	}
+            REAL -->> DOUBLE PRECISION
 
-	@Override
-	public ExecAggregator newAggregator()
-	{
-		AvgAggregator avgAggregator = new AvgAggregator();
-		avgAggregator.aggregator = (SumAggregator)this.aggregator.newAggregator();
-		avgAggregator.scale = this.scale;
-		return avgAggregator;
-	}
+            others -->> DECIMAL
+        */
+        /*
+         * -sf- Note: When summing scalar values, we always return a long (as of v0.6 anyway). This means
+         * that TINYINT,SMALLINT,INTEGER,and BIGINT are all already sharing a type, which means if we overflowed,
+         * we overflowed a long. As a result, we have the following upgrade schedule:
+         *
+         * SCALAR(long) -> DOUBLE
+         * REAL                    ->    DOUBLE
+         * DOUBLE                ->    DECIMAL
+         *
+         * Note also that we don't need to re-accumulate the passed in addend if we have a BufferedSumAggregator,
+         * because the value of addend must be present in the buffer before an overflow failure can occur. This
+         * means that we can just call "upgrade" to move the aggregator to the correct type, but otherwise we don't
+         * have to do anything
+         */
+        if(aggregator instanceof LongBufferedSumAggregator){
+            aggregator = ((LongBufferedSumAggregator)aggregator).upgrade();
+        }
+        else
+            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE);
 
-	/////////////////////////////////////////////////////////////
-	//
-	// EXTERNALIZABLE INTERFACE
-	//
-	/////////////////////////////////////////////////////////////
-	/**
-	 *
-	 * @exception IOException on error
-	 */
-	@Override
-	protected void writeExternalOld(ObjectOutput out) throws IOException {
-		out.writeObject(aggregator);
-		out.writeBoolean(eliminatedNulls);
-		out.writeLong(count);
-		out.writeInt(scale);
-	}
+        aggregator.accumulate(addend);
+    }
 
-	/**
-	 * @see java.io.Externalizable#readExternal
-	 *
-	 * @exception IOException on error
-	 */
-	@Override
-	protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
-		aggregator = (SumAggregator)in.readObject(); //TODO -sf- is this the most efficient? perhaps better to get the sum direct
-		eliminatedNulls = in.readBoolean();
-		count = in.readLong();
-		scale = in.readInt();
-	}
+    public void merge(ExecAggregator addend)
+            throws StandardException
+    {
+        if(addend==null) return; //treat null entries as zero --they do not contribute to the average
+        AvgAggregator otherAvg = (AvgAggregator) addend;
+        this.aggregator.merge(otherAvg.aggregator);
+        this.count+= otherAvg.count;
 
-	/**
-	 * Get the formatID which corresponds to this class.
-	 *
-	 *	@return	the formatID of this class
-	 */
-	public	int	getTypeFormatId()	{ return StoredFormatIds.AGG_AVG_V01_ID; }
-	public String toString()
-	{
-		try {
-			return "AvgAggregator: { sum=" + (value!= null?value.getString():"NULL") + ", count=" + count + "}";
-		}
-		catch (StandardException e)
-		{
-			return super.toString() + ":" + e.getMessage();
-		}
-	}
+        // if I haven't been used take the other.
+//                if (count == 0) {
+//                        count = otherAvg.count;
+//                        value = otherAvg.value;
+//                        scale = otherAvg.scale;
+//                        return;
+//                }
 
-	@Override
-	protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException{
-		CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
-		CatalogMessage.AvgAggregator avgAggregator = CatalogMessage.AvgAggregator.newBuilder()
-				.setSumAggregator(aggregator.toProtobufBuilder().build())
-				.setCount(count)
-				.setScale(scale)
-				.build();
+        // Don't bother merging if the other is a NULL value aggregate.
+        /* Note:Beetle:5346 fix change the sort to be High, that makes
+         * the neccessary for the NULL check because after the change
+         * addend could have a  NULL value even on distincts unlike when
+         * NULLs were sort order  Low, because by  sorting NULLs Low
+         * they  happens to be always first row which makes it as
+         * aggreagte result object instead of addends.
+         * Query that will fail without the following check:
+         * select avg(a) , count(distinct a) from t1;
+         */
+//                if(otherAvg.value != null)
+//                {
+//                        // subtract one here as the accumulate will add one back in
+//                        count += (otherAvg.count - 1);
+//                        accumulate(otherAvg.value);
+//                }
+    }
 
-		builder.setType(CatalogMessage.SystemAggregator.Type.AvgAggregator)
-				.setExtension(CatalogMessage.AvgAggregator.avgAggregator, avgAggregator);
+    public void add(DataValueDescriptor addend) throws StandardException{
+        accumulate(addend);
+    }
 
-		return builder;
-	}
+    /**
+     * Return the result of the aggregation.  If the count
+     * is zero, then we haven't averaged anything yet, so
+     * we return null.  Otherwise, return the running
+     * average as a double.
+     *
+     * @return null or the average as Double
+     */
+    public DataValueDescriptor getResult() throws StandardException
+    {
+        if (count == 0)
+        {
+            return null;
+        }
 
-	@Override
-	protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
-		super.init(systemAggregator);
-		CatalogMessage.AvgAggregator avgAggregator =
-				systemAggregator.getExtension(CatalogMessage.AvgAggregator.avgAggregator);
+        NumberDataValue sum = (NumberDataValue)aggregator.getResult();
+        NumberDataValue avg = (NumberDataValue) sum.getNewNull();
 
-		count = avgAggregator.getCount();
-		scale = avgAggregator.getScale();
-		CatalogMessage.SystemAggregator ag = avgAggregator.getSumAggregator();
-		aggregator = ProtobufUtils.toSumAggregator(ag);
-	}
+
+        if (count > (long) Integer.MAX_VALUE)
+        {
+            // TINYINT, SMALLINT, INTEGER implement arithmetic using integers
+            // If the sum is still represented as a TINYINT, SMALLINT or INTEGER
+            // we cannot let their int based arithmetic handle it, since they
+            // will perform a getInt() on the long value which will truncate the long value.
+            // One solution would be to promote the sum to a SQLLongint, but its value
+            // will be less than or equal to Integer.MAX_VALUE, so the average will be 0.
+            String typeName = sum.getTypeName();
+
+            if (typeName.equals(TypeId.INTEGER_NAME) ||
+                    typeName.equals(TypeId.TINYINT_NAME) ||
+                    typeName.equals(TypeId.SMALLINT_NAME))
+            {
+                avg.setValue(0);
+                return avg;
+            }
+        }
+
+        NumberDataValue countv = new com.splicemachine.db.iapi.types.SQLLongint(count);
+        sum.divide(sum, countv, avg, scale);
+
+        return avg;
+    }
+
+    @Override
+    public ExecAggregator newAggregator()
+    {
+        AvgAggregator avgAggregator = new AvgAggregator();
+        avgAggregator.aggregator = (SumAggregator)this.aggregator.newAggregator();
+        avgAggregator.scale = this.scale;
+        return avgAggregator;
+    }
+
+    /////////////////////////////////////////////////////////////
+    //
+    // EXTERNALIZABLE INTERFACE
+    //
+    /////////////////////////////////////////////////////////////
+    /**
+     *
+     * @exception IOException on error
+     */
+    @Override
+    protected void writeExternalOld(ObjectOutput out) throws IOException {
+        out.writeObject(aggregator);
+        out.writeBoolean(eliminatedNulls);
+        out.writeLong(count);
+        out.writeInt(scale);
+    }
+
+    /**
+     * @see java.io.Externalizable#readExternal
+     *
+     * @exception IOException on error
+     */
+    @Override
+    protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
+        aggregator = (SumAggregator)in.readObject(); //TODO -sf- is this the most efficient? perhaps better to get the sum direct
+        eliminatedNulls = in.readBoolean();
+        count = in.readLong();
+        scale = in.readInt();
+    }
+
+    /**
+     * Get the formatID which corresponds to this class.
+     *
+     *    @return    the formatID of this class
+     */
+    public    int    getTypeFormatId()    { return StoredFormatIds.AGG_AVG_V01_ID; }
+    public String toString()
+    {
+        try {
+            return "AvgAggregator: { sum=" + (value!= null?value.getString():"NULL") + ", count=" + count + "}";
+        }
+        catch (StandardException e)
+        {
+            return super.toString() + ":" + e.getMessage();
+        }
+    }
+
+    @Override
+    protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException{
+        CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
+        CatalogMessage.AvgAggregator avgAggregator = CatalogMessage.AvgAggregator.newBuilder()
+                .setSumAggregator(aggregator.toProtobufBuilder().build())
+                .setCount(count)
+                .setScale(scale)
+                .build();
+
+        builder.setType(CatalogMessage.SystemAggregator.Type.AvgAggregator)
+                .setExtension(CatalogMessage.AvgAggregator.avgAggregator, avgAggregator);
+
+        return builder;
+    }
+
+    @Override
+    protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
+        super.init(systemAggregator);
+        CatalogMessage.AvgAggregator avgAggregator =
+                systemAggregator.getExtension(CatalogMessage.AvgAggregator.avgAggregator);
+
+        count = avgAggregator.getCount();
+        scale = avgAggregator.getScale();
+        CatalogMessage.SystemAggregator ag = avgAggregator.getSumAggregator();
+        aggregator = ProtobufUtils.toSumAggregator(ag);
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CountAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/CountAggregator.java
@@ -50,150 +50,150 @@ import java.io.ObjectOutput;
  */
 public final class CountAggregator extends SystemAggregator
 {
-	private long value;
-	private boolean isCountStar;
+    private long value;
+    private boolean isCountStar;
 
-	/**
-	 */
-	public ExecAggregator setup( ClassFactory cf, String aggregateName, DataTypeDescriptor returnType )
-	{
-			isCountStar = aggregateName.equals("COUNT(*)");
-			return this;
-	}
+    /**
+     */
+    public ExecAggregator setup( ClassFactory cf, String aggregateName, DataTypeDescriptor returnType )
+    {
+            isCountStar = aggregateName.equals("COUNT(*)");
+            return this;
+    }
 
-	/**
-	 * @see ExecAggregator#merge
-	 *
-	 * @exception	StandardException	on error
-	 */
-	public void merge(ExecAggregator addend)
-		throws StandardException
-	{
-			if(addend==null)
-					return; //assume null is the same thing as zero
-		if (SanityManager.DEBUG)
-		{
-			SanityManager.ASSERT(addend instanceof CountAggregator,
-				"addend is supposed to be the same type of aggregator for the merge operator");
-		}
+    /**
+     * @see ExecAggregator#merge
+     *
+     * @exception    StandardException    on error
+     */
+    public void merge(ExecAggregator addend)
+        throws StandardException
+    {
+            if(addend==null)
+                    return; //assume null is the same thing as zero
+        if (SanityManager.DEBUG)
+        {
+            SanityManager.ASSERT(addend instanceof CountAggregator,
+                "addend is supposed to be the same type of aggregator for the merge operator");
+        }
 
-		value += ((CountAggregator)addend).value;
-	}
+        value += ((CountAggregator)addend).value;
+    }
 
-	public void add(DataValueDescriptor addend) throws StandardException{
-		value+=addend.getLong();
-	}
+    public void add(DataValueDescriptor addend) throws StandardException{
+        value+=addend.getLong();
+    }
 
-	/**
-	 * Return the result of the aggregation.  Just
-	 * spit out the running count.
-	 *
-	 * @return the value as a Long 
-	 */
-	public DataValueDescriptor getResult()
-	{
-		return new com.splicemachine.db.iapi.types.SQLLongint(value);
-	}
+    /**
+     * Return the result of the aggregation.  Just
+     * spit out the running count.
+     *
+     * @return the value as a Long
+     */
+    public DataValueDescriptor getResult()
+    {
+        return new com.splicemachine.db.iapi.types.SQLLongint(value);
+    }
 
 
-	/**
-	 * Accumulate for count().  Toss out all nulls in this kind of count.
-	 * Increment the count for count(*). Count even the null values.
-	 *
-	 * @param addend	value to be added in
-	 * @param ga		the generic aggregator that is calling me
-	 *
-	 * @see ExecAggregator#accumulate
-	 */
-	public void accumulate(DataValueDescriptor addend, Object ga)
-		throws StandardException
-	{
-		if (isCountStar)
-			value++;
-		else
-			super.accumulate(addend, ga);
-	}
+    /**
+     * Accumulate for count().  Toss out all nulls in this kind of count.
+     * Increment the count for count(*). Count even the null values.
+     *
+     * @param addend    value to be added in
+     * @param ga        the generic aggregator that is calling me
+     *
+     * @see ExecAggregator#accumulate
+     */
+    public void accumulate(DataValueDescriptor addend, Object ga)
+        throws StandardException
+    {
+        if (isCountStar)
+            value++;
+        else
+            super.accumulate(addend, ga);
+    }
 
-	protected final void accumulate(DataValueDescriptor addend) {
-			value++;
-	}
+    protected final void accumulate(DataValueDescriptor addend) {
+            value++;
+    }
 
-	/**
-	 * @return ExecAggregator the new aggregator
-	 */
-	public ExecAggregator newAggregator()
-	{
-		CountAggregator ca = new CountAggregator();
-		ca.isCountStar = isCountStar;
-		return ca;
-	}
+    /**
+     * @return ExecAggregator the new aggregator
+     */
+    public ExecAggregator newAggregator()
+    {
+        CountAggregator ca = new CountAggregator();
+        ca.isCountStar = isCountStar;
+        return ca;
+    }
 
-	public boolean isCountStar()
-	{
-		return isCountStar;
-	}
+    public boolean isCountStar()
+    {
+        return isCountStar;
+    }
 
-	/////////////////////////////////////////////////////////////
-	// 
-	// FORMATABLE INTERFACE
-	// 
-	/////////////////////////////////////////////////////////////
-	/**
-	 * Although we are not expected to be persistent per se,
-	 * we may be written out by the sorter temporarily.  So
-	 * we need to be able to write ourselves out and read
-	 * ourselves back in.
-	 *
-	 * @exception IOException thrown on error
-	 */
-	@Override
-	protected void writeExternalOld(ObjectOutput out) throws IOException {
-		super.writeExternal(out);
-		out.writeBoolean(isCountStar);
-		out.writeLong(value);
-	}
+    /////////////////////////////////////////////////////////////
+    //
+    // FORMATABLE INTERFACE
+    //
+    /////////////////////////////////////////////////////////////
+    /**
+     * Although we are not expected to be persistent per se,
+     * we may be written out by the sorter temporarily.  So
+     * we need to be able to write ourselves out and read
+     * ourselves back in.
+     *
+     * @exception IOException thrown on error
+     */
+    @Override
+    protected void writeExternalOld(ObjectOutput out) throws IOException {
+        super.writeExternal(out);
+        out.writeBoolean(isCountStar);
+        out.writeLong(value);
+    }
 
-	/**
-	 * @see java.io.Externalizable#readExternal
-	 *
-	 * @exception IOException io exception
-	 * @exception ClassNotFoundException on error
-	 */
-	@Override
-	protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
-		super.readExternal(in);
-		isCountStar = in.readBoolean();
-		value = in.readLong();
-	}
+    /**
+     * @see java.io.Externalizable#readExternal
+     *
+     * @exception IOException io exception
+     * @exception ClassNotFoundException on error
+     */
+    @Override
+    protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
+        super.readExternal(in);
+        isCountStar = in.readBoolean();
+        value = in.readLong();
+    }
 
-	/**
-	 * Get the formatID which corresponds to this class.
-	 *
-	 *	@return	the formatID of this class
-	 */
-	public	int	getTypeFormatId() { return StoredFormatIds.AGG_COUNT_V01_ID; }
+    /**
+     * Get the formatID which corresponds to this class.
+     *
+     *    @return    the formatID of this class
+     */
+    public    int    getTypeFormatId() { return StoredFormatIds.AGG_COUNT_V01_ID; }
 
-	@Override
-	protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
-		CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
+    @Override
+    protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
+        CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
 
-		CatalogMessage.CountAggregator countAggregator = CatalogMessage.CountAggregator.newBuilder()
-				.setIsCountStar(isCountStar)
-				.setValue(value)
-				.build();
+        CatalogMessage.CountAggregator countAggregator = CatalogMessage.CountAggregator.newBuilder()
+                .setIsCountStar(isCountStar)
+                .setValue(value)
+                .build();
 
-		builder.setType(CatalogMessage.SystemAggregator.Type.CountAggregator)
-				.setExtension(CatalogMessage.CountAggregator.countAggregator, countAggregator);
+        builder.setType(CatalogMessage.SystemAggregator.Type.CountAggregator)
+                .setExtension(CatalogMessage.CountAggregator.countAggregator, countAggregator);
 
-		return builder;
-	}
+        return builder;
+    }
 
-	@Override
-	protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
-		super.init(systemAggregator);
-		CatalogMessage.CountAggregator countAggregator =
-				systemAggregator.getExtension(CatalogMessage.CountAggregator.countAggregator);
-		isCountStar = countAggregator.getIsCountStar();
-		value = countAggregator.getValue();
-	}
+    @Override
+    protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
+        super.init(systemAggregator);
+        CatalogMessage.CountAggregator countAggregator =
+                systemAggregator.getExtension(CatalogMessage.CountAggregator.countAggregator);
+        isCountStar = countAggregator.getIsCountStar();
+        value = countAggregator.getValue();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/DecimalBufferedSumAggregator.java
@@ -50,195 +50,195 @@ import static com.splicemachine.db.iapi.types.SQLDecimal.getBigDecimal;
  *         Date: 5/16/14
  */
 public class DecimalBufferedSumAggregator extends SumAggregator {
-	private BigDecimal[] buffer;
-	private int length;
-	private int position;
+    private BigDecimal[] buffer;
+    private int length;
+    private int position;
 
-	private BigDecimal sum = BigDecimal.ZERO;
-	private boolean isNull = true;
-	private int bufferSize;
+    private BigDecimal sum = BigDecimal.ZERO;
+    private boolean isNull = true;
+    private int bufferSize;
 
-	public DecimalBufferedSumAggregator() { // SERDE
+    public DecimalBufferedSumAggregator() { // SERDE
 
-	}
+    }
 
-	public DecimalBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
-		init(agg);
-	}
+    public DecimalBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
+        init(agg);
+    }
 
-	public DecimalBufferedSumAggregator(int bufferSize) {
-		init(bufferSize);
-	}
+    public DecimalBufferedSumAggregator(int bufferSize) {
+        init(bufferSize);
+    }
 
-	private void init(int bufferSize) {
-		int s = 1;
-		while(s<bufferSize){
-			s<<=1;
-		}
-		buffer = new BigDecimal[s];
-		this.length = s-1;
-		position = 0;
-		this.bufferSize = bufferSize;
-	}
-	@Override
-	protected void accumulate(DataValueDescriptor addend) throws StandardException {
-		buffer[position] = getBigDecimal(addend);
-		incrementPosition();
-	}
+    private void init(int bufferSize) {
+        int s = 1;
+        while(s<bufferSize){
+            s<<=1;
+        }
+        buffer = new BigDecimal[s];
+        this.length = s-1;
+        position = 0;
+        this.bufferSize = bufferSize;
+    }
+    @Override
+    protected void accumulate(DataValueDescriptor addend) throws StandardException {
+        buffer[position] = getBigDecimal(addend);
+        incrementPosition();
+    }
 
 
-	@Override
-	public void merge(ExecAggregator addend) throws StandardException {
-		if(addend==null) return; //treat null entries as zero
-		//In Splice, we should never see a different type of an ExecAggregator
-		DecimalBufferedSumAggregator other = (DecimalBufferedSumAggregator)addend;
-		if (other.isNull){
-			return;
-		}
+    @Override
+    public void merge(ExecAggregator addend) throws StandardException {
+        if(addend==null) return; //treat null entries as zero
+        //In Splice, we should never see a different type of an ExecAggregator
+        DecimalBufferedSumAggregator other = (DecimalBufferedSumAggregator)addend;
+        if (other.isNull){
+            return;
+        }
 
-		if (!Objects.equals(other.sum, BigDecimal.ZERO)) {
-			buffer[position] = other.sum;
-			incrementPosition();
-		}
-		for (int i = 0; i< other.position;i++) {
-			buffer[position] = other.buffer[i];
-			incrementPosition();
-		}
-	}
+        if (!Objects.equals(other.sum, BigDecimal.ZERO)) {
+            buffer[position] = other.sum;
+            incrementPosition();
+        }
+        for (int i = 0; i< other.position;i++) {
+            buffer[position] = other.buffer[i];
+            incrementPosition();
+        }
+    }
 
-	@Override
-	protected void writeExternalOld(ObjectOutput out) throws IOException {
-		//Need to sum up all the intermediate values before serializing
-		if(position!=0){
-			try {
-				sum(position);
-			} catch (StandardException e) {
-				throw new IOException(e);
-			}
-			position=0;
-		}
-		out.writeBoolean(eliminatedNulls);
-		out.writeBoolean(isNull);
-		out.writeObject(sum);
-	}
+    @Override
+    protected void writeExternalOld(ObjectOutput out) throws IOException {
+        //Need to sum up all the intermediate values before serializing
+        if(position!=0){
+            try {
+                sum(position);
+            } catch (StandardException e) {
+                throw new IOException(e);
+            }
+            position=0;
+        }
+        out.writeBoolean(eliminatedNulls);
+        out.writeBoolean(isNull);
+        out.writeObject(sum);
+    }
 
-	@Override
-	protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
-		this.eliminatedNulls = in.readBoolean();
-		this.isNull = in.readBoolean();
-		this.sum = (BigDecimal)in.readObject();
-	}
+    @Override
+    protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.eliminatedNulls = in.readBoolean();
+        this.isNull = in.readBoolean();
+        this.sum = (BigDecimal)in.readObject();
+    }
 
-	@Override
-	protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
-		if(position!=0){
-			try {
-				sum(position);
-			} catch (StandardException e) {
-				throw new IOException(e);
-			}
-			position=0;
-		}
-		try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-			 ObjectOutputStream os = new ObjectOutputStream(bos)) {
-			os.writeObject(sum);
-			os.flush();
-			byte[] bs = bos.toByteArray();
+    @Override
+    protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
+        if(position!=0){
+            try {
+                sum(position);
+            } catch (StandardException e) {
+                throw new IOException(e);
+            }
+            position=0;
+        }
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutputStream os = new ObjectOutputStream(bos)) {
+            os.writeObject(sum);
+            os.flush();
+            byte[] bs = bos.toByteArray();
 
-			CatalogMessage.DecimalBufferedSumAggregator aggregator =
-					CatalogMessage.DecimalBufferedSumAggregator.newBuilder()
-							.setIsNull(isNull)
-							.setSum(ByteString.copyFrom(bs))
-							.setBufferSize(bufferSize)
-							.build();
+            CatalogMessage.DecimalBufferedSumAggregator aggregator =
+                    CatalogMessage.DecimalBufferedSumAggregator.newBuilder()
+                            .setIsNull(isNull)
+                            .setSum(ByteString.copyFrom(bs))
+                            .setBufferSize(bufferSize)
+                            .build();
 
-			CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
-			builder.setType(CatalogMessage.SystemAggregator.Type.DecimalBufferedSumAggregator)
-					.setExtension(CatalogMessage.DecimalBufferedSumAggregator.decimalBufferedSumAggregator, aggregator);
-			return builder;
-		}
-	}
+            CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
+            builder.setType(CatalogMessage.SystemAggregator.Type.DecimalBufferedSumAggregator)
+                    .setExtension(CatalogMessage.DecimalBufferedSumAggregator.decimalBufferedSumAggregator, aggregator);
+            return builder;
+        }
+    }
 
-	@Override
-	protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
-		super.init(systemAggregator);
-		CatalogMessage.DecimalBufferedSumAggregator aggregator =
-				systemAggregator.getExtension(CatalogMessage.DecimalBufferedSumAggregator.decimalBufferedSumAggregator);
-		isNull = aggregator.getIsNull();
-		byte[] ba = aggregator.getSum().toByteArray();
-		try (ByteArrayInputStream bis = new ByteArrayInputStream(ba);
-			 ObjectInputStream ois = new ObjectInputStream(bis)) {
-			this.sum =	(BigDecimal)ois.readObject();
-		}
-		init(aggregator.getBufferSize());
-	}
+    @Override
+    protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
+        super.init(systemAggregator);
+        CatalogMessage.DecimalBufferedSumAggregator aggregator =
+                systemAggregator.getExtension(CatalogMessage.DecimalBufferedSumAggregator.decimalBufferedSumAggregator);
+        isNull = aggregator.getIsNull();
+        byte[] ba = aggregator.getSum().toByteArray();
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(ba);
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            this.sum =    (BigDecimal)ois.readObject();
+        }
+        init(aggregator.getBufferSize());
+    }
 
-	@Override
-	public DataValueDescriptor getResult() throws StandardException {
-		if (value == null) {
-			value = new SQLDecimal();
-		}
-		if(isNull){
-			value.setToNull();
-			return value;
-		}
-		if(position!=0){
-			sum(position);
-			position=0;
-		}
-		value.setBigDecimal(sum);
-		return value;
-	}
+    @Override
+    public DataValueDescriptor getResult() throws StandardException {
+        if (value == null) {
+            value = new SQLDecimal();
+        }
+        if(isNull){
+            value.setToNull();
+            return value;
+        }
+        if(position!=0){
+            sum(position);
+            position=0;
+        }
+        value.setBigDecimal(sum);
+        return value;
+    }
 
-	/**
-	 * Can only be safely called after first calling getResult();
-	 * e.g. after GenericAggregator.finish() has been called
-	 * @return the current sum;
-	 */
-	public BigDecimal getSum(){
-		assert position==0: "There are entries still to be buffered!";
-		return sum;
-	}
+    /**
+     * Can only be safely called after first calling getResult();
+     * e.g. after GenericAggregator.finish() has been called
+     * @return the current sum;
+     */
+    public BigDecimal getSum(){
+        assert position==0: "There are entries still to be buffered!";
+        return sum;
+    }
 
-	public void init(BigDecimal sum,boolean eliminatedNulls){
-		this.sum = sum;
-		this.eliminatedNulls = eliminatedNulls;
-		this.isNull=false;
-	}
+    public void init(BigDecimal sum,boolean eliminatedNulls){
+        this.sum = sum;
+        this.eliminatedNulls = eliminatedNulls;
+        this.isNull=false;
+    }
 
-	@Override
-	public ExecAggregator newAggregator() {
-		return new DecimalBufferedSumAggregator(buffer.length);
-	}
+    @Override
+    public ExecAggregator newAggregator() {
+        return new DecimalBufferedSumAggregator(buffer.length);
+    }
 
-	private void sum(int bufferLength) throws StandardException {
-		for (int i=0;i<bufferLength;i++) {
-			BigDecimal l = buffer[i];
-			sum=sum.add(l);
-		}
-	}
+    private void sum(int bufferLength) throws StandardException {
+        for (int i=0;i<bufferLength;i++) {
+            BigDecimal l = buffer[i];
+            sum=sum.add(l);
+        }
+    }
 
-	private void incrementPosition() throws StandardException {
-		int newposition = (position+1) & length;
-		if(newposition==0){
-			sum(buffer.length);
-		}
-		isNull=false;
-		position = newposition;
-	}
+    private void incrementPosition() throws StandardException {
+        int newposition = (position+1) & length;
+        if(newposition==0){
+            sum(buffer.length);
+        }
+        isNull=false;
+        position = newposition;
+    }
 
-	public void addDirect(BigDecimal bigDecimal) throws StandardException {
-		buffer[position] = bigDecimal;
-		incrementPosition();
-	}
+    public void addDirect(BigDecimal bigDecimal) throws StandardException {
+        buffer[position] = bigDecimal;
+        incrementPosition();
+    }
 
-	public String toString() {
-		String bufferInfo = isNull ? null : (position < 25 && position > 0 ?
-				Arrays.toString(Arrays.copyOfRange(buffer, 0, position))
-				: String.format("%s buffered", position));
-		return "DecimalBufferedSumAggregator: " + (isNull ? "NULL" :
-				String.format("{ sum=%s buffer=%s }", sum, bufferInfo));
-	}
+    public String toString() {
+        String bufferInfo = isNull ? null : (position < 25 && position > 0 ?
+                Arrays.toString(Arrays.copyOfRange(buffer, 0, position))
+                : String.format("%s buffered", position));
+        return "DecimalBufferedSumAggregator: " + (isNull ? "NULL" :
+                String.format("{ sum=%s buffer=%s }", sum, bufferInfo));
+    }
 
 
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/LongBufferedSumAggregator.java
@@ -50,200 +50,200 @@ import java.util.Arrays;
  */
 public class LongBufferedSumAggregator extends SumAggregator {
 
-	private long[] buffer;
-	private int length;
-	private int position;
+    private long[] buffer;
+    private int length;
+    private int position;
 
-	private long sum = 0;
-	private boolean isNull = true; //set to false when elements are added
+    private long sum = 0;
+    private boolean isNull = true; //set to false when elements are added
 
-	private int bufferSize;
+    private int bufferSize;
 
-	public LongBufferedSumAggregator() {
+    public LongBufferedSumAggregator() {
 
-	}
-	public LongBufferedSumAggregator(int bufferSize) {
-		init(bufferSize);
-	}
+    }
+    public LongBufferedSumAggregator(int bufferSize) {
+        init(bufferSize);
+    }
 
-	private void init(int bufferSize) {
-		int s = 1;
-		while(s<bufferSize){
-			s<<=1;
-		}
-		buffer = new long[s];
-		this.length = s-1;
-		position = 0;
-		this.bufferSize = bufferSize;
-	}
+    private void init(int bufferSize) {
+        int s = 1;
+        while(s<bufferSize){
+            s<<=1;
+        }
+        buffer = new long[s];
+        this.length = s-1;
+        position = 0;
+        this.bufferSize = bufferSize;
+    }
 
-	public LongBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
-		init(agg);
-	}
+    public LongBufferedSumAggregator(CatalogMessage.SystemAggregator agg) throws IOException, ClassNotFoundException {
+        init(agg);
+    }
 
-	@Override
-	protected void accumulate(DataValueDescriptor addend) throws StandardException {
-		buffer[position] = addend.getLong();
-		incrementPosition();
-	}
+    @Override
+    protected void accumulate(DataValueDescriptor addend) throws StandardException {
+        buffer[position] = addend.getLong();
+        incrementPosition();
+    }
 
 
-	@Override
-	public void merge(ExecAggregator addend) throws StandardException {
-		if(addend==null)
-			return; //treat null entries as zero
-		//In Splice, we should never see a different type of an ExecAggregator
-		LongBufferedSumAggregator other = (LongBufferedSumAggregator) addend;
+    @Override
+    public void merge(ExecAggregator addend) throws StandardException {
+        if(addend==null)
+            return; //treat null entries as zero
+        //In Splice, we should never see a different type of an ExecAggregator
+        LongBufferedSumAggregator other = (LongBufferedSumAggregator) addend;
 
-		if (other.isNull){
-			return;
-		}
+        if (other.isNull){
+            return;
+        }
 
-		if (other.sum != 0) {
-			buffer[position] = other.sum;
-			incrementPosition();
-		}
-		for (int i = 0; i< other.position;i++) {
-			buffer[position] = other.buffer[i];
-			incrementPosition();
-		}
-	}
+        if (other.sum != 0) {
+            buffer[position] = other.sum;
+            incrementPosition();
+        }
+        for (int i = 0; i< other.position;i++) {
+            buffer[position] = other.buffer[i];
+            incrementPosition();
+        }
+    }
 
-	@Override
-	protected void writeExternalOld(ObjectOutput out) throws IOException {
-		//Need to sum up all the intermediate values before serializing
-		if(position!=0){
-			try {
-				sum(position);
-			} catch (StandardException e) {
-				throw new IOException(e);
-			}
-			position=0;
-		}
-		out.writeBoolean(eliminatedNulls);
-		out.writeBoolean(isNull);
-		out.writeLong(sum);
-	}
+    @Override
+    protected void writeExternalOld(ObjectOutput out) throws IOException {
+        //Need to sum up all the intermediate values before serializing
+        if(position!=0){
+            try {
+                sum(position);
+            } catch (StandardException e) {
+                throw new IOException(e);
+            }
+            position=0;
+        }
+        out.writeBoolean(eliminatedNulls);
+        out.writeBoolean(isNull);
+        out.writeLong(sum);
+    }
 
-	@Override
-	protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
-		this.eliminatedNulls = in.readBoolean();
-		this.isNull = in.readBoolean();
-		this.sum = in.readLong();
-	}
+    @Override
+    protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
+        this.eliminatedNulls = in.readBoolean();
+        this.isNull = in.readBoolean();
+        this.sum = in.readLong();
+    }
 
-	@Override
-	protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
-		//Need to sum up all the intermediate values before serializing
-		if(position!=0){
-			try {
-				sum(position);
-			} catch (StandardException e) {
-				throw new IOException(e);
-			}
-			position=0;
-		}
-		CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
-		CatalogMessage.LongBufferedSumAggregator aggregator =
-				CatalogMessage.LongBufferedSumAggregator.newBuilder()
-						.setIsNull(isNull)
-						.setSum(sum)
-						.setBufferSize(bufferSize)
-						.build();
-		builder.setType(CatalogMessage.SystemAggregator.Type.LongBufferedSumAggregator)
-				.setExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator, aggregator);
-		return builder;
-	}
+    @Override
+    protected CatalogMessage.SystemAggregator.Builder toProtobufBuilder() throws IOException {
+        //Need to sum up all the intermediate values before serializing
+        if(position!=0){
+            try {
+                sum(position);
+            } catch (StandardException e) {
+                throw new IOException(e);
+            }
+            position=0;
+        }
+        CatalogMessage.SystemAggregator.Builder builder = super.toProtobufBuilder();
+        CatalogMessage.LongBufferedSumAggregator aggregator =
+                CatalogMessage.LongBufferedSumAggregator.newBuilder()
+                        .setIsNull(isNull)
+                        .setSum(sum)
+                        .setBufferSize(bufferSize)
+                        .build();
+        builder.setType(CatalogMessage.SystemAggregator.Type.LongBufferedSumAggregator)
+                .setExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator, aggregator);
+        return builder;
+    }
 
-	@Override
-	protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
-		super.init(systemAggregator);
-		CatalogMessage.LongBufferedSumAggregator aggregator =
-				systemAggregator.getExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator);
-		this.isNull = aggregator.getIsNull();
-		this.sum = aggregator.getSum();
-		init(aggregator.getBufferSize());
-	}
+    @Override
+    protected void init(CatalogMessage.SystemAggregator systemAggregator) throws IOException, ClassNotFoundException {
+        super.init(systemAggregator);
+        CatalogMessage.LongBufferedSumAggregator aggregator =
+                systemAggregator.getExtension(CatalogMessage.LongBufferedSumAggregator.longBufferedSumAggregator);
+        this.isNull = aggregator.getIsNull();
+        this.sum = aggregator.getSum();
+        init(aggregator.getBufferSize());
+    }
 
-	@Override
-	public DataValueDescriptor getResult() throws StandardException {
-		if (value == null) {
-			value = new SQLLongint();
-		}
-		if(isNull){
-			value.setToNull();
-			return value;
-		}
-		if(position!=0){
-			sum(position);
-			position=0;
-		}
-		value.setValue(sum);
-		return value;
-	}
+    @Override
+    public DataValueDescriptor getResult() throws StandardException {
+        if (value == null) {
+            value = new SQLLongint();
+        }
+        if(isNull){
+            value.setToNull();
+            return value;
+        }
+        if(position!=0){
+            sum(position);
+            position=0;
+        }
+        value.setValue(sum);
+        return value;
+    }
 
-	/**
-	 * Can only be safely called after first calling getResult();
-	 * e.g. after GenericAggregator.finish() has been called
-	 * @return the current sum;
-	 */
-	public long getSum(){
-		assert position==0: "There are entries still to be buffered!";
-		return sum;
-	}
+    /**
+     * Can only be safely called after first calling getResult();
+     * e.g. after GenericAggregator.finish() has been called
+     * @return the current sum;
+     */
+    public long getSum(){
+        assert position==0: "There are entries still to be buffered!";
+        return sum;
+    }
 
-	public void init(long sum,boolean eliminatedNulls){
-		this.sum = sum;
-		this.eliminatedNulls = eliminatedNulls;
-	}
+    public void init(long sum,boolean eliminatedNulls){
+        this.sum = sum;
+        this.eliminatedNulls = eliminatedNulls;
+    }
 
-	@Override
-	public ExecAggregator newAggregator() {
-		return new LongBufferedSumAggregator(64);
-	}
+    @Override
+    public ExecAggregator newAggregator() {
+        return new LongBufferedSumAggregator(64);
+    }
 
-	/**
-	 * Update this aggregator to an aggregator which does not suffer from the same overflows.
-	 *
-	 * @return an aggregator which can contain larger numbers
-	 * @throws StandardException if something goes wrong.
-	 */
-	public SumAggregator upgrade() throws StandardException {
-		DecimalBufferedSumAggregator aggregator = new DecimalBufferedSumAggregator(buffer.length);
-		aggregator.init(BigDecimal.valueOf(sum), eliminatedNulls);
-		for(int i=0;i<position;i++){
-			aggregator.addDirect(BigDecimal.valueOf(buffer[i]));
-		}
-		return aggregator;
-	}
+    /**
+     * Update this aggregator to an aggregator which does not suffer from the same overflows.
+     *
+     * @return an aggregator which can contain larger numbers
+     * @throws StandardException if something goes wrong.
+     */
+    public SumAggregator upgrade() throws StandardException {
+        DecimalBufferedSumAggregator aggregator = new DecimalBufferedSumAggregator(buffer.length);
+        aggregator.init(BigDecimal.valueOf(sum), eliminatedNulls);
+        for(int i=0;i<position;i++){
+            aggregator.addDirect(BigDecimal.valueOf(buffer[i]));
+        }
+        return aggregator;
+    }
 
-	private void sum(int bufferLength) throws StandardException {
-		long newSum = sum;
-		try {
-			for (int i = 0; i < bufferLength; i++) {
-				newSum = ArithmeticUtils.addAndCheck(newSum, buffer[i]);
-			}
-		}
-		catch (MathArithmeticException e) {
-			throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE,"BIGINT");
-		}
-		sum = newSum;
-	}
+    private void sum(int bufferLength) throws StandardException {
+        long newSum = sum;
+        try {
+            for (int i = 0; i < bufferLength; i++) {
+                newSum = ArithmeticUtils.addAndCheck(newSum, buffer[i]);
+            }
+        }
+        catch (MathArithmeticException e) {
+            throw StandardException.newException(SQLState.LANG_OUTSIDE_RANGE_FOR_DATATYPE,"BIGINT");
+        }
+        sum = newSum;
+    }
 
-	private void incrementPosition() throws StandardException {
-		int newposition = (position+1) & length;
-		if(newposition==0){
-			sum(buffer.length);
-		}
-		isNull=false;
-		position = newposition;
-	}
+    private void incrementPosition() throws StandardException {
+        int newposition = (position+1) & length;
+        if(newposition==0){
+            sum(buffer.length);
+        }
+        isNull=false;
+        position = newposition;
+    }
 
-	public String toString() {
-		String bufferInfo = isNull ? null : (position < 25 && position > 0 ?
-				Arrays.toString(Arrays.copyOfRange(buffer, 0, position))
-				: String.format("%s buffered", position));
-		return "LongBufferedSumAggregator: " + (isNull ? "NULL" :
-				String.format("{ sum=%s buffer=%s }", sum, bufferInfo));
-	}
+    public String toString() {
+        String bufferInfo = isNull ? null : (position < 25 && position > 0 ?
+                Arrays.toString(Arrays.copyOfRange(buffer, 0, position))
+                : String.format("%s buffered", position));
+        return "LongBufferedSumAggregator: " + (isNull ? "NULL" :
+                String.format("{ sum=%s buffer=%s }", sum, bufferInfo));
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/UnionOperationIT.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
 import com.splicemachine.derby.test.framework.TestConnection;
 import com.splicemachine.test.HBaseTest;
 import com.splicemachine.util.StatementUtils;
@@ -36,7 +37,7 @@ import java.util.*;
 import static com.splicemachine.derby.test.framework.SpliceUnitTest.resultSetSize;
 import static org.junit.Assert.*;
 
-public class UnionOperationIT {
+public class UnionOperationIT extends SpliceUnitTest {
 
     private static final String CLASS_NAME = UnionOperationIT.class.getSimpleName().toUpperCase();
     private static final SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);


### PR DESCRIPTION
## Description

`MaxMinAggregator.toProtobufBuilder` used to call `value.toProtobuf()` without checking whether `value` is null or not. 
This PR makes `MaxMinAggregator.toProbufBuilder` behave like `SumAggregator.toProtobufBuilder` and checks for `value != null`

## How to test

```
drop table t0;

drop table t2;

CREATE TABLE t0(c0 boolean , c1 TIMESTAMP);

CREATE TABLE t2(c0 TIMESTAMP not null);

INSERT INTO T0(C0) VALUES (FALSE);

INSERT INTO T0(C0, C1) VALUES (TRUE, '1970-01-13 04:08:02'), (TRUE, '1969-12-12 03:20:09');

INSERT INTO T0(C1) VALUES ('1969-12-12 03:20:09');

INSERT INTO T0(C1) VALUES ('1970-01-13 08:53:47');

SELECT MAX(agg0) FROM (SELECT MAX(T2.C0)  as agg0 FROM T0 LEFT OUTER JOIN T2 ON ((T0.C1)!=(T2.C0)) WHERE T0.C0 UNION ALL SELECT MAX(T2.C0)  as agg0 FROM T0 LEFT OUTER JOIN T2 ON ((T0.C1)!=(T2.C0)) WHERE NOT (T0.C0) UNION ALL SELECT MAX(T2.C0)  as agg0 FROM T0 LEFT OUTER JOIN T2 ON ((T0.C1)!=(T2.C0)) WHERE (T0.C0) IS NULL) as asdf;
```
should not throw an NPE anymore