### PR TITLE
DB-12120 Database property and hint for cost model

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -195,6 +195,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING = false;
     boolean DEFAULT_DISABLE_INDEX_PREFIX_ITERATION= false;
     boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
+    String DEFAULT_COST_MODEL_NAME = "v1";
 
     boolean DEFAULT_PRESERVE_LINE_ENDINGS = false;
 
@@ -780,4 +781,8 @@ public interface CompilerContext extends Context
     boolean compilingTrigger();
 
     void setCompilingTrigger(boolean newVal);
+
+    void setCostModelName(String costModelName);
+
+    String getCostModelName();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizableList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizableList.java
@@ -120,4 +120,9 @@ public interface OptimizableList {
 	 * Return the maximum number of tables to be considered for exhaustive search.
 	 */
 	int getTableLimitForExhaustiveSearch();
+
+	/**
+	 * Return the name of the cost model used to optimize this optimizable list.
+	 */
+	String getCostModelName();
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/OptimizerFactory.java
@@ -31,7 +31,6 @@
 
 package com.splicemachine.db.iapi.sql.compile;
 
-import com.splicemachine.db.iapi.sql.compile.costing.CostModel;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
@@ -70,12 +69,11 @@ public interface OptimizerFactory {
      * @throws StandardException Thrown on error
      */
     Optimizer getOptimizer(OptimizableList optimizableList,
-                           OptimizablePredicateList predicateList,
-                           DataDictionary dDictionary,
-                           RequiredRowOrdering requiredRowOrdering,
-                           int numTablesInQuery,
-                           LanguageConnectionContext lcc,
-                           CostModel costModel)
+						   OptimizablePredicateList predicateList,
+						   DataDictionary dDictionary,
+						   RequiredRowOrdering requiredRowOrdering,
+						   int numTablesInQuery,
+						   LanguageConnectionContext lcc)
             throws StandardException;
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -171,6 +171,12 @@ public interface LanguageConnectionContext extends Context {
     int getTableLimitForExhaustiveSearch();
 
     /**
+     * Get value of costModelName
+     * @return value of costModelName
+     */
+    String getCostModelName();
+
+    /**
      * Get value of minPlanTimeout
      * @return value of minPlanTimeout
      */
@@ -1539,7 +1545,7 @@ public interface LanguageConnectionContext extends Context {
 
     boolean favorIndexPrefixIteration();
 
-    CostModel getCostModel();
+    CostModel getCostModel(String costModelName);
 
     void setupLocalSPSCache(boolean fromSparkExecution,
                             SPSDescriptor fromTableDmlSpsDescriptor) throws StandardException;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -40,6 +40,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.PreparedStatement;
 import com.splicemachine.db.iapi.sql.Statement;
 import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.compile.costing.CostModelRegistry;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.StatementContext;
 import com.splicemachine.db.iapi.sql.depend.Dependency;
@@ -506,6 +507,7 @@ public class GenericStatement implements Statement{
 
         setSSQFlatteningForUpdateDisabled(lcc, cc);
         setVarcharDB2CompatibilityMode(lcc, cc);
+        setCostModelName(lcc, cc);
         return cc;
     }
 
@@ -835,6 +837,13 @@ public class GenericStatement implements Statement{
                 default:
                     cc.setFloatingPointNotation(CompilerContext.DEFAULT_FLOATING_POINT_NOTATION);
             }
+        }
+    }
+
+    private void setCostModelName(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String costModelString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.COST_MODEL);
+        if (costModelString != null && CostModelRegistry.exists(costModelString)) {
+            cc.setCostModelName(costModelString);
         }
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -364,6 +364,16 @@ public class CompilerContextImpl extends ContextImpl
         ssqFlatteningForUpdateDisabled = onOff;
     }
 
+    @Override
+    public String getCostModelName() {
+        return costModelName;
+    }
+
+    @Override
+    public void setCostModelName(String costModelName) {
+        this.costModelName = costModelName;
+    }
+
     /**
      * Get the current next subquery number from this CompilerContext.
      *
@@ -1232,6 +1242,7 @@ public class CompilerContextImpl extends ContextImpl
     private       boolean                             disablePerParallelTaskJoinCosting            = DEFAULT_DISABLE_PARALLEL_TASKS_JOIN_COSTING;
     private       boolean                             disablePrefixIteratorMode                    = DEFAULT_DISABLE_INDEX_PREFIX_ITERATION;
     private       boolean                             varcharDB2CompatibilityMode                  = DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
+    private       String                              costModelName                                = DEFAULT_COST_MODEL_NAME;
     /**
      * Saved execution time default schema, if we need to change it
      * temporarily.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -34,10 +34,7 @@ package com.splicemachine.db.impl.sql.compile;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
-import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
-import com.splicemachine.db.iapi.sql.compile.Optimizable;
-import com.splicemachine.db.iapi.sql.compile.OptimizableList;
-import com.splicemachine.db.iapi.sql.compile.Optimizer;
+import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.compile.costing.CostModelRegistry;
 import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.util.JBitSet;
@@ -94,7 +91,7 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
         fixedJoinOrder=!((Boolean)optimizeJoinOrder);
         isTransparent=false;
         tableLimitForExhaustiveSearch = getLanguageConnectionContext().getTableLimitForExhaustiveSearch();
-        costModelName = getLanguageConnectionContext().getCostModelName();
+        costModelName = getCostModelFromProperties();
     }
 
     /**
@@ -1517,10 +1514,23 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
         return tableLimitForExhaustiveSearch;
     }
 
+    public String getCostModelFromProperties() {
+        // get session property first
+        String value = getLanguageConnectionContext().getCostModelName();
+        if (value == null) {
+            // if session property is not set, get database property
+            value = getCompilerContext().getCostModelName();
+        }
+        if (value == null || !CostModelRegistry.exists(value)) {
+            value = CompilerContext.DEFAULT_COST_MODEL_NAME;
+        }
+        return value;
+    }
+
     @Override
     public String getCostModelName() {
         if (costModelName == null) {
-            return getLanguageConnectionContext().getCostModelName();
+            return getCostModelFromProperties();
         }
         return costModelName;
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerFactoryImpl.java
@@ -90,8 +90,7 @@ public class Level2OptimizerFactoryImpl
 			DataDictionary dDictionary,
 			RequiredRowOrdering requiredRowOrdering,
 			int numTablesInQuery,
-			LanguageConnectionContext lcc,
-			CostModel costModel)
+			LanguageConnectionContext lcc)
 				throws StandardException
 	{
 
@@ -107,8 +106,7 @@ public class Level2OptimizerFactoryImpl
 							lcc.getLockEscalationThreshold(),
 							requiredRowOrdering,
 							numTablesInQuery,
-							lcc,
-							costModel);
+							lcc);
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Level2OptimizerImpl.java
@@ -57,13 +57,12 @@ public class Level2OptimizerImpl extends OptimizerImpl{
                                int tableLockThreshold,
                                RequiredRowOrdering requiredRowOrdering,
                                int numTablesInQuery,
-                               LanguageConnectionContext lcc,
-                               CostModel costModel)
+                               LanguageConnectionContext lcc)
             throws StandardException{
         super(optimizableList, predicateList, dDictionary,
               ruleBasedOptimization, noTimeout, useStatistics, maxMemoryPerTable,
               joinStrategies, tableLockThreshold, requiredRowOrdering,
-              numTablesInQuery, costModel);
+              numTablesInQuery, lcc.getCostModel(optimizableList.getCostModelName()));
 
         // Remember whether or not optimizer trace is on;
         optimizerTrace=lcc.getOptimizerTrace();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerFactoryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OptimizerFactoryImpl.java
@@ -142,8 +142,7 @@ public class OptimizerFactoryImpl
 								  DataDictionary dDictionary,
 								  RequiredRowOrdering requiredRowOrdering,
 								  int numTablesInQuery,
-								  LanguageConnectionContext lcc,
-								  CostModel costModel)
+								  LanguageConnectionContext lcc)
 				throws StandardException
 	{
 		/* Get/set up the array of join strategies.
@@ -165,8 +164,7 @@ public class OptimizerFactoryImpl
 							dDictionary,
 							requiredRowOrdering,
 							numTablesInQuery,
-							lcc,
-								costModel);
+							lcc);
 	}
 
 	/**
@@ -199,8 +197,7 @@ public class OptimizerFactoryImpl
 										 DataDictionary dDictionary,
 										 RequiredRowOrdering requiredRowOrdering,
 										 int numTablesInQuery,
-										 LanguageConnectionContext lcc,
-										 CostModel costModel)
+										 LanguageConnectionContext lcc)
 				throws StandardException
 	{
 
@@ -216,7 +213,7 @@ public class OptimizerFactoryImpl
 							lcc.getLockEscalationThreshold(),
 							requiredRowOrdering,
 							numTablesInQuery,
-							costModel);
+							lcc.getCostModel(optimizableList.getCostModelName()));
 	}
 
 	/**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultSetNode.java
@@ -1128,8 +1128,7 @@ public abstract class ResultSetNode extends QueryTreeNode{
                                                     dataDictionary,
                                                     requiredRowOrdering,
                                                     getCompilerContext().getMaximalPossibleTableCount(),
-                                                    lcc,
-                                                    lcc.getCostModel());
+                                                    lcc);
         }
 
         optimizer.prepForNextRound();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TableOperatorNode.java
@@ -766,8 +766,7 @@ public abstract class TableOperatorNode extends FromTable{
                                                     getDataDictionary(),
                                                     null,
                                                     getCompilerContext().getMaximalPossibleTableCount(),
-                                                    lcc,
-                                                    lcc.getCostModel());
+                                                    lcc);
             optimizer.prepForNextRound();
             optimizer.setAssignedTableMap(otherChildReferenceMap);
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -292,6 +292,9 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     // default to 6
     private int tableLimitForExhaustiveSearch = 6;
 
+    // default to v1
+    private String costModelName = "v1";
+
     // this used to be computed in OptimizerFactoryContextImpl; i.e everytime a
     // connection was made. To keep the semantics same I'm putting it out here
     // instead of in the OptimizerFactory which is only initialized when the
@@ -459,6 +462,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             throw e;
         }  catch (Exception e) {
             // no op, use default value 6
+        }
+
+        String costModelString = PropertyUtil.getCachedDatabaseProperty(this, Property.COST_MODEL);
+        if (costModelString != null && CostModelRegistry.exists(costModelString)) {
+            costModelName = costModelString;
         }
 
         try {
@@ -715,6 +723,15 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
         if (tableLimit != null)
             return tableLimit;
         return tableLimitForExhaustiveSearch;
+    }
+
+    @Override
+    public String getCostModelName() {
+        String cmName = (String) sessionProperties.getProperty(
+                SessionProperties.PROPERTYNAME.COSTMODEL);
+        if (cmName != null)
+            return cmName;
+        return costModelName;
     }
 
     @Override
@@ -4134,13 +4151,11 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     }
 
     @Override
-    public CostModel getCostModel() {
-        String costModelName = getSessionProperties().getPropertyString(SessionProperties.PROPERTYNAME.COSTMODEL);
-        if(CostModelRegistry.exists(costModelName)) {
+    public CostModel getCostModel(String costModelName) {
+        if(costModelName != null && CostModelRegistry.exists(costModelName)) {
             return CostModelRegistry.getCostModel(costModelName);
-        } else {
-            return CostModelRegistry.getCostModel("v1");
         }
+        return null;
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -292,9 +292,6 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     // default to 6
     private int tableLimitForExhaustiveSearch = 6;
 
-    // default to v1
-    private String costModelName = "v1";
-
     // this used to be computed in OptimizerFactoryContextImpl; i.e everytime a
     // connection was made. To keep the semantics same I'm putting it out here
     // instead of in the OptimizerFactory which is only initialized when the
@@ -462,11 +459,6 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             throw e;
         }  catch (Exception e) {
             // no op, use default value 6
-        }
-
-        String costModelString = PropertyUtil.getCachedDatabaseProperty(this, Property.COST_MODEL);
-        if (costModelString != null && CostModelRegistry.exists(costModelString)) {
-            costModelName = costModelString;
         }
 
         try {
@@ -727,11 +719,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     @Override
     public String getCostModelName() {
-        String cmName = (String) sessionProperties.getProperty(
-                SessionProperties.PROPERTYNAME.COSTMODEL);
-        if (cmName != null)
-            return cmName;
-        return costModelName;
+        return (String) sessionProperties.getProperty(SessionProperties.PROPERTYNAME.COSTMODEL);
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerFactoryImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerFactoryImpl.java
@@ -54,8 +54,7 @@ public class SpliceLevel2OptimizerFactoryImpl extends OptimizerFactoryImpl {
                                   DataDictionary dDictionary,
                                   RequiredRowOrdering requiredRowOrdering,
                                   int numTablesInQuery,
-                                  LanguageConnectionContext lcc,
-                                  CostModel costModel) throws StandardException {
+                                  LanguageConnectionContext lcc) throws StandardException {
         /* Get/set up the array of join strategies.
          * See comment in boot().  If joinStrategySet
          * is null, then we may do needless allocations
@@ -81,8 +80,7 @@ public class SpliceLevel2OptimizerFactoryImpl extends OptimizerFactoryImpl {
                                 dDictionary,
                                 requiredRowOrdering,
                                 numTablesInQuery,
-                                lcc,
-                                costModel);
+                                lcc);
     }
 
 
@@ -92,8 +90,7 @@ public class SpliceLevel2OptimizerFactoryImpl extends OptimizerFactoryImpl {
             DataDictionary dDictionary,
             RequiredRowOrdering requiredRowOrdering,
             int numTablesInQuery,
-            LanguageConnectionContext lcc,
-            CostModel costModel) throws StandardException {
+            LanguageConnectionContext lcc) throws StandardException {
 
         return new SpliceLevel2OptimizerImpl(
                 optimizableList,
@@ -107,8 +104,7 @@ public class SpliceLevel2OptimizerFactoryImpl extends OptimizerFactoryImpl {
                 lcc.getLockEscalationThreshold(),
                 requiredRowOrdering,
                 numTablesInQuery,
-                lcc,
-                costModel);
+                lcc);
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
@@ -171,8 +171,7 @@ public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
                                      int tableLockThreshold,
                                      RequiredRowOrdering requiredRowOrdering,
                                      int numTablesInQuery,
-                                     LanguageConnectionContext lcc,
-                                     CostModel costModel) throws StandardException{
+                                     LanguageConnectionContext lcc) throws StandardException{
         super(optimizableList,
               predicateList,
               dDictionary,
@@ -184,12 +183,12 @@ public class SpliceLevel2OptimizerImpl extends Level2OptimizerImpl{
               tableLockThreshold,
               requiredRowOrdering,
               numTablesInQuery,
-              lcc, costModel);
+              lcc);
         SConfiguration configuration=EngineDriver.driver().getConfiguration();
         this.minTimeout=configuration.getOptimizerPlanMinimumTimeout();
         this.maxTimeout=configuration.getOptimizerPlanMaximumTimeout();
         isMemPlatform = EngineDriver.isMemPlatform();
-        this.costModel = costModel;
+        this.costModel = lcc.getCostModel(optimizableList.getCostModelName());
         tracer().trace(OptimizerFlag.STARTED,0,0,0.0,null);
     }
 


### PR DESCRIPTION
## Short Description
This change adds a database property and a query hint for setting cost model.

## Long Description
- Database property:
  ```
  CALL SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('costModel', 'v2');
  CALL SYSCS_UTIL.SYSCS_GET_GLOBAL_DATABASE_PROPERTY('costModel');
  ```
- Session property:
  ```
  set session_property costModel='v1';
  values current session_property;
  ```
- Query hint:
  ```
  explain select * from --splice-properties costModel='v2'
    sys.systables;
  ```

## How to test
```
CALL SYSCS_UTIL.SYSCS_SET_GLOBAL_DATABASE_PROPERTY('costModel', 'v2');
name                |value
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PROPERTY_NAME       |costModel
NEW VALUE           |v2
PREVIOUS VALUE      |NULL
INFO                |

4 rows selected
ELAPSED TIME = 330 milliseconds
CALL SYSCS_UTIL.SYSCS_GET_GLOBAL_DATABASE_PROPERTY('costModel');
HOST_NAME                                                                                                               |PROPERTY_VALUE
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
MacBook-Pro:1527                                                                                                        |v2
```
After setting the `costModel` database property to `v2`, explain any query should get `costModel='v2'` in plan.

Session property should overwrite database property value.

Query hint should overwrite both session property and database property values.

If none of the properties are set and no query hint is given, default cost model should be `v1`.

Any value other than `v1` and `v2` should be invalid for `costModel` property.