### PR TITLE
DB-12130: quote schema and table names for check_table

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceTableAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceTableAdmin.java
@@ -30,6 +30,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.SQLVarchar;
+import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.impl.jdbc.EmbedConnection;
 import com.splicemachine.db.impl.jdbc.EmbedResultSet40;
 import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
@@ -383,7 +384,8 @@ public class SpliceTableAdmin {
 
     private static long countTable(String schema, String table, String index) throws SQLException {
         String sql = String.format(
-                "select count(*) from \"%s\".\"%s\" --splice-properties index=%s", schema, table, index==null?"null":index);
+                "select count(*) from %s.%s --splice-properties index=%s", IdUtil.normalToDelimited(schema),
+                IdUtil.normalToDelimited(table), index==null ? "null" : index);
         Connection connection = SpliceAdmin.getDefaultConn();
         try(PreparedStatement ps = connection.prepareStatement(sql);
                 ResultSet rs = ps.executeQuery()) {

--- a/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceTableAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceTableAdmin.java
@@ -383,7 +383,7 @@ public class SpliceTableAdmin {
 
     private static long countTable(String schema, String table, String index) throws SQLException {
         String sql = String.format(
-                "select count(*) from %s.%s --splice-properties index=%s", schema, table, index==null?"null":index);
+                "select count(*) from \"%s\".\"%s\" --splice-properties index=%s", schema, table, index==null?"null":index);
         Connection connection = SpliceAdmin.getDefaultConn();
         try(PreparedStatement ps = connection.prepareStatement(sql);
                 ResultSet rs = ps.executeQuery()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
System procedure syscs_util.check_table has problem with quoted schema or table name.

## Long Description
System procedure syscs_util.check_table has problem with quoted schema or table name. This was caused by a query that does not quote schema and table name.

## How to test
Run this test case
create table "t"(i int);
insert into "t" values 1,2,3;
create index ti on "t"(i);
call syscs_util.check_table('SPLICE', null, null, 1, '/path/to/report');