### PR TITLE
DB-12116: batch write to SPLICE_CONGLOMERATE_SI during upgrade

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -1518,20 +1518,25 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
         List<byte[]> oldLocations = (new ArrayList<>(locations.keySet())).stream().map(e->Bytes.fromHex(e)).collect(Collectors.toList());
         Iterator<DataResult>  result = table.batchGet(null, oldLocations);
         List<DataDelete> deletes = Lists.newArrayList();
-        DataPut[] puts = new DataPut[locations.size()];
+        List<DataPut> puts = Lists.newArrayList();
         SIDriver driver = SIDriver.driver();
-        int i = 0;
         while (result.hasNext()) {
             DataResult dataResult = result.next();
             DataCell dataCell=dataResult.latestCell(SIConstants.DEFAULT_FAMILY_BYTES,SpliceSequence.autoIncrementValueQualifier);
-            DataDelete delete=driver.baseOperationFactory().newDelete(dataCell.key());
-            deletes.add(delete);
-            DataPut put = driver.baseOperationFactory().newPut(locations.get(Bytes.toHex(dataResult.key())));
-            put.addCell(SIConstants.DEFAULT_FAMILY_BYTES,SpliceSequence.autoIncrementValueQualifier, dataCell.value());
-            puts[i++] = put;
+            if(dataCell != null) {
+                DataDelete delete = driver.baseOperationFactory().newDelete(dataCell.key());
+                deletes.add(delete);
+                DataPut put = driver.baseOperationFactory().newPut(locations.get(Bytes.toHex(dataResult.key())));
+                put.addCell(SIConstants.DEFAULT_FAMILY_BYTES, SpliceSequence.autoIncrementValueQualifier, dataCell.value());
+                puts.add(put);
+            }
         }
-        table.delete(deletes);
-        table.writeBatch(puts);
+        if (puts.size() > 0) {
+            table.delete(deletes);
+            DataPut[] p = new DataPut[puts.size()];
+            p = puts.toArray(p);
+            table.writeBatch(p);
+        }
     }
 
     private void snapshotTable(TransactionController tc, int catalogNum) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeUtils.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeUtils.java
@@ -49,8 +49,7 @@ public class UpgradeUtils {
     public static void initializeConglomerateSITable(TransactionController tc) throws IOException {
         SIDriver driver = SIDriver.driver();
         int rowsRewritten = 0;
-
-        int batchSize = 100;
+        int batchSize = driver.getConfiguration().getMaxBufferEntries();
         List<DataPut> mutations = Lists.newArrayList();
         EntryDecoder entryDecoder = new EntryDecoder();
         TxnView txn = ((SpliceTransactionManager) tc).getActiveStateTxn();
@@ -77,7 +76,6 @@ public class UpgradeUtils {
                             encoder.reset();
                             encoder.encodeNextUnsorted(nextRaw);
                             put.addCell(SIConstants.DEFAULT_FAMILY_BYTES, SIConstants.PACKED_COLUMN_BYTES, entryEncoder.encode());
-                            //destTable.put(put);
                             mutations.add(put);
                             rowsRewritten++;
                             if (rowsRewritten % batchSize == 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Copying all conglomerates from SPLICE_CONGLOMERATE to SPLICE_CONGLOMERATE_SI is slow if there are a large amount of conglomerates.

## Long Description
It is slow because conglomerates are copied one at a time, each invoking an RPC. To speed up, conglomerates are batched to write to SPLICE_CONGLOMERATE_SI.

## How to test
(e.g. if bugfix: how to reproduce bug / impact)
(if feature: a easy example of how to check the feature)
(if feature is a configuration: an example to see different behavior with different configuration)
