### PR TITLE
DB-12102 Properly escape ' and \ when sending a query to spark 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/OperatorToString.java
@@ -856,9 +856,11 @@ public class OperatorToString {
                         dvd instanceof SQLLongvarchar ||
                         dvd instanceof SQLClob) {
                         if (vars.buildExpressionTree)
-                            str = format("%s", cn.getValue().getString());
+                            str = cn.getValue().getString();
                         else
-                            str = format("\'%s\' ", cn.getValue().getString());                 
+                            str = format("\'%s\' ", replace( replace(
+                                    cn.getValue().getString(), "\\", "\\\\"),
+                                    "'", "\\'"));
                     }
                     else if (dvd instanceof SQLDate)
                         str = format("date(\'%s\') ", cn.getValue().getString());
@@ -1127,8 +1129,8 @@ public class OperatorToString {
         }
         int replLength = searchString.length();
         int increase = replacement.length() - replLength;
-        increase = (increase < 0 ? 0 : increase);
-        increase *= (max < 0 ? 16 : (max > 64 ? 64 : max));
+        increase = (Math.max(increase, 0));
+        increase *= (max < 0 ? 16 : (Math.min(max, 64)));
         StringBuilder buf = new StringBuilder(text.length() + increase);
         while (end != -1) {
             buf.append(text.substring(start, end)).append(replacement);

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateWithSpecialCharactersIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateWithSpecialCharactersIT.java
@@ -1,0 +1,79 @@
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.LongerThanTwoMinutes;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class PredicateWithSpecialCharactersIT extends SpliceUnitTest {
+
+    private Boolean useSpark;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{true});
+        params.add(new Object[]{false});
+        return params;
+    }
+
+    public static final String CLASS_NAME = PredicateWithSpecialCharactersIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    public PredicateWithSpecialCharactersIT(Boolean useSpark) {
+        this.useSpark = useSpark;
+    }
+
+    private static final String[] specialChars = {"''", "\\", "\""};
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        spliceClassWatcher.execute("create table t1 (a1 char(50) not null)");
+        spliceClassWatcher.execute(format("insert into t1 values %s",
+                Arrays.stream(specialChars)
+                        .map(s -> format("'a%sb'", s))
+                        .collect(Collectors.joining(","))
+        ));
+        spliceClassWatcher.execute("create view v1 as select * from t1 union select * from t1");
+    }
+
+    @Test
+    public void testCount() throws Exception {
+        for (String specialChar: specialChars) {
+            testQuery(format("SELECT COUNT(*) FROM v1 --splice-properties useSpark=true\n WHERE a1 = 'a%sb'", specialChar),
+                    "1 |\n" +
+                    "----\n" +
+                    " 1 |", methodWatcher);
+        }
+    }
+}


### PR DESCRIPTION
## Description

When sending predicates to spark, we need to escape ' and \ properly. Predicates such as `World's` would cause a ParserException on spark's side.

## How to test

```
set session_property useOlap=true;
drop schema foo cascade;
create schema foo;
set schema foo;

call SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE();
CREATE TABLE ITEM_CODES ( ITEMTEXT VARCHAR (50) NOT NULL);

CREATE VIEW VERBOSE_INV AS SELECT * FROM item_codes UNION SELECT * FROM item_codes;
INSERT INTO ITEM_CODES VALUES ('a''b');
INSERT INTO ITEM_CODES VALUES ('a\b');
INSERT INTO ITEM_CODES VALUES ('a"b');


SELECT COUNT(*) FROM VERBOSE_INV WHERE ITEMTEXT = 'a''b';
SELECT COUNT(*) FROM VERBOSE_INV WHERE ITEMTEXT = 'a\b';
SELECT COUNT(*) FROM VERBOSE_INV WHERE ITEMTEXT = 'a"b';
```

All three select should return 1