### PR TITLE
DB-11095 Fix shouldRunSpark() for DT as RHS of a join

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/DMLStatementNode.java
@@ -278,9 +278,7 @@ public abstract class DMLStatementNode extends StatementNode {
         CollectNodesVisitor cnv = new CollectNodesVisitor(FromTable.class);
         resultSet.accept(cnv);
         for (Object obj : cnv.getList()) {
-            if (obj instanceof FromBaseTable) {
-                ((FromBaseTable) obj).determineSpark();
-            }
+            ((FromTable) obj).determineSpark();
             type = type.combine(((FromTable) obj).getDataSetProcessorType());
             sparkExecType = sparkExecType.combine(((FromTable) obj).getSparkExecutionType());
         }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -4715,32 +4715,6 @@ public class FromBaseTable extends FromTable {
                 super.toHTMLString();
     }
 
-    public void determineSpark() {
-        setDataSetProcessorType(getDataSetProcessorTypeForAccessPath(getTrulyTheBestAccessPath()));
-    }
-
-    /**
-     * Return the data set processor type for a given access path.
-     *
-     * @param accessPath the access path
-     */
-    public DataSetProcessorType getDataSetProcessorTypeForAccessPath(AccessPath accessPath) {
-        if (! dataSetProcessorType.isDefaultOltp()) {
-            // No need to assess cost
-            return dataSetProcessorType;
-        }
-        long sparkRowThreshold = getLanguageConnectionContext().getOptimizerFactory().getDetermineSparkRowThreshold();
-        // we need to check not only the number of row scanned, but also the number of output rows for the
-        // join result
-        assert dataSetProcessorType.isDefaultOltp();
-        if (accessPath != null &&
-                (accessPath.getCostEstimate().getScannedBaseTableRows() > sparkRowThreshold ||
-                 accessPath.getCostEstimate().getEstimatedRowCount() > sparkRowThreshold)) {
-                return DataSetProcessorType.COST_SUGGESTED_OLAP;
-        }
-        return dataSetProcessorType;
-    }
-
     private boolean hasConstantPredicate(int tableNum, int colNum, OptimizablePredicateList predList) {
         if (predList instanceof PredicateList)
             return ((PredicateList)predList).constantColumn(tableNum, colNum);

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ExecutorChoiceIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ExecutorChoiceIT.java
@@ -1,0 +1,67 @@
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+
+public class ExecutorChoiceIT extends SpliceUnitTest {
+    public static final String CLASS_NAME = DecimalIT.class.getSimpleName().toUpperCase();
+    protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher(CLASS_NAME);
+    protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain = RuleChain.outerRule(spliceClassWatcher)
+            .around(spliceSchemaWatcher);
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(CLASS_NAME);
+
+    public static void createData(Connection conn, String schemaName) throws Exception {
+        new TableCreator(conn)
+                .withCreate("create table if not exists t1(cid char(36), cs date, l double, lz double)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table if not exists t2(wed date)")
+                .create();
+
+        spliceClassWatcher.executeQuery(format(
+                "call SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'T1', 5914, 13, 1)", schemaName));
+        spliceClassWatcher.executeQuery(format(
+                "call SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'T2', 143, 4, 1)", schemaName));
+
+        conn.commit();
+    }
+
+    @BeforeClass
+    public static void createDataSet() throws Exception {
+        createData(spliceClassWatcher.getOrCreateConnection(), spliceSchemaWatcher.toString());
+    }
+
+    @Test
+    public void testSimpleCrossProduct1() throws Exception {
+        String query = "explain select * from t1, t2";
+        firstRowContainsQuery(query, "engine=OLAP (cost)", methodWatcher);
+    }
+
+    @Test
+    public void testSimpleCrossProduct2() throws Exception {
+        String query = "explain select * from t1 join t2 on 1=1";
+        firstRowContainsQuery(query, "engine=OLAP (cost)", methodWatcher);
+    }
+
+    @Test
+    public void testCrossProductDT() throws Exception {
+        String query = "explain select * from --splice-properties joinOrder=fixed\n" +
+                       " t1, (select distinct wed from t2)";
+        firstRowContainsQuery(query, "engine=OLAP (cost)", methodWatcher);
+    }
+}


### PR DESCRIPTION
## Short Description
This change fixes execution engine decision when RHS of a join is not a base table.

## Long Description
In `shouldRunSpark()`, `determineSpark()` is called under a guard that `obj instanceof FromBaseTable`. However, for the following query, join cost is not stored in any `FromBaseTable`:

```
select * from --splice-properties joinOrder=fixed
    t1, (select distinct c2 from t2);
```

This is because the RHS of the join is a derived table. The join cost is stored in the `ProjectRestrictNode` on top of the `SelectNode` of the derived table. Since we check `obj instanceof FromBaseTable`, effectively join cost is not considered in deciding execution engine of this query.

The fix is to move `determineSpark()` to `FromTable` and remove the `FromBaseTable` check. Now we call `determineSpark()` on all `FromTable`s collected from the plan, including both PRNs and `FromBaseTable`s.

## How to test
Setup:
```
create table if not exists t1(c1 int);
create table if not exists t2(c2 int);

call syscs_util.fake_table_statistics('SPLICE', 'T1', 5000, 13, 1);
call syscs_util.fake_table_statistics('SPLICE', 'T2', 1000, 4, 1);
```
Query:
```
explain select * from --splice-properties joinOrder=fixed
    t1, (select distinct c2 from t2);
```
Before the fix, the query goes to OLTP despite of 5000000 output rows. After the fix, the query goes to OLAP.