### PR TITLE
DB-11930 Custom HBase Filter for Index Prefix Iteration

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -1401,6 +1401,7 @@ public class FromBaseTable extends FromTable {
             finalCostEstimate = firstPassCostEstimate = firstPassCostEstimate.cloneMe();
             AccessPath firstPassAccessPath = new AccessPathImpl(optimizer);
             firstPassAccessPath.copy(currentAccessPath);
+            currentAccessPath.setNumUnusedLeadingIndexFields(0);
             disableIndexPrefixIteration = true;
             CostEstimate secondPassCostEstimate =
                 estimateCostHelper(predList, cd, outerCost, optimizer, rowOrdering);
@@ -1416,10 +1417,13 @@ public class FromBaseTable extends FromTable {
 
     private void reduceEstimatedCosts(AccessPath accessPath) {
         accessPath.setCostEstimate(accessPath.getCostEstimate().cloneMe());
-
-        double costScaleFactor = 1e-9;
         CostEstimate estimate = accessPath.getCostEstimate();
 
+        reduceEstimatedCosts(estimate);
+    }
+
+    private void reduceEstimatedCosts(CostEstimate estimate) {
+        double costScaleFactor = 1e-9;
         estimate.setLocalCost(estimate.getLocalCost() * costScaleFactor);
         estimate.setRemoteCost(estimate.getRemoteCost() * costScaleFactor);
         estimate.setLocalCostPerParallelTask(estimate.getLocalCostPerParallelTask() * costScaleFactor);
@@ -1839,6 +1843,7 @@ public class FromBaseTable extends FromTable {
         boolean oldIsAntiJoin = outerCost.isAntiJoin();
         outerCost.setAntiJoin(isAntiJoin);
         currentJoinStrategy.estimateCost(this, baseTableRestrictionList, cd, outerCost, optimizer, costEstimate);
+        adjustCostsForHintedIndexPrefixIteration(costEstimate, baseTableRestrictionList, optimizer);
         outerCost.setAntiJoin(oldIsAntiJoin);
         tracer.trace(OptimizerFlag.COST_OF_N_SCANS,tableNumber,0,outerCost.rowCount(),costEstimate, correlationName);
 
@@ -1846,6 +1851,24 @@ public class FromBaseTable extends FromTable {
         currentJoinStrategy.putBasePredicates(predList, baseTableRestrictionList);
 
         return costEstimate;
+    }
+
+    // Make the cost of Index Prefix Iteration cheaper if the
+    // favorUnionedIndexScans session hint is used.
+    private void
+    adjustCostsForHintedIndexPrefixIteration(CostEstimate costEstimate, PredicateList predList, Optimizer optimizer) {
+        if (!getLanguageConnectionContext().favorIndexPrefixIteration())
+            return;
+
+        if (optimizer.getOuterTable() instanceof Optimizable) {
+            Optimizable opt = (Optimizable)optimizer.getOuterTable();
+            AccessPath ap = opt.getCurrentAccessPath();
+            if (ap.getNumUnusedLeadingIndexFields() > 0)
+                reduceEstimatedCosts(costEstimate);
+        }
+        else if (currentAccessPath.getNumUnusedLeadingIndexFields() > 0) {
+            reduceEstimatedCosts(costEstimate);
+        }
     }
 
     @Override

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -5104,4 +5104,15 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
         return null;
     }
 
+    public boolean hasLeadingIndexColumnStartOrStopKey() {
+        for (int i = 0; i < size(); i++) {
+            Predicate p = (Predicate) getOptPredicate(i);
+            if (p.isStartKey() || p.isStopKey()) {
+                if (p.getIndexPosition() == 0)
+                    return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/BaseActivation.java
@@ -214,6 +214,7 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
 
     protected List<Pair<ExecRow, ExecRow>> keyRows;
     protected List<ExecRow> firstIndexColumnKeys;
+    private boolean skipBuildOfFirstKeyColumn = false;
 
     private long numRowsSeen = 0L;
     //
@@ -1728,6 +1729,14 @@ public abstract class BaseActivation implements CursorActivation, GeneratedByteC
 
     public boolean getSameStartStopScanKeyPrefix() {
         return sameStartStopScanKeyPrefix;
+    }
+
+    public void setSkipBuildOfFirstKeyColumn(boolean skipBuildOfFirstKeyColumn) {
+        this.skipBuildOfFirstKeyColumn = skipBuildOfFirstKeyColumn;
+    }
+
+    public boolean getSkipBuildOfFirstKeyColumn() {
+        return skipBuildOfFirstKeyColumn;
     }
 
     public void setFirstIndexColumnKeys(List<ExecRow> firstIndexColumnKeys) {

--- a/hbase_storage/pom.xml
+++ b/hbase_storage/pom.xml
@@ -28,11 +28,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.splicemachine</groupId>
-            <artifactId>splice_machine</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/hbase_storage/pom.xml
+++ b/hbase_storage/pom.xml
@@ -28,6 +28,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.splicemachine</groupId>
+            <artifactId>splice_machine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/MemStoreFlushAwareScanner.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.concurrent.atomic.AtomicReference;
+
+import com.splicemachine.derby.hbase.KeyPrefixProbingFilter;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
@@ -76,7 +78,8 @@ public class MemStoreFlushAwareScanner extends StoreScanner implements RegionSca
         this.stopRow = Bytes.equals(scan.getStopRow(), HConstants.EMPTY_END_ROW) ? null : scan.getStopRow();
         this.filter = scan.getFilter();
         this.batch = scan.getBatch();
-        this.checkFilter = filter instanceof MultiRowRangeFilter;
+        this.checkFilter = filter instanceof MultiRowRangeFilter ||
+                           filter instanceof KeyPrefixProbingFilter;
     }
     
     protected boolean isStopRow(Cell peek) {

--- a/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
+++ b/hbase_storage/src/main/java/com/splicemachine/access/client/SkeletonClientSideRegionScanner.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.access.client;
 
+import com.splicemachine.derby.hbase.KeyPrefixProbingFilter;
 import org.apache.hadoop.hbase.regionserver.*;
 import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.utils.SpliceLogUtils;
@@ -271,7 +272,8 @@ public abstract class SkeletonClientSideRegionScanner implements RegionScanner{
 
     private KeyValueScanner getMemStoreScanner() throws IOException {
         Scan memScan = new Scan(scan);
-        if (!(scan.getFilter() instanceof MultiRowRangeFilter))   
+        if (!(scan.getFilter() instanceof MultiRowRangeFilter) &&
+            !(scan.getFilter() instanceof KeyPrefixProbingFilter))
             memScan.setFilter(null);   // Remove SamplingFilter if the scan has it
         memScan.setAsyncPrefetch(false); // async would keep buffering rows indefinitely
         memScan.setReadType(Scan.ReadType.PREAD);

--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/KeyPrefixProbingFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/KeyPrefixProbingFilter.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.hbase;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.ZeroCopyLiteralByteString;
+import com.splicemachine.access.client.SpliceKVComparator;
+import com.splicemachine.coprocessor.SpliceMessage;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.derby.utils.marshall.dvd.DescriptorSerializer;
+import com.splicemachine.derby.utils.marshall.dvd.TypeProvider;
+import com.splicemachine.derby.utils.marshall.dvd.VersionedSerializers;
+import com.splicemachine.encoding.MultiFieldDecoder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.FilterBase;
+import org.apache.hadoop.hbase.filter.MultiRowRangeFilter;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.FilterProtos;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.Writable;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static com.splicemachine.encoding.MultiFieldDecoder.create;
+import static org.apache.hadoop.hbase.filter.Filter.ReturnCode.INCLUDE;
+import static org.apache.hadoop.hbase.filter.Filter.ReturnCode.SEEK_NEXT_USING_HINT;
+
+public class KeyPrefixProbingFilter extends FilterBase implements Writable{
+    @SuppressWarnings("unused")
+    private static final long serialVersionUID=1l;
+    private byte[] currentPrefix = new byte[0];
+    private int currentPrefixLength = 0;
+    private byte[] nextRowkeyHint = new byte[0];
+    private int nextRowkeyHintLength = 0;
+
+    private DataValueDescriptor firstKeyColumnDVD;
+    private int typeFormatId;
+    private byte[] firstKeyColumnDVDAsByteArray;
+    private String tableVersion;
+    private TypeProvider typeProvider;
+    private DescriptorSerializer[] serializers;
+    private DescriptorSerializer   serializer;
+    private ReturnCode currentReturnCode = ReturnCode.INCLUDE;
+    private MultiFieldDecoder decoder = create();
+    protected Filter secondaryFilter;
+
+    public KeyPrefixProbingFilter(){
+        super();
+    }
+
+    public KeyPrefixProbingFilter(DataValueDescriptor firstKeyColumnDVD, String tableVersion, Filter secondaryFilter){
+        this();
+        if (firstKeyColumnDVD == null)
+            throw new RuntimeException();
+        if (tableVersion == null)
+            throw new RuntimeException();
+        if (!(secondaryFilter instanceof MultiRowRangeFilter))
+            throw new RuntimeException();
+        MultiRowRangeFilter multiRowRangeFilter = (MultiRowRangeFilter)secondaryFilter;
+
+        this.firstKeyColumnDVD = firstKeyColumnDVD.cloneValue(true);
+        this.typeFormatId      = this.firstKeyColumnDVD.getTypeFormatId();
+        this.tableVersion      = tableVersion;
+        if (secondaryFilter instanceof SpliceMultiRowRangeFilter)
+            this.secondaryFilter   = secondaryFilter;
+        else
+            this.secondaryFilter = new SpliceMultiRowRangeFilter(new ArrayList<>(multiRowRangeFilter.getRowRanges()));
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(firstKeyColumnDVD);
+            oos.flush();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        firstKeyColumnDVDAsByteArray = bos.toByteArray();
+        populateSerializers();
+    }
+
+    public byte [] getFirstKeyColumnDVDAsByteArray() {
+        return firstKeyColumnDVDAsByteArray;
+    }
+
+    public String getTableVersion() {
+        return tableVersion;
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "intentional")
+    private void populateSerializers() {
+        typeProvider = VersionedSerializers.typesForVersion(tableVersion);
+        DataValueDescriptor [] dvdArray = new DataValueDescriptor[1];
+        dvdArray[0] = firstKeyColumnDVD;
+        serializers = VersionedSerializers.forVersion(tableVersion,true).getSerializers(dvdArray);
+        serializer = serializers[0];
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException{
+        out.writeInt(firstKeyColumnDVDAsByteArray.length);
+        out.write(firstKeyColumnDVDAsByteArray);
+        out.writeUTF(tableVersion);
+        byte [] filterAsBytes = secondaryFilter.toByteArray();
+        out.writeInt(filterAsBytes.length);
+        out.write(filterAsBytes);
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException{
+        firstKeyColumnDVDAsByteArray=new byte[in.readInt()];
+        in.readFully(firstKeyColumnDVDAsByteArray);
+        try {
+            ByteArrayInputStream bis = new ByteArrayInputStream(firstKeyColumnDVDAsByteArray);
+            ObjectInput ois = new ObjectInputStream(bis);
+            firstKeyColumnDVD = (DataValueDescriptor) ois.readObject();
+            typeFormatId = firstKeyColumnDVD.getTypeFormatId();
+        }
+        catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        }
+        tableVersion = in.readUTF();
+        byte [] filterAsBytes = new byte[in.readInt()];
+        in.readFully(filterAsBytes);
+        try {
+            secondaryFilter = SpliceMultiRowRangeFilter.parseFrom(filterAsBytes);
+        }
+        catch (DeserializationException de) {
+            throw new IOException(de);
+        }
+        populateSerializers();
+    }
+
+    @Override
+    public ReturnCode filterCell(final Cell ignored) throws IOException {
+        if (currentReturnCode == INCLUDE)
+            return secondaryFilter.filterCell(ignored);
+        return currentReturnCode;
+    }
+
+    @Override
+    public boolean filterRowKey(Cell firstRowCell) throws IOException {
+        byte[] rowArr = firstRowCell.getRowArray();
+        int length = firstRowCell.getRowLength();
+        int offset = firstRowCell.getRowOffset();
+
+        decoder.set(rowArr, offset, length);
+        int prefixLength = keyColumnByteLength();
+
+        if (prefixLength <= 0 || SpliceKVComparator.isSpecialTimestamp(firstRowCell)) {
+            currentReturnCode = INCLUDE;
+            return false;
+        }
+
+        int compareResult;
+        boolean savePrefix = false;
+        if (currentPrefix.length == 0) {
+            compareResult = 0;
+            savePrefix = true;
+        }
+        else {
+            compareResult = Bytes.compareTo(rowArr, offset, prefixLength, currentPrefix, 0, currentPrefixLength);
+            if (compareResult > 0)
+                savePrefix = true;
+        }
+        if (savePrefix) {
+            currentReturnCode = INCLUDE;
+            if (currentPrefix.length < prefixLength)
+                currentPrefix = new byte[prefixLength*2];
+            if (nextRowkeyHint.length < prefixLength)
+                nextRowkeyHint = new byte[prefixLength*2];
+
+            currentPrefixLength = prefixLength;
+            System.arraycopy(rowArr, offset, currentPrefix, 0, prefixLength);
+            System.arraycopy(rowArr, offset, nextRowkeyHint, 0, prefixLength);
+            // Add the delimiter
+            nextRowkeyHint[prefixLength-1] = 0x01;
+            nextRowkeyHintLength = prefixLength;
+        }
+        if (compareResult < 0)
+            currentReturnCode = SEEK_NEXT_USING_HINT;
+        else {
+            if (currentReturnCode == SEEK_NEXT_USING_HINT)
+                return false;
+
+            Cell partialCell =
+                PrivateCellUtil.createFirstOnRow(rowArr, offset + prefixLength,
+                                                 (short) (length - prefixLength));
+            boolean filterAllRemaining = secondaryFilter.filterRowKey(partialCell);
+
+            if (filterAllRemaining) {
+                currentReturnCode = SEEK_NEXT_USING_HINT;
+                secondaryFilter.reset();
+            }
+        }
+
+        return false;
+    }
+
+    // decoder.set must be called before calling this function
+    private int keyColumnByteLength() {
+        int length;
+        if(typeProvider.isScalar(typeFormatId))
+            length = decoder.skipLong();
+        else if(typeProvider.isFloat(typeFormatId))
+            length = decoder.skipFloat();
+        else if(typeProvider.isDouble(typeFormatId))
+            length = decoder.skipDouble();
+        else
+            length = decoder.skip();
+
+        return length;
+    }
+
+    @Override
+    public Cell getNextCellHint(Cell currentKV) throws IOException {
+        if (currentReturnCode == INCLUDE) {
+
+            Cell secondaryHint = secondaryFilter.getNextCellHint(currentKV);
+            byte[] rowArr = secondaryHint.getRowArray();
+            int length = secondaryHint.getRowLength();
+            int offset = secondaryHint.getRowOffset();
+
+            int newRowKeyLength = currentPrefixLength + length;
+            byte[] rowHint = new byte[newRowKeyLength];
+            System.arraycopy(currentPrefix, 0, rowHint, 0, currentPrefixLength);
+            System.arraycopy(rowArr, offset, rowHint, currentPrefixLength, length);
+            return PrivateCellUtil.createFirstOnRow(rowHint, 0, (short) rowHint.length);
+        }
+        else
+            return PrivateCellUtil.createFirstOnRow(nextRowkeyHint, 0, (short) nextRowkeyHintLength);
+    }
+
+    /**
+     * @return The filter serialized using pb
+     */
+    @Override
+    public byte[] toByteArray() throws IOException {
+        SpliceMessage.KeyPrefixProbingFilterMessage.Builder builder = SpliceMessage.KeyPrefixProbingFilterMessage.newBuilder();
+		builder.setFirstKeyColumnDVDAsByteArray(ZeroCopyLiteralByteString.wrap(firstKeyColumnDVDAsByteArray));
+		builder.setTableVersion(tableVersion);
+		ByteString filterAsBytes = ByteString.copyFrom(secondaryFilter.toByteArray());
+        builder.setSecondaryFilter(filterAsBytes);
+        return builder.build().toByteArray();
+    }
+
+    /**
+     * @param data A pb serialized {@code KeyPrefixProbingFilter} instance
+     * @return An instance of {@code KeyPrefixProbingFilter} made from <code>bytes</code>
+     * @throws org.apache.hadoop.hbase.exceptions.DeserializationException
+     * @see #toByteArray
+     */
+    @SuppressWarnings("unused") //Deserialization method-- REQUIRED
+    public static KeyPrefixProbingFilter parseFrom(final byte [] data) throws DeserializationException{
+        SpliceMessage.KeyPrefixProbingFilterMessage proto;
+        try{
+            proto=SpliceMessage.KeyPrefixProbingFilterMessage.parseFrom(data);
+        }catch(InvalidProtocolBufferException e){
+            throw new DeserializationException(e);
+        }
+
+        try {
+            ByteArrayInputStream bis = new ByteArrayInputStream(proto.getFirstKeyColumnDVDAsByteArray().toByteArray());
+            ObjectInput in = new ObjectInputStream(bis);
+            DataValueDescriptor dvd = (DataValueDescriptor) in.readObject();
+
+            MultiRowRangeFilter secondaryFilter =
+                 MultiRowRangeFilter.parseFrom(proto.getSecondaryFilter().toByteArray());
+
+            return new KeyPrefixProbingFilter(dvd, proto.getTableVersion(), secondaryFilter);
+        }
+        catch (Exception e) {
+            throw new DeserializationException(e);
+        }
+    }
+
+    boolean areSerializedFieldsEqual(Filter o) {
+        if (o == this) return true;
+        if (!(o instanceof KeyPrefixProbingFilter)) return false;
+
+        KeyPrefixProbingFilter other = (KeyPrefixProbingFilter)o;
+        return this.getTableVersion().equals(other.getTableVersion()) &&
+               Bytes.equals(this.getFirstKeyColumnDVDAsByteArray(),
+                            other.getFirstKeyColumnDVDAsByteArray())  &&
+               this.secondaryFilter.equals(other.secondaryFilter);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+    return obj instanceof Filter && areSerializedFieldsEqual((Filter) obj);
+    }
+
+    @Override
+    public int hashCode() {
+        Object[] objectsToHash = { firstKeyColumnDVDAsByteArray, tableVersion, secondaryFilter };
+        return Arrays.deepHashCode(objectsToHash);
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
@@ -20,6 +20,7 @@
 package com.splicemachine.derby.hbase;
 
 import com.splicemachine.db.iapi.error.StandardException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.PrivateCellUtil;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
 
+@SuppressFBWarnings(value="HE_EQUALS_NO_HASHCODE", justification="Intentional")
 public class SpliceMultiRowRangeFilter extends MultiRowRangeFilter {
 
     private final RangeIteration ranges;

--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2012-2021 Splice Machine Inc.  All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splicemachine.derby.hbase;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.filter.MultiRowRangeFilter;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.FilterProtos;
+import org.apache.hbase.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.splicemachine.db.shared.common.reference.SQLState.LANG_INTERNAL_ERROR;
+
+public class SpliceMultiRowRangeFilter extends MultiRowRangeFilter {
+
+    private final RangeIteration ranges;
+    private RowRange range;
+    private int index;
+    private boolean done = false;
+    private ReturnCode currentReturnCode;
+    private static final int ROW_BEFORE_FIRST_RANGE = -1;
+
+  /**
+   * @param list A list of <code>RowRange</code>
+   */
+    public SpliceMultiRowRangeFilter(List<RowRange> list) {
+        super(list);
+        this.ranges = new RangeIteration(super.getRowRanges());
+    }
+
+    @Override
+    public void reset() throws IOException {
+        done = false;
+        ranges.setFoundFirstRange(false);
+        currentReturnCode = ReturnCode.INCLUDE;
+    }
+
+    @Override
+    public boolean filterAllRemaining() {
+        return false;
+    }
+
+    @Override
+    public ReturnCode filterCell(final Cell ignored) {
+      return currentReturnCode;
+    }
+
+    @Override
+    public Cell getNextCellHint(Cell currentKV) {
+        // skip to the next range's start row
+        // #getComparisonData lets us avoid the `if (reversed)` branch
+        byte[] comparisonData = range.getComparisonData();
+        return PrivateCellUtil.createFirstOnRow(comparisonData, 0, (short) comparisonData.length);
+    }
+
+    @Override
+    public boolean filterRowKey(Cell firstRowCell) {
+        if (filterAllRemaining()) return true;
+
+        // N.b. We can only do this after we're iterating over records. If we try to do
+        // it before, the Scan (and this filter) may not yet be fully initialized. This is a
+        // wart on Filter and something that'd be nice to clean up (like CP's in HBase2.0)
+        if (!ranges.isInitialized()) {
+          ranges.initialize(isReversed());
+        }
+
+        // If it is the first time of running, calculate the current range index for
+        // the row key. If index is out of bound which happens when the start row
+        // user sets is after the largest stop row of the ranges, stop the scan.
+        // If row key is after the current range, find the next range and update index.
+        byte[] rowArr = firstRowCell.getRowArray();
+        int length = firstRowCell.getRowLength();
+        int offset = firstRowCell.getRowOffset();
+        if (!ranges.hasFoundFirstRange() || !range.contains(rowArr, offset, length)) {
+          byte[] rowkey = CellUtil.cloneRow(firstRowCell);
+          index = ranges.getNextRangeIndex(rowkey);
+          if (ranges.isIterationComplete(index)) {
+            done = true;
+            currentReturnCode = ReturnCode.NEXT_ROW;
+            ranges.setFoundFirstRange(false);
+            return true;
+          }
+          if(index != ROW_BEFORE_FIRST_RANGE) {
+            range = ranges.get(index);
+          } else {
+            range = ranges.get(0);
+          }
+          if (ranges.isExclusive()) {
+            ranges.resetExclusive();
+            currentReturnCode = ReturnCode.NEXT_ROW;
+            return false;
+          }
+          if (!ranges.hasFoundFirstRange()) {
+            if(index != ROW_BEFORE_FIRST_RANGE) {
+              currentReturnCode = ReturnCode.INCLUDE;
+            } else {
+              currentReturnCode = ReturnCode.SEEK_NEXT_USING_HINT;
+            }
+            ranges.setFoundFirstRange(true);
+          } else {
+            if (range.contains(rowArr, offset, length)) {
+              currentReturnCode = ReturnCode.INCLUDE;
+            } else {
+              currentReturnCode = ReturnCode.SEEK_NEXT_USING_HINT;
+            }
+          }
+        } else {
+          currentReturnCode = ReturnCode.INCLUDE;
+        }
+        return false;
+    }
+
+    public static SpliceMultiRowRangeFilter parseFrom(final byte[] pbBytes)
+        throws DeserializationException {
+        FilterProtos.MultiRowRangeFilter proto;
+        try {
+          proto = FilterProtos.MultiRowRangeFilter.parseFrom(pbBytes);
+        } catch (InvalidProtocolBufferException e) {
+          throw new DeserializationException(e);
+        }
+        int length = proto.getRowRangeListCount();
+        List<FilterProtos.RowRange> rangeProtos = proto.getRowRangeListList();
+        List<RowRange> rangeList = new ArrayList<>(length);
+        for (FilterProtos.RowRange rangeProto : rangeProtos) {
+          RowRange range = new RowRange(rangeProto.hasStartRow() ? rangeProto.getStartRow()
+              .toByteArray() : null, rangeProto.getStartRowInclusive(), rangeProto.hasStopRow() ?
+                  rangeProto.getStopRow().toByteArray() : null, rangeProto.getStopRowInclusive());
+          rangeList.add(range);
+        }
+        return new SpliceMultiRowRangeFilter(rangeList);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof SpliceMultiRowRangeFilter && super.equals((Filter) obj);
+    }
+
+    private static class RangeIteration {
+        private boolean exclusive = false;
+        private boolean initialized = false;
+        private boolean foundFirstRange = false;
+        private final List<RowRange> sortedAndMergedRanges;
+        private List<? extends RowRange> ranges;
+
+        public RangeIteration(List<RowRange> sortedAndMergedRanges) {
+          this.sortedAndMergedRanges = sortedAndMergedRanges;
+        }
+
+        void initialize(boolean reversed) {
+          // Avoid double initialization
+          assert !this.initialized;
+          if (reversed) {
+            throw new RuntimeException(StandardException.newException(LANG_INTERNAL_ERROR,
+                                       "SpliceMultiRowRangeFilter does not support reverse scan"));
+          } else {
+            this.ranges = sortedAndMergedRanges;
+          }
+          this.initialized = true;
+        }
+
+        /**
+         * Calculates the position where the given rowkey fits in the ranges list.
+         *
+         * @param rowKey the row key to calculate
+         * @return index the position of the row key
+         */
+        public int getNextRangeIndex(byte[] rowKey) {
+          RowRange temp;
+          temp = new RowRange(rowKey, true, null, true);
+          // Because we make sure that `ranges` has the correct natural ordering (given it containing
+          // RowRange or ReverseRowRange objects). This keeps us from having to have two different
+          // implementations below.
+          final int index = Collections.binarySearch(ranges, temp);
+          if (index < 0) {
+            int insertionPosition = -index - 1;
+            // check if the row key in the range before the insertion position
+            if (insertionPosition != 0 && ranges.get(insertionPosition - 1).contains(rowKey)) {
+              return insertionPosition - 1;
+            }
+            // check if the row key is before the first range
+            if (insertionPosition == 0 && !ranges.get(insertionPosition).contains(rowKey)) {
+              return ROW_BEFORE_FIRST_RANGE;
+            }
+            if (!foundFirstRange) {
+              foundFirstRange = true;
+            }
+            return insertionPosition;
+          }
+          // the row key equals one of the start keys, and the the range exclude the start key
+          if(ranges.get(index).isSearchRowInclusive() == false) {
+            exclusive = true;
+          }
+          return index;
+        }
+
+        /**
+         * Sets {@link #foundFirstRange} to {@code true}, indicating that we found a matching row range.
+         */
+        public void setFoundFirstRange(boolean foundFirstRange) {
+          this.foundFirstRange = foundFirstRange;
+        }
+
+        /**
+         * Gets the RowRange at the given offset.
+         */
+        @SuppressWarnings("unchecked")
+        public <T extends RowRange> T get(int i) {
+          return (T) ranges.get(i);
+        }
+
+        /**
+         * Returns true if the first matching row range was found.
+         */
+        public boolean hasFoundFirstRange() {
+          return foundFirstRange;
+        }
+
+        /**
+         * Returns true if the current range's key is exclusive
+         */
+        public boolean isExclusive() {
+          return exclusive;
+        }
+
+        /**
+         * Resets the exclusive flag.
+         */
+        public void resetExclusive() {
+          exclusive = false;
+        }
+
+        /**
+         * Returns true if this class has been initialized by calling {@link #initialize(boolean)}.
+         */
+        public boolean isInitialized() {
+          return initialized;
+        }
+
+        /**
+         * Returns true if we exhausted searching all row ranges.
+         */
+        public boolean isIterationComplete(int index) {
+          return index >= ranges.size();
+        }
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
+++ b/hbase_storage/src/main/java/com/splicemachine/storage/HScan.java
@@ -14,6 +14,9 @@
 
 package com.splicemachine.storage;
 
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.derby.hbase.KeyPrefixProbingFilter;
 import com.splicemachine.utils.Pair;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.Filter;
@@ -56,6 +59,9 @@ public class HScan implements DataScan {
      * it to the {@link Scan} held in this {@link HScan} as a {@link Filter}.
      *
      * @param rowkeyPairs the list of [startKey, stopKey) pairs to convert.
+     * @param skipStartStopKeyAdjustment if true, do not adjust the start and
+     *                                   stop keys using the first and last
+     *                                   row ranges.
      *
      * @return if this {@link HScan} currently has no filter, build a new
      * {@link MultiRowRangeFilter} out of {@code rowkeyPairs} and attach it
@@ -72,7 +78,8 @@ public class HScan implements DataScan {
      * @see     Scan
      */
     @Override
-    public void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs) throws IOException {
+    public void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs,
+                                      boolean skipStartStopKeyAdjustment) throws IOException {
         if (rowkeyPairs == null || rowkeyPairs.size() < 1) {
             return;
         }
@@ -102,14 +109,16 @@ public class HScan implements DataScan {
             byte[] filterStopRow = sortedRanges.get(sortedRanges.size()-1).getStopRow();
             // Only replace the current start/stop row if those from the filter
             // are more restrictive.
-            if (currentStartRow == null     ||
-                currentStartRow.length == 0 ||
-                Bytes.compareTo(currentStartRow, filterStartRow) < 0)
-                scan.withStartRow(filterStartRow);
-            if (currentStopRow == null     ||
-                currentStopRow.length == 0 ||
-                Bytes.compareTo(currentStopRow, filterStopRow) > 0)
-                scan.withStopRow(filterStopRow);
+            if (!skipStartStopKeyAdjustment) {
+                if (currentStartRow == null ||
+                    currentStartRow.length == 0 ||
+                    Bytes.compareTo(currentStartRow, filterStartRow) < 0)
+                    scan.withStartRow(filterStartRow);
+                if (currentStopRow == null ||
+                    currentStopRow.length == 0 ||
+                    Bytes.compareTo(currentStopRow, filterStopRow) > 0)
+                    scan.withStopRow(filterStopRow);
+            }
         }
     }
 
@@ -239,5 +248,12 @@ public class HScan implements DataScan {
     @Override
     public void setSmall(boolean small) {
         scan.setSmall(small);
+    }
+
+    @Override
+    public void attachKeyPrefixFilter(DataValueDescriptor firstColumn, String tableVersion) throws IOException {
+        Filter secondaryFilter = scan.getFilter();
+        scan.setFilter(null);
+        filter(new HFilterWrapper(new KeyPrefixProbingFilter(firstColumn, tableVersion, secondaryFilter)));
     }
 }

--- a/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
@@ -16,6 +16,7 @@ package com.splicemachine.storage;
 
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.encoding.Encoding;
 import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -150,7 +151,7 @@ public class MScan implements DataScan{
     }
 
     @Override
-    public void attachKeyPrefixFilter(DataValueDescriptor firstColumn, String tableVersion) throws IOException {
+    public void attachKeyPrefixFilter(Encoding.SpliceEncodingKind firstKeyColumnEncodingKind) throws IOException {
         // No implementation on mem platform for now.
         // If this function is getting called, it is an error condition.
         throw new IOException();

--- a/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MScan.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.storage;
 
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.utils.Pair;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -35,7 +37,8 @@ public class MScan implements DataScan{
     private boolean descending = false;
 
     @Override
-    public void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs)  throws IOException {
+    public void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs,
+                                      boolean skipStartStopKeyAdjustment)  throws IOException {
         // No implementation on mem platform for now.
         // If this function is getting called, it is an error condition.
         throw new IOException();
@@ -144,5 +147,12 @@ public class MScan implements DataScan{
 
     @Override
     public void setSmall(boolean small) {
+    }
+
+    @Override
+    public void attachKeyPrefixFilter(DataValueDescriptor firstColumn, String tableVersion) throws IOException {
+        // No implementation on mem platform for now.
+        // If this function is getting called, it is an error condition.
+        throw new IOException();
     }
 }

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
@@ -16,6 +16,7 @@ package com.splicemachine.storage;
 
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.encoding.Encoding;
 import com.splicemachine.utils.Pair;
 
 import java.io.IOException;
@@ -69,5 +70,5 @@ public interface DataScan extends Attributable{
     void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs,
                                boolean skipStartStopKeyAdjustment) throws IOException;
 
-    void attachKeyPrefixFilter(DataValueDescriptor firstColumn, String tableVersion) throws IOException;
+    void attachKeyPrefixFilter(Encoding.SpliceEncodingKind firstKeyColumnEncodingKind) throws IOException;
 }

--- a/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
+++ b/splice_access_api/src/main/java/com/splicemachine/storage/DataScan.java
@@ -14,6 +14,8 @@
 
 package com.splicemachine.storage;
 
+import com.splicemachine.db.iapi.sql.execute.ExecRow;
+import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.utils.Pair;
 
 import java.io.IOException;
@@ -64,6 +66,8 @@ public interface DataScan extends Attributable{
     // that that excludes rows not covered by any range.
     // Currently not supported on the mem platform, where attempting to add this
     // filter will throw an IOException.
-    void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs) throws IOException;
+    void addRowkeyRangesFilter(List<Pair<byte[],byte[]>> rowkeyPairs,
+                               boolean skipStartStopKeyAdjustment) throws IOException;
 
+    void attachKeyPrefixFilter(DataValueDescriptor firstColumn, String tableVersion) throws IOException;
 }

--- a/splice_encoding/src/main/java/com/splicemachine/encoding/Encoding.java
+++ b/splice_encoding/src/main/java/com/splicemachine/encoding/Encoding.java
@@ -37,6 +37,13 @@ public final class Encoding {
 
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
+    public enum SpliceEncodingKind {
+        SCALAR,
+        FLOAT,
+        DOUBLE,
+        OTHER
+    }
+
     private Encoding(){} //can't construct me!
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -237,7 +237,8 @@ public class TriggerNewTransitionRows
                     false,   // rowIdKey
                     conglomerate,
                     null,
-                    null);
+                    null,
+                    false);
 
                     s.cacheRows(SCAN_CACHE_SIZE).batchCells(-1);
                     deSiify(s);

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1ScanCostEstimator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1ScanCostEstimator.java
@@ -128,9 +128,8 @@ public class V1ScanCostEstimator extends AbstractScanCostEstimator {
         double closeLatency = scc.getCloseLatency();
         double localLatency = scc.getLocalLatency();
         double remoteLatency = scc.getRemoteLatency();
-        // IndexPrefixIteration is not currently parallel, so penalize by a factor of the parallelism.
         double remoteCost = (openLatency + closeLatency) +
-                (numFirstIndexColumnProbes*2*scc.getParallelism())*remoteLatency*(1+colSizeFactor/1024d) +
+                (numFirstIndexColumnProbes*2)*remoteLatency*(1+colSizeFactor/1024d) +
                 totalRowCount*totalSelectivity*remoteLatency*(1+colSizeFactor/1024d); // Per Kb
 
         assert openLatency >= 0 : "openLatency cannot be negative -> " + openLatency;
@@ -148,8 +147,8 @@ public class V1ScanCostEstimator extends AbstractScanCostEstimator {
         double congAverageWidth = scc.getConglomerateAvgRowWidth();
         double baseCost = openLatency+closeLatency;
         assert numFirstIndexColumnProbes >= 0;
-        // IndexPrefixIteration is not currently parallel, so penalize by a factor of the parallelism.
-        baseCost += (numFirstIndexColumnProbes*2*scc.getParallelism())*localLatency*(1+congAverageWidth/100d);
+
+        baseCost += (numFirstIndexColumnProbes*2)*localLatency*(1+congAverageWidth/100d);
         baseCost += (totalRowCount*baseTableSelectivity*localLatency*(1+congAverageWidth/100d));
         assert congAverageWidth >= 0 : "congAverageWidth cannot be negative -> " + congAverageWidth;
         assert baseCost >= 0 : "baseCost cannot be negative -> " + baseCost;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
@@ -290,14 +290,15 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
 
     @Override
     public DataScan getScan(TxnView txn) throws StandardException {
-        return getScan(txn, null, null, null, null, null, false, null);
+        return getScan(txn, null, null, null, null, null, false, null, false);
     }
 
     @Override
     public DataScan getScan(TxnView txn, ExecRow startKeyOverride, int[] keyDecodingMap, ExecRow stopKeyPrefix,
                             List<Pair<ExecRow, ExecRow>> keyRows, DataValueDescriptor scanKeyPrefix,
                             boolean sameStartStopScanKeyPrefix,
-                            List<ExecRow> firstIndexColumnKeys) throws StandardException {
+                            List<ExecRow> firstIndexColumnKeys,
+                            boolean skipBuildOfFirstKeyColumn) throws StandardException {
         boolean sameStartStop = startKeyOverride == null && sameStartStopPosition;
         ExecRow startPosition = getStartPosition();
         ExecRow stopPosition = sameStartStop ? startPosition : getStopPosition();
@@ -377,10 +378,12 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
                 rowIdKey,
                 conglomerate,
                 keyRows,
-                firstIndexColumnKeys);
+                firstIndexColumnKeys,
+                skipBuildOfFirstKeyColumn);
     }
 
-    public List<Pair<byte[],byte[]>> getStartStopKeys(TxnView txn, List<ExecRow> scanKeyPrefixes, int[] keyDecodingMap, DataValueDescriptor[] probeValues) throws StandardException {
+    public List<Pair<byte[],byte[]>> getStartStopKeys(TxnView txn, List<ExecRow> scanKeyPrefixes, int[] keyDecodingMap,
+                                                      DataValueDescriptor[] probeValues, boolean skipBuildOfFirstKeyColumn) throws StandardException {
         boolean sameStartStop = sameStartStopPosition;
         ExecRow startPosition;
         ExecRow stopPosition;
@@ -435,7 +438,8 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
                     tableVersion,
                     rowIdKey,
                     getResultRow(),
-                    scanKeyPrefix);
+                    scanKeyPrefix,
+                    skipBuildOfFirstKeyColumn);
                 startStopKeys.add(startStopKey);
             }
         }
@@ -489,7 +493,9 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
 
 
     @Override
-    public List<DataScan> getScans(TxnView txn, List<ExecRow> scanKeyPrefixes, Activation activation, int[] keyDecodingMap) throws StandardException {
+    public List<DataScan> getScans(TxnView txn, List<ExecRow> scanKeyPrefixes,
+                                   Activation activation, int[] keyDecodingMap,
+                                   boolean skipBuildOfFirstKeyColumn) throws StandardException {
         throw new RuntimeException("getScans is not supported");
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -29,6 +29,7 @@ import com.splicemachine.derby.stream.iapi.OperationContext;
 import com.splicemachine.derby.stream.iapi.ScanSetBuilder;
 import com.splicemachine.si.api.txn.TxnView;
 import com.splicemachine.storage.DataScan;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -206,6 +207,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
     }
 
     @Override
+    @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Intentional")
     public DataSet<ExecRow> getDataSet(DataSetProcessor dsp) throws StandardException {
         if (!isOpen)
             throw new IllegalStateException("Operation is not open");

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -226,8 +226,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
                 deSiify(scan);
                 if (firstRowOfIndexPrefixIteration != null) {
                     try {
-                        scan.attachKeyPrefixFilter(firstRowOfIndexPrefixIteration.getColumn(1),
-                                                   tableVersion);
+                        attachKeyPrefixFilter(scan, firstRowOfIndexPrefixIteration.getColumn(1));
                     } catch (IOException e) {
                         throw StandardException.plainWrapException(e);
                     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -312,7 +312,8 @@ public abstract class ScanOperation extends SpliceBaseOperation {
                 ((BaseActivation)activation).getKeyRows(),
                 ((BaseActivation)activation).getScanKeyPrefix(),
                 ((BaseActivation)activation).getSameStartStopScanKeyPrefix(),
-                ((BaseActivation)activation).getFirstIndexColumnKeys());
+                ((BaseActivation)activation).getFirstIndexColumnKeys(),
+                ((BaseActivation)activation).getSkipBuildOfFirstKeyColumn());
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.derby.impl.sql.execute.operations;
 
+import com.splicemachine.EngineDriver;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
 import com.splicemachine.db.iapi.services.io.FormatableBitSet;
@@ -28,9 +29,11 @@ import com.splicemachine.derby.iapi.sql.execute.SpliceOperationContext;
 import com.splicemachine.derby.stream.function.SetCurrentLocatedRowAndRowKeyFunction;
 import com.splicemachine.derby.stream.iapi.DataSet;
 import com.splicemachine.derby.stream.iapi.DataSetProcessor;
+import com.splicemachine.derby.stream.iapi.ScanSetBuilder;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.storage.DataScan;
 import com.splicemachine.utils.ByteSlice;
 import com.splicemachine.utils.SpliceLogUtils;
 import org.apache.log4j.Logger;
@@ -56,6 +59,7 @@ public class TableScanOperation extends ScanOperation{
     protected int[] baseColumnMap;
     protected static final String NAME=TableScanOperation.class.getSimpleName().replaceAll("Operation","");
     protected byte[] tableNameBytes;
+    protected ExecRow firstRowOfIndexPrefixIteration = null;
 
     /**
      *
@@ -345,11 +349,21 @@ public class TableScanOperation extends ScanOperation{
         // we currently don't support external tables in Control, so this shouldn't happen
         assert storedAs == null || !( dsp.getType() == DataSetProcessor.Type.CONTROL && !storedAs.isEmpty() )
                 : "tried to access external table " + tableDisplayName + ":" + tableName + " over control/OLTP";
+
+        DataScan dataScan = getNonSIScan();
+        if (firstRowOfIndexPrefixIteration != null) {
+            try {
+                dataScan.attachKeyPrefixFilter(firstRowOfIndexPrefixIteration.getColumn(1), tableVersion);
+            } catch (IOException e) {
+                throw StandardException.plainWrapException(e);
+            }
+        }
+
         return dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
                 .tableDisplayName(tableDisplayName)
                 .activation(activation)
                 .transaction(txn)
-                .scan(getNonSIScan())
+                .scan(dataScan)
                 .template(currentTemplate)
                 .tableVersion(tableVersion)
                 .indexName(indexName)
@@ -373,6 +387,52 @@ public class TableScanOperation extends ScanOperation{
                 .map(new SetCurrentLocatedRowAndRowKeyFunction<>(operationContext));
     }
 
+    /**
+     * @return the Table Scan DataSet which probes each first index column via KeyPrefixProbingFilter
+     */
+    public DataSet<ExecRow> getKeyPrefixFilterScan(ExecRow firstRow, DataSetProcessor dsp) throws StandardException{
+        TxnView txn = getCurrentTransaction();
+        operationContext = dsp.createOperationContext(this);
+
+        DataScan dataScan = getNonSIScan();
+        try {
+            dataScan.attachKeyPrefixFilter(firstRow.getColumn(1), tableVersion);
+        }
+        catch (IOException e) {
+            throw StandardException.plainWrapException(e);
+        }
+
+        DataSet<ExecRow> dataSet =
+        dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
+                .tableDisplayName(tableDisplayName)
+                .activation(activation)
+                .transaction(txn)
+                .scan(dataScan)
+                .template(currentTemplate)
+                .tableVersion(tableVersion)
+                .indexName(indexName)
+                .reuseRowLocation(true)
+                .keyColumnEncodingOrder(scanInformation.getColumnOrdering())
+                .keyColumnSortOrder(scanInformation.getConglomerate().getAscDescInfo())
+                .keyColumnTypes(getKeyFormatIds())
+                .accessedKeyColumns(scanInformation.getAccessedPkColumns())
+                .keyDecodingMap(getKeyDecodingMap())
+                .rowDecodingMap(getRowDecodingMap())
+                .baseColumnMap(baseColumnMap)
+                .delimited(delimited)
+                .escaped(escaped)
+                .lines(lines)
+                .storedAs(storedAs)
+                .location(location)
+                .partitionByColumns(getPartitionColumnMap())
+                .defaultRow(defaultRow,scanInformation.getDefaultValueMap())
+                .ignoreRecentTransactions(isReadOnly(txn))
+                .buildDataSet(this)
+                .map(new SetCurrentLocatedRowAndRowKeyFunction<>(operationContext));
+
+        return dataSet;
+    }
+
     protected boolean isReadOnly(TxnView txn) {
         while(txn != Txn.ROOT_TRANSACTION) {
             if (txn.allowsWrites())
@@ -386,4 +446,13 @@ public class TableScanOperation extends ScanOperation{
     public boolean isForUpdate(){
         return forUpdate;
     }
+
+    public ExecRow getFirstRowOfIndexPrefixIteration() {
+        return firstRowOfIndexPrefixIteration;
+    }
+
+    public void setFirstRowOfIndexPrefixIteration(ExecRow firstRowOfIndexPrefixIteration) {
+        this.firstRowOfIndexPrefixIteration = firstRowOfIndexPrefixIteration;
+    }
+
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -387,52 +387,6 @@ public class TableScanOperation extends ScanOperation{
                 .map(new SetCurrentLocatedRowAndRowKeyFunction<>(operationContext));
     }
 
-    /**
-     * @return the Table Scan DataSet which probes each first index column via KeyPrefixProbingFilter
-     */
-    public DataSet<ExecRow> getKeyPrefixFilterScan(ExecRow firstRow, DataSetProcessor dsp) throws StandardException{
-        TxnView txn = getCurrentTransaction();
-        operationContext = dsp.createOperationContext(this);
-
-        DataScan dataScan = getNonSIScan();
-        try {
-            dataScan.attachKeyPrefixFilter(firstRow.getColumn(1), tableVersion);
-        }
-        catch (IOException e) {
-            throw StandardException.plainWrapException(e);
-        }
-
-        DataSet<ExecRow> dataSet =
-        dsp.<TableScanOperation,ExecRow>newScanSet(this,tableName)
-                .tableDisplayName(tableDisplayName)
-                .activation(activation)
-                .transaction(txn)
-                .scan(dataScan)
-                .template(currentTemplate)
-                .tableVersion(tableVersion)
-                .indexName(indexName)
-                .reuseRowLocation(true)
-                .keyColumnEncodingOrder(scanInformation.getColumnOrdering())
-                .keyColumnSortOrder(scanInformation.getConglomerate().getAscDescInfo())
-                .keyColumnTypes(getKeyFormatIds())
-                .accessedKeyColumns(scanInformation.getAccessedPkColumns())
-                .keyDecodingMap(getKeyDecodingMap())
-                .rowDecodingMap(getRowDecodingMap())
-                .baseColumnMap(baseColumnMap)
-                .delimited(delimited)
-                .escaped(escaped)
-                .lines(lines)
-                .storedAs(storedAs)
-                .location(location)
-                .partitionByColumns(getPartitionColumnMap())
-                .defaultRow(defaultRow,scanInformation.getDefaultValueMap())
-                .ignoreRecentTransactions(isReadOnly(txn))
-                .buildDataSet(this)
-                .map(new SetCurrentLocatedRowAndRowKeyFunction<>(operationContext));
-
-        return dataSet;
-    }
-
     protected boolean isReadOnly(TxnView txn) {
         while(txn != Txn.ROOT_TRANSACTION) {
             if (txn.allowsWrites())

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
@@ -66,7 +66,7 @@ public interface ScanInformation<T> {
                      List<Pair<T, T>> keyRows, DataValueDescriptor scanKeyPrefix,
                      boolean sameStartStopScanKeyPrefix,
                      List<ExecRow> firstIndexColumnKeys,
-                     boolean SkipBuildOfFirstKeyColumn) throws StandardException;
+                     boolean skipBuildOfFirstKeyColumn) throws StandardException;
 
     Qualifier[][] getScanQualifiers() throws StandardException;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
@@ -65,13 +65,15 @@ public interface ScanInformation<T> {
     DataScan getScan(TxnView txn, T startKeyHint, int[] keyDecodingMap, T stopKeyPrefix,
                      List<Pair<T, T>> keyRows, DataValueDescriptor scanKeyPrefix,
                      boolean sameStartStopScanKeyPrefix,
-                     List<ExecRow> firstIndexColumnKeys) throws StandardException;
+                     List<ExecRow> firstIndexColumnKeys,
+                     boolean SkipBuildOfFirstKeyColumn) throws StandardException;
 
     Qualifier[][] getScanQualifiers() throws StandardException;
 
     long getConglomerateId();
     
-    List<DataScan> getScans(TxnView txn, List<ExecRow> scanKeyPrefixes, Activation activation, int[] keyDecodingMap) throws StandardException;
+    List<DataScan> getScans(TxnView txn, List<ExecRow> scanKeyPrefixes, Activation activation,
+                            int[] keyDecodingMap, boolean skipBuildOfFirstKeyColumn) throws StandardException;
 
     int[] getColumnOrdering() throws StandardException;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -99,7 +99,8 @@ public class Scans extends SpliceUtils {
                                      boolean rowIdKey,
                                      SpliceConglomerate conglomerate,
                                      List<Pair<ExecRow, ExecRow>> keyRows,
-                                     List<ExecRow> firstIndexColumnKeys) throws StandardException {
+                                     List<ExecRow> firstIndexColumnKeys,
+                                     boolean skipBuildOfFirstKeyColumn) throws StandardException {
         assert dataValueFactory != null;
         DataScan scan =SIDriver.driver().getOperationFactory().newDataScan(txn);//SpliceUtils.createScan(txn, scanColumnList != null && scanColumnList.anySetBit() == -1); // Here is the count(*) piece
         scan.returnAllVersions();
@@ -123,7 +124,7 @@ public class Scans extends SpliceUtils {
                     sortOrder, scannedRow, keyTablePositionMap, keyDecodingMap,
                     dataValueFactory, tableVersion, rowIdKey,
                     conglomerate.getFormat_ids(),
-                    keyRows, firstIndexColumnKeys);
+                    keyRows, firstIndexColumnKeys, skipBuildOfFirstKeyColumn);
 
             if (!rowIdKey) {
                 buildPredicateFilter(qualifiers, scanColumnList, scan, keyDecodingMap);
@@ -147,7 +148,8 @@ public class Scans extends SpliceUtils {
                                  String tableVersion,
                                  boolean rowIdKey,
                                  ExecRow templateRow,
-                                 DataValueDescriptor scanKeyPrefix) throws StandardException {
+                                 DataValueDescriptor scanKeyPrefix,
+                                 boolean skipBuildOfFirstKeyColumn) throws StandardException {
         assert dataValueFactory != null;
         try {
             if (rowIdKey) {
@@ -167,7 +169,7 @@ public class Scans extends SpliceUtils {
                               stopKeyValue, stopKeyPrefix, stopSearchOperator,
                               sortOrder, formatIds, keyTablePositionMap, keyDecodingMap,
                               dataValueFactory, tableVersion, rowIdKey,
-                              templateRow, scanKeyPrefix);
+                              templateRow, scanKeyPrefix, skipBuildOfFirstKeyColumn);
 
 //            if (!rowIdKey) {
 //                buildPredicateFilter(qualifiers, scanColumnList, scan, keyDecodingMap);
@@ -196,7 +198,7 @@ public class Scans extends SpliceUtils {
                                  SpliceConglomerate conglomerate) throws StandardException {
         return setupScan(startKeyValue, startSearchOperator, stopKeyValue, null, stopSearchOperator, qualifiers,
                 sortOrder, scanColumnList, txn, sameStartStopPosition, scannedRow, keyDecodingMap,
-                keyTablePositionMap, dataValueFactory, tableVersion, rowIdKey, conglomerate, null, null);
+                keyTablePositionMap, dataValueFactory, tableVersion, rowIdKey, conglomerate, null, null, false);
     }
 
     public static void buildPredicateFilter(Qualifier[][] qualifiers,
@@ -256,7 +258,8 @@ public class Scans extends SpliceUtils {
                            int[] keyDecodingMap,
                            DataValueFactory dataValueFactory,
                            String tableVersion,
-                           boolean rowIdKey) throws IOException {
+                           boolean rowIdKey,
+                           boolean skipBuildOfFirstKeyColumn) throws IOException {
 
         boolean generateStartKey = false;
         boolean generateStopKey = false;
@@ -309,13 +312,15 @@ public class Scans extends SpliceUtils {
             }
 
             if (generateStartKey) {
-                startRow = DerbyBytesUtil.generateScanKeyForIndex(startKeyValue, startSearchOperator, sortOrder, tableVersion, rowIdKey);
+                startRow = DerbyBytesUtil.generateScanKeyForIndex(startKeyValue, startSearchOperator, sortOrder,
+                                                                  tableVersion, rowIdKey, skipBuildOfFirstKeyColumn);
 
                 if (startRow == null)
                     startRow = SIConstants.EMPTY_BYTE_ARRAY;
             }
             if (generateStopKey) {
-                stopRow = DerbyBytesUtil.generateScanKeyForIndex(stop, stopSearchOperator, sortOrder, tableVersion, rowIdKey);
+                stopRow = DerbyBytesUtil.generateScanKeyForIndex(stop, stopSearchOperator, sortOrder,
+                                                                 tableVersion, rowIdKey, skipBuildOfFirstKeyColumn);
                 if (stopKeyPrefix != null) {
                     stopRow = Bytes.unsignedCopyAndIncrement(stopRow);
                 }
@@ -342,7 +347,8 @@ public class Scans extends SpliceUtils {
                                        boolean rowIdKey,
                                        int[] columnTypes,
                                        List<Pair<ExecRow, ExecRow>> keyRows,
-                                       List<ExecRow> firstIndexColumnKeys) throws IOException, StandardException {
+                                       List<ExecRow> firstIndexColumnKeys,
+                                       boolean skipBuildOfFirstKeyColumn) throws IOException, StandardException {
         Pair<byte[], byte[]> startStopKeys;
         DataValueDescriptor[] startKeyDVDs = null, stopKeyDVDs = null;
         byte[] startKey;
@@ -359,7 +365,8 @@ public class Scans extends SpliceUtils {
                     keyDecodingMap,
                     dataValueFactory,
                     tableVersion,
-                    rowIdKey);
+                    rowIdKey,
+                    skipBuildOfFirstKeyColumn);
 
             startKey = startStopKeys.getFirst();
             stopKey = startStopKeys.getSecond();
@@ -390,7 +397,7 @@ public class Scans extends SpliceUtils {
 
                 startKeyDVDs[0] = keyPrefixRow.getColumn(1);
                 stopKeyDVDs[0]  = keyPrefixRow.getColumn(1);
-                startStopKeys =
+                 startStopKeys =
                   buildStartAndStopKeys(startKeyDVDs, ScanController.GE,
                                         stopKeyDVDs, null,
                                         GT,
@@ -400,7 +407,8 @@ public class Scans extends SpliceUtils {
                                         keyDecodingMap,
                                         dataValueFactory,
                                         tableVersion,
-                                        false);
+                                        false,
+                                        skipBuildOfFirstKeyColumn);
                 startKey = startStopKeys.getFirst();
                 stopKey = startStopKeys.getSecond();
                 if (startKey != null && stopKey != null)
@@ -408,7 +416,7 @@ public class Scans extends SpliceUtils {
             }
             // Convert the list of keys into a MultiRowRangeFilter.
             if (!keys.isEmpty())
-                scan.addRowkeyRangesFilter(keys);
+                scan.addRowkeyRangesFilter(keys, skipBuildOfFirstKeyColumn);
         }
 
         if (keyRows != null && !isMemPlatform()) {
@@ -433,7 +441,8 @@ public class Scans extends SpliceUtils {
                                         keyDecodingMap,
                                         dataValueFactory,
                                         tableVersion,
-                                        false);
+                                        false,
+                                        skipBuildOfFirstKeyColumn);
                 startKey = startStopKeys.getFirst();
                 stopKey = startStopKeys.getSecond();
                 if (startKey != null && stopKey != null)
@@ -442,7 +451,7 @@ public class Scans extends SpliceUtils {
 
             // Convert the list of keys into a MultiRowRangeFilter.
             if (!keys.isEmpty())
-                scan.addRowkeyRangesFilter(keys);
+                scan.addRowkeyRangesFilter(keys, skipBuildOfFirstKeyColumn);
         }
 
     }
@@ -458,7 +467,8 @@ public class Scans extends SpliceUtils {
                                                   String tableVersion,
                                                   boolean rowIdKey,
                                                   ExecRow templateRow,
-                                                  DataValueDescriptor scanKeyPrefix) throws IOException, StandardException {
+                                                  DataValueDescriptor scanKeyPrefix,
+                                                  boolean skipBuildOfFirstKeyColumn) throws IOException, StandardException {
         byte[] startRow;
         byte[] stopRow;
         try {
@@ -519,7 +529,7 @@ public class Scans extends SpliceUtils {
             }
 
             if (generateStartKey) {
-                startRow = DerbyBytesUtil.generateScanKeyForIndex(startKeyValue, startSearchOperator, sortOrder, tableVersion, rowIdKey);
+                startRow = DerbyBytesUtil.generateScanKeyForIndex(startKeyValue, startSearchOperator, sortOrder, tableVersion, rowIdKey, skipBuildOfFirstKeyColumn);
                 if (startRow == null)
                     throw StandardException.newException(PARAMETER_CANNOT_BE_NULL, "startRow");
             }
@@ -527,7 +537,7 @@ public class Scans extends SpliceUtils {
                 throw StandardException.newException(PARAMETER_CANNOT_BE_NULL, "startRow");
 
             if (generateStopKey) {
-                stopRow = DerbyBytesUtil.generateScanKeyForIndex(stop, stopSearchOperator, sortOrder, tableVersion, rowIdKey);
+                stopRow = DerbyBytesUtil.generateScanKeyForIndex(stop, stopSearchOperator, sortOrder, tableVersion, rowIdKey, skipBuildOfFirstKeyColumn);
                 if (stopKeyPrefix != null) {
                     stopRow = Bytes.unsignedCopyAndIncrement(stopRow);
                 }

--- a/splice_machine/src/test/java/com/splicemachine/benchmark/IndexPrefixIterationBenchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/benchmark/IndexPrefixIterationBenchmark.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2021 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.benchmark;
+
+import com.splicemachine.derby.test.framework.SpliceNetConnection;
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.test.Benchmark;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+@Category(Benchmark.class)
+@RunWith(Parameterized.class)
+public class IndexPrefixIterationBenchmark extends Benchmark {
+
+    private static final Logger LOG = Logger.getLogger(IndexPrefixIterationBenchmark.class);
+
+    private static final String SCHEMA = IndexPrefixIterationBenchmark.class.getSimpleName();
+
+    private static final String TABLE_NAME = "BASE_TABLE";
+    private static final String IDX_NAME = "RIGHT_IDX";
+    private static final int NUM_CONNECTIONS = 1;
+    private static final int NUM_EXECS = 10;
+    private static final int NUM_WARMUP_RUNS = 1;
+
+    private final int tableSize;
+    private final int batchSize;
+
+    public IndexPrefixIterationBenchmark(int tableSize, int batchSize) {
+        this.tableSize = tableSize;
+        this.batchSize = batchSize;
+    }
+
+    @ClassRule
+    public static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    static Connection makeConnection() throws SQLException {
+        Connection connection = SpliceNetConnection.getDefaultConnection();
+        connection.setSchema(spliceSchemaWatcher.schemaName);
+        connection.setAutoCommit(true);
+        return connection;
+    }
+
+    static Connection testConnection;
+    static Statement testStatement;
+
+    @Before
+    public void setUp() throws Exception {
+
+        getInfo();
+
+        LOG.info("Create tables");
+        testConnection = makeConnection();
+        testStatement = testConnection.createStatement();
+
+        testStatement.execute("CREATE TABLE " + TABLE_NAME + " (col1_pk INTEGER, col2 INTEGER, col3 INTEGER, col4_pk INTEGER, col5 INTEGER,  PRIMARY KEY(col1_pk, col4_pk))");
+        testStatement.execute("CREATE INDEX " + IDX_NAME + " on " + TABLE_NAME + " (col2, col3)");
+
+        curSize.set(0);
+        runBenchmark(NUM_CONNECTIONS, () -> populateTable(TABLE_NAME, tableSize));
+
+        testStatement.execute(String.format("call syscs_util.syscs_flush_table('%s', '%s')", SCHEMA, TABLE_NAME));
+
+        LOG.info("Collect statistics");
+        try (ResultSet rs = testStatement.executeQuery("ANALYZE SCHEMA " + SCHEMA)) {
+            assertTrue(rs.next());
+        }
+
+        testStatement.execute("set session_property favorIndexPrefixIteration=true");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        testStatement.execute("DROP TABLE " + TABLE_NAME);
+        testStatement.close();
+        testConnection.close();
+    }
+
+    static final String STAT_ERROR = "ERROR";
+    static final String STAT_PREP = "PREPARE ";
+    static AtomicInteger curSize = new AtomicInteger(0);
+
+    private void populateTable(String tableName, int size) {
+        int newSize = 0;
+        try (Connection conn = makeConnection()) {
+            try (PreparedStatement insert = conn.prepareStatement("INSERT INTO " + tableName + " VALUES (?,?,?,?,?)")) {
+                newSize = curSize.addAndGet(batchSize);
+                for (int i = 0; i < newSize; ++i) {
+                    insert.setInt(1, newSize);
+                    insert.setInt(2, newSize);
+                    insert.setInt(3, i);
+                    insert.setInt(4, i);
+                    insert.setInt(5, i);
+                    insert.addBatch();
+                }
+                long start = System.currentTimeMillis();
+                int[] counts = insert.executeBatch();
+                long end = System.currentTimeMillis();
+                int count = 0;
+                for (int c : counts) count += c;
+                if (count != batchSize) {
+                    updateStats(STAT_ERROR);
+                }
+                if (count > 0) {
+                    updateStats(STAT_PREP + tableName, count, end - start);
+                }
+            }
+            try (Statement insert = conn.createStatement()) {
+                for (; ; ) {
+                    if (newSize >= size) break;
+                    String insertStmt =
+                        String.format("INSERT INTO " + tableName + " select %s, %s, col3+%s, col4_pk+%s, col5+%s" +
+                                      " from " + tableName + " --splice-properties useSpark=true\n", newSize, newSize, newSize, newSize, newSize);
+                    newSize *= 2;
+                    long start = System.currentTimeMillis();
+                    int count = insert.executeUpdate(insertStmt);
+                    long end = System.currentTimeMillis();
+                    if (count > 0) {
+                        updateStats(STAT_PREP + tableName, count, end - start);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    private int getRowCount(ResultSet rs) throws SQLException {
+        assertTrue(rs.next());
+        return rs.getInt(1);
+    }
+
+    private void benchmark(int numExec, boolean warmUp, boolean useIdx, boolean onOlap) {
+        String sqlText = String.format("select count(*) from \n" +
+                "   %s R --splice-properties index=%s, useSpark=%b\n",
+                TABLE_NAME, useIdx ? IDX_NAME : "null", onOlap);
+        String dataLabel = warmUp ? "Warm" : "Cold";
+        if (useIdx) {
+            dataLabel += "Idx";
+            sqlText += " where R.col3 between 0 and 9";
+        }
+        else {
+            dataLabel += "BaseTable";
+            sqlText += " where R.col4_pk between 0 and 9";
+        }
+        if (onOlap)
+            dataLabel += "Olap";
+        else
+            dataLabel += "Oltp";
+
+        try (Connection conn = makeConnection()) {
+            try (Statement statement = conn.createStatement()) {
+                statement.execute("set session_property favorIndexPrefixIteration=true");
+            }
+            try (PreparedStatement query = conn.prepareStatement(sqlText)) {
+                // validate plan
+                testQueryContains(conn, "explain " + sqlText, "IndexPrefixIteratorMode");
+
+                // warm-up runs
+                if (warmUp) {
+                    for (int i = 0; i < NUM_WARMUP_RUNS; ++i) {
+                        query.executeQuery();
+                    }
+                }
+
+                // measure and validate result row count
+                for (int i = 0; i < numExec; ++i) {
+                    long start = System.currentTimeMillis();
+                    try (ResultSet rs = query.executeQuery()) {
+                        if (getRowCount(rs) != 10) {
+                            updateStats(STAT_ERROR);
+                        } else {
+                            long stop = System.currentTimeMillis();
+                            updateStats(dataLabel, stop - start);
+                        }
+                    } catch (SQLException ex) {
+                        LOG.error("ERROR execution " + i + " of join benchmark using " + dataLabel + ": " + ex.getMessage());
+                        updateStats(STAT_ERROR);
+                    }
+                }
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Connection broken", t);
+        }
+    }
+
+    @Parameterized.Parameters
+    public static Collection testParams() {
+        return Arrays.asList(new Object[][] {
+                { 10, 10},
+                { 100, 10 },
+                { 1000, 10 },
+                { 1000, 100 },
+                { 10000, 10 },
+                { 10000, 1000 },
+                { 100000, 100 },
+                { 100000, 10000 },
+                { 1000000, 1000 },
+                { 1000000, 65000},
+                { 10000000, 1000 },
+                { 10000000, 65000 },
+        });
+    }
+
+    /* Warming up would bring data into hbase block cache. To run cold only benchmarks,
+     * hbase block cache must be disabled first:
+     * hfile.block.cache.size = 0
+     */
+
+    @Test
+    public void testVariations() throws Exception {
+        LOG.info("IndexPrefixIterationCold");
+        runBenchmark(1, () -> benchmark(NUM_EXECS, false, false, false));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, false, false, true));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, false, true, false));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, false, true, true));
+
+        LOG.info("IndexPrefixIterationWarm");
+        runBenchmark(1, () -> benchmark(NUM_EXECS, true, false, false));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, true, false, true));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, true, true, false));
+        runBenchmark(1, () -> benchmark(NUM_EXECS, true, true, true));
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/test/Benchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/test/Benchmark.java
@@ -16,6 +16,7 @@
 package com.splicemachine.test;
 
 import com.splicemachine.derby.test.framework.SpliceNetConnection;
+import com.splicemachine.homeless.TestUtils;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 
@@ -26,6 +27,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
+
+import static org.junit.Assert.fail;
 
 public class Benchmark {
 
@@ -239,6 +242,23 @@ public class Benchmark {
                 if (k < matchLines.size()) {
                     Assert.fail("fail to match the given strings");
                 }
+            }
+        }
+    }
+
+    /***
+     * Executes `query` using `conn` and verify the output contain `containedString`.
+     *
+     * @param containedString The string to search for in the query result.
+     */
+    public static void testQueryContains(Connection conn,
+                                         String query,
+                                         String containedString) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement(query)) {
+            try (ResultSet resultSet = ps.executeQuery()) {
+                String queryOutputString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(resultSet);
+            if (!queryOutputString.contains(containedString))
+                fail("ResultSet does not contain string: " + containedString + "\nResult set:\n"+queryOutputString);
             }
         }
     }

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -33,9 +33,8 @@ message AllocateFilterMessage {
 }
 
 message KeyPrefixProbingFilterMessage {
-    required bytes  firstKeyColumnDVDAsByteArray = 1;
-    required string tableVersion = 2;
-    required bytes  secondaryFilter = 3;
+    required int32 firstKeyColumnEncodingKind = 1;
+    required bytes  secondaryFilter = 2;
 }
 
 message SuccessFilterMessage {

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -32,6 +32,12 @@ message AllocateFilterMessage {
     optional bytes addressMatch = 1;
 }
 
+message KeyPrefixProbingFilterMessage {
+    required bytes  firstKeyColumnDVDAsByteArray = 1;
+    required string tableVersion = 2;
+    required bytes  secondaryFilter = 3;
+}
+
 message SuccessFilterMessage {
     repeated bytes failedTasks = 1;
 }


### PR DESCRIPTION
## Short Description
Improve performance of Index Prefix Iteration with a large number of values in the first index column.

## Long Description
[SPLICE-2399](https://github.com/splicemachine/spliceengine/pull/5013) Added index key lookups with no predicates on the leading index column, improving query performance.  When the number of values in that column is high, the time taken to discover the values to probe is excessive.  For example, on a table with 130K values, it takes roughly 2 minutes to collect those 130K values.  The problem is that there is no way to dynamically alter a scan from the SpliceOperation side of execution (the SpliceOperation is converted to an HBase scan and fulfilled via a connection to a Region Server).  Once the first value is found, we can't modify the start key value (search key) of the scan, or modify a Filter attached to the scan, and have the modification take effect.  So, we have to close the scan and open a brand new scan with a different start key.  The creation and destruction of 130K scans is too costly, which accounts for the observed slowness.

The solution is to write a new custom HBase filter, named KeyPrefixProbingFilter, which knows how to find the length of the first column's constituent of the HBase rowkey (bytes in the HBase Cell) and probe within the first column values present.  Within a given first column value (in encoded format), a secondary MultiRowRangeFilter will be applied to probe the start keys and stop keys of index columns 2,3,4, etc.   Since this secondary filter needs to be reset and reapplied again and again, it needs special logic over the HBase MultiRowRangeFilter, which is single-pass.  A new SpliceMultiRowRangeFilter class which extends MultiRowRangeFilter is added for this purpose.  With these 2 new filters, the original costly value discovery logic is totally bypassed (except for the mem platform, which does not use HBase).  The query which previously took over 2 minutes now runs in under a second.

Also fixed in this pull request is a missing resetting of currentAccessPath.numUnusedLeadingIndexFields when costing the disableIndexPrefixIteration path, plus a reduction of optimizer costs for index prefix iteration plans when the favorIndexPrefixIteration session hint is used.

## How to test
connect 'jdbc:splice://localhost:1527/splicedb;user=splice;password=admin;useSpark=true';
CREATE TABLE FeatureStoreTest.FeatureStaging

(
    entity_key INTEGER,
    update_order INTEGER,
    ts TIMESTAMP,
    feature1 DOUBLE,
    feature2 DOUBLE,
    PRIMARY KEY (entity_key, update_order)
) ;

-- add entities at update_order = 1, with variable first timestamp
INSERT INTO FeatureStoreTest.FeatureStaging VALUES ( 1, 1, '2000-01-01 00:00:00', 0, 0 );

INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 1, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 2, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 4, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 8, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 16, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 32, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 64, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 128, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 256, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 512, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 1024, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 2048, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 4096, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 8192, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 16384, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 32768, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;
INSERT INTO FeatureStoreTest.FeatureStaging SELECT entity_key + 65536, update_order, timestampadd(SQL_TSI_DAY, CAST(ROUND(-44 + RANDOM()*88, 0) AS INTEGER), ts), feature1, feature2 FROM FeatureStoreTest.FeatureStaging;

INSERT INTO FeatureStoreTest.FeatureStaging
SELECT entity_key,
       update_order + 1,
       timestampadd(SQL_TSI_DAY, CAST( randValue AS INTEGER), ts),
       feature1 + randValue,
       feature2 + randValue
FROM FeatureStoreTest.FeatureStaging,
     (VALUES(CAST(ROUND(-4 + RANDOM()*8, 0) AS INTEGER)))oneRandom(randValue);

INSERT INTO FeatureStoreTest.FeatureStaging
SELECT entity_key,
       update_order + 2,
       timestampadd(SQL_TSI_DAY, CAST( randValue AS INTEGER), ts),
       feature1 + randValue,
       feature2 + randValue
FROM FeatureStoreTest.FeatureStaging,
     (VALUES(CAST(ROUND(-4 + RANDOM()*8, 0) AS INTEGER)))oneRandom(randValue);

INSERT INTO FeatureStoreTest.FeatureStaging
SELECT entity_key,
       update_order + 4,
       timestampadd(SQL_TSI_DAY, CAST( randValue AS INTEGER), ts),
       feature1 + randValue,
       feature2 + randValue
FROM FeatureStoreTest.FeatureStaging,
     (VALUES(CAST(ROUND(-4 + RANDOM()*8, 0) AS INTEGER)))oneRandom(randValue);
 
INSERT INTO FeatureStoreTest.FeatureStaging
SELECT entity_key,
       update_order + 8,
       timestampadd(SQL_TSI_DAY, CAST( randValue AS INTEGER), ts),
       feature1 + randValue,
       feature2 + randValue
FROM FeatureStoreTest.FeatureStaging,
     (VALUES(CAST(ROUND(-4 + RANDOM()*8, 0) AS INTEGER)))oneRandom(randValue);

analyze table FeatureStaging;
call syscs_util.syscs_flush_table('FEATURESTORETEST', 'FEATURESTAGING');

/* The following SQL should take about 1 second to run.  Before it took 2-3 minutes. */

> explain
> SELECT count(*)
> FROM FeatureStoreTest.FeatureStaging  
> WHERE update_order=1;
> Plan
> //----
> Cursor(n=5,rows=1,updateMode=READ_ONLY (1),engine=OLAP (cost))
>   ->  ScrollInsensitive(n=5,totalCost=4273.544,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=3)
>     ->  ProjectRestrict(n=4,totalCost=244.25,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=3)
>       ->  GroupBy(n=3,totalCost=244.25,outputRows=1,outputHeapSize=0 B,partitions=1,parallelTasks=3)
>         ->  ProjectRestrict(n=2,totalCost=732.699,outputRows=131072,outputHeapSize=2.1 MB,partitions=1,parallelTasks=3)
>           ->  ProjectRestrict(n=1,totalCost=732.699,outputRows=131072,outputHeapSize=2.1 MB,partitions=1,parallelTasks=3)
>             ->  TableScan[FEATURESTAGING(1696),IndexPrefixIteratorMode(132480 values)](n=0,totalCost=732.699,scannedRows=131072,outputRows=131072,outputHeapSize=2.1 MB,partitions=1,parallelTasks=3,keys=[(UPDATE_ORDER[0:2] = 1)])
> 
> 
> SELECT count(*)
> FROM FeatureStoreTest.FeatureStaging 
> WHERE update_order=1;
> 
> splice> > > 1
> //-
> 131072
> 
> 1 row selected
> ELAPSED TIME = 822 milliseconds
