### PR TITLE
DB-12140 Fix index on expressions logic for UnaryDateTimestampOperatorNode

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -42,9 +42,11 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.ProtobufUtils;
 import com.splicemachine.db.iapi.util.ByteArray;
+import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.sql.CatalogMessage;
 import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.BaseExecutableIndexExpression;
+import splice.com.google.common.base.Predicates;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -727,8 +729,7 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
         for (int i = 0; i < exprTexts.length; i++) {
             ValueNode exprAst = (ValueNode) p.parseSearchCondition(exprTexts[i]);
             setTableNumberToIndexExpr(exprAst, optTable);
-            bindNecessaryNodesInIndexExpr(exprAst, optTable, lcc);
-            exprAsts[i] = exprAst;
+            exprAsts[i] = bindNecessaryNodesInIndexExpr(exprAst, optTable, lcc);
         }
         lcc.popCompilerContext(newCC);
         return exprAsts;
@@ -756,24 +757,10 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
      * @param lcc a LanguageConnectionContext instance
      * @throws StandardException
      */
-    private static void bindNecessaryNodesInIndexExpr(ValueNode ast, Optimizable optTable, LanguageConnectionContext lcc)
+    private static ValueNode bindNecessaryNodesInIndexExpr(ValueNode ast, Optimizable optTable, LanguageConnectionContext lcc)
             throws StandardException
     {
-        // JavaToSQLValueNode has to be bound because the subtree structure might change during binding.
-        // Also, in case of a method call, method name may be resolved to a different one.
-        CollectNodesVisitor cnv = new CollectNodesVisitor(JavaToSQLValueNode.class);
-        ast.accept(cnv);
-        List<JavaToSQLValueNode> jtsvList = cnv.getList();
-        if (!jtsvList.isEmpty() && optTable instanceof FromTable) {
-            NodeFactory nf = lcc.getLanguageConnectionFactory().getNodeFactory();
-            FromList fromList = (FromList) nf.getNode(
-                    C_NodeTypes.FROM_LIST,
-                    nf.doJoinOrderOptimization(),
-                    optTable,
-                    lcc.getContextManager());
-            for (JavaToSQLValueNode jtsvNode : jtsvList) {
-                jtsvNode.bindExpression(fromList, new SubqueryList(), new ArrayList<AggregateNode>() {});
-            }
-        }
+        IndexExpressionBindingVisitor iebv = new IndexExpressionBindingVisitor(lcc, optTable);
+        return (ValueNode) ast.accept(iebv);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexExpressionBindingVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexExpressionBindingVisitor.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+
+import java.util.ArrayList;
+
+/**
+ * Bind an index expression.
+ * 
+ */
+public class IndexExpressionBindingVisitor implements Visitor
+{
+    private final Optimizable optTable;
+    private final FromList fromList;
+    private final SubqueryList subqList;
+    private final ArrayList<AggregateNode> aggrList;
+
+    public IndexExpressionBindingVisitor(LanguageConnectionContext lcc, Optimizable optTable) throws StandardException {
+        this.optTable = optTable;
+        NodeFactory nf = lcc.getLanguageConnectionFactory().getNodeFactory();
+        fromList = (FromList) nf.getNode(
+                C_NodeTypes.FROM_LIST,
+                nf.doJoinOrderOptimization(),
+                this.optTable,
+                lcc.getContextManager());
+        subqList = new SubqueryList();
+        aggrList = new ArrayList<AggregateNode>() {};
+    }
+
+    @Override
+    public Visitable visit(Visitable node, QueryTreeNode parent) throws StandardException {
+        if (!(optTable instanceof FromTable)) {
+            return node;
+        }
+
+        // JavaToSQLValueNode has to be bound because the subtree structure might change during binding.
+        // In case of a method call, method name may be resolved to a different one.
+        // For UnaryDateTimestampOperatorNode, the subtree might be evaluated to a constant.
+        if (node instanceof JavaToSQLValueNode || node instanceof UnaryDateTimestampOperatorNode) {
+            return ((ValueNode) node).bindExpression(fromList, subqList, aggrList);
+        }
+        return node;
+    }
+
+    public boolean stopTraversal() 
+    {
+        return false;
+    }
+
+    public boolean skipChildren(Visitable node) 
+    {
+        return false;
+    }
+
+    public boolean visitChildrenFirst(Visitable node)
+    {
+        return false;
+    }
+}

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -1537,6 +1537,30 @@ public class IndexIT extends SpliceUnitTest{
     }
 
     @Test
+    public void testFullScanViaExpressionBasedIndexWithExpressionSelected() throws Exception {
+        String tableName = "TEST_FULL_SCAN_SELECT_INDEX_EXPR";
+        String indexExpr = "timestampdiff(SQL_TSI_FRAC_SECOND, timestamp('1970-01-01 00:00:00'), t)";
+        methodWatcher.executeUpdate(format("create table %s (t TIMESTAMP NOT NULL)", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('2020-01-01 01:01:01')", tableName));
+
+        methodWatcher.executeUpdate(format("CREATE INDEX %1$s_IDX ON %1$s (%2$s)", tableName, indexExpr));
+        methodWatcher.executeUpdate(format("insert into %s values ('2020-02-02 02:02:02')", tableName));
+
+        String query = format("select %1$s from %2$s --splice-properties index=%2$s_IDX\n", indexExpr, tableName);
+
+        rowContainsQuery(new int[]{2,3}, "explain " + query, methodWatcher, "ScrollInsensitive", "IndexScan[TEST_FULL_SCAN_SELECT_INDEX_EXPR_IDX");
+
+        String expected = "1          |\n" +
+                "---------------------\n" +
+                "1577840461000000000 |\n" +
+                "1580608922000000000 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
     public void testScansStarStopKeyFromIndexExpressionPredicate() throws Exception {
         String tableName = "TEST_START_STOP_KEY_EXPR_INDEX";
         methodWatcher.executeUpdate(format("create table %s (c char(4), i int)", tableName));
@@ -1789,7 +1813,8 @@ public class IndexIT extends SpliceUnitTest{
         methodWatcher.executeUpdate("create table TEST_IN_LIST_RHS_2(b1 int, b2 int)");
         methodWatcher.executeUpdate("insert into TEST_IN_LIST_RHS_2 values(0,0),(3,30),(5,50)");
 
-        String query = "select b1, a2 from TEST_IN_LIST_RHS --splice-properties index=TEST_IN_LIST_RHS_IDX\n, " +
+        String query = "select b1, a2 from --splice-properties joinOrder=fixed\n" +
+                "TEST_IN_LIST_RHS --splice-properties index=TEST_IN_LIST_RHS_IDX\n, " +
                 "TEST_IN_LIST_RHS_2 where b1 in (1, a1 * 3)";
 
         String[] expectedOps = new String[]{


### PR DESCRIPTION
## Short Description
This change fixes two problems:
1. An index created based on expressions using `UnaryDateTimestampOperatorNode` is not treated as an covering index even when an query refers to exactly the same expression.
2. An index on expression is not chosen based on cost if index expressions do not occur in any predicates.

## Long Description
For the first problem, root cause is that `bindExpression` of `UnaryDateTimestampOperatorNode` modifies the subtree in some cases. If this happens, the stored AST for index expression at index creation time is different than the AST parsed in query time. Solution is to bind `UnaryDateTimestampOperatorNode` nodes in index expression ASTs in query time, too.

Since we currently do this to `JavaToSQLValueNode` already, I refactor the code to have a new visitor doing this binding job for index expressions.

For the second problem, root cause is that in current optimizer architecture, best plan is determined based on `FromList` cost, not including other parts of the query (e.g., grouping, ordering, window function, etc.). In the problematic query, index expression is used only in select list, which is currently not costed at all.

Current solution is to prefer an index on expression if we know it's covering. Concretely, base cost of such an access path is multiplied by 0.999.

In theory, this problem should be resolved once we move to our next optimizer.

## How to test
Setup:
```
CREATE TABLE T1 (
    "T" TIMESTAMP NOT NULL
    , CONSTRAINT SQLBF0B9DCD0179B01B36930004E01C4FE8 PRIMARY KEY("T")) ;

create index tidx on t1 (timestampdiff(SQL_TSI_FRAC_SECOND, timestamp('1970-01-01 00:00:00'), t));
```

Query:
```
1. explain select timestampdiff(SQL_TSI_FRAC_SECOND, timestamp('1970-01-01 00:00:00'), t) from T1 --splice-properties index=TIDX
    ;
2. explain select timestampdiff(SQL_TSI_FRAC_SECOND, timestamp('1970-01-01 00:00:00'), t) from T1;
```
Before this fix:
- Query 1 plan contains an index lookup step
- Query 2 plan contains a table scan

After this fix:
- Query 1 plan doesn't contain the index lookup step
- Query 2 plan contains an index scan