### PR TITLE
DB-12140 Fix index on expressions logic for UnaryDateTimestampOperatorNode (optimizer)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -42,9 +42,11 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.ProtobufUtils;
 import com.splicemachine.db.iapi.util.ByteArray;
+import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.sql.CatalogMessage;
 import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.BaseExecutableIndexExpression;
+import splice.com.google.common.base.Predicates;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -727,8 +729,7 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
         for (int i = 0; i < exprTexts.length; i++) {
             ValueNode exprAst = (ValueNode) p.parseSearchCondition(exprTexts[i]);
             setTableNumberToIndexExpr(exprAst, optTable);
-            bindNecessaryNodesInIndexExpr(exprAst, optTable, lcc);
-            exprAsts[i] = exprAst;
+            exprAsts[i] = bindNecessaryNodesInIndexExpr(exprAst, optTable, lcc);
         }
         lcc.popCompilerContext(newCC);
         return exprAsts;
@@ -756,24 +757,10 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
      * @param lcc a LanguageConnectionContext instance
      * @throws StandardException
      */
-    private static void bindNecessaryNodesInIndexExpr(ValueNode ast, Optimizable optTable, LanguageConnectionContext lcc)
+    private static ValueNode bindNecessaryNodesInIndexExpr(ValueNode ast, Optimizable optTable, LanguageConnectionContext lcc)
             throws StandardException
     {
-        // JavaToSQLValueNode has to be bound because the subtree structure might change during binding.
-        // Also, in case of a method call, method name may be resolved to a different one.
-        CollectNodesVisitor cnv = new CollectNodesVisitor(JavaToSQLValueNode.class);
-        ast.accept(cnv);
-        List<JavaToSQLValueNode> jtsvList = cnv.getList();
-        if (!jtsvList.isEmpty() && optTable instanceof FromTable) {
-            NodeFactory nf = lcc.getLanguageConnectionFactory().getNodeFactory();
-            FromList fromList = (FromList) nf.getNode(
-                    C_NodeTypes.FROM_LIST,
-                    nf.doJoinOrderOptimization(),
-                    optTable,
-                    lcc.getContextManager());
-            for (JavaToSQLValueNode jtsvNode : jtsvList) {
-                jtsvNode.bindExpression(fromList, new SubqueryList(), new ArrayList<AggregateNode>() {});
-            }
-        }
+        IndexExpressionBindingVisitor iebv = new IndexExpressionBindingVisitor(lcc, optTable);
+        return (ValueNode) ast.accept(iebv);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexExpressionBindingVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/IndexExpressionBindingVisitor.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Some parts of this source code are based on Apache Derby, and the following notices apply to
+ * Apache Derby:
+ *
+ * Apache Derby is a subproject of the Apache DB project, and is licensed under
+ * the Apache License, Version 2.0 (the "License"); you may not use these files
+ * except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Splice Machine, Inc. has modified the Apache Derby code in this file.
+ *
+ * All such Splice Machine modifications are Copyright 2012 - 2020 Splice Machine, Inc.,
+ * and are licensed to you under the GNU Affero General Public License.
+ */
+package com.splicemachine.db.impl.sql.compile;
+
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.compile.*;
+import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+
+import java.util.ArrayList;
+
+/**
+ * Bind an index expression.
+ * 
+ */
+public class IndexExpressionBindingVisitor implements Visitor
+{
+    private final Optimizable optTable;
+    private final FromList fromList;
+    private final SubqueryList subqList;
+    private final ArrayList<AggregateNode> aggrList;
+
+    public IndexExpressionBindingVisitor(LanguageConnectionContext lcc, Optimizable optTable) throws StandardException {
+        this.optTable = optTable;
+        NodeFactory nf = lcc.getLanguageConnectionFactory().getNodeFactory();
+        fromList = (FromList) nf.getNode(
+                C_NodeTypes.FROM_LIST,
+                nf.doJoinOrderOptimization(),
+                this.optTable,
+                lcc.getContextManager());
+        subqList = new SubqueryList();
+        aggrList = new ArrayList<AggregateNode>() {};
+    }
+
+    @Override
+    public Visitable visit(Visitable node, QueryTreeNode parent) throws StandardException {
+        if (!(optTable instanceof FromTable)) {
+            return node;
+        }
+
+        // JavaToSQLValueNode has to be bound because the subtree structure might change during binding.
+        // In case of a method call, method name may be resolved to a different one.
+        // For UnaryDateTimestampOperatorNode, the subtree might be evaluated to a constant.
+        if (node instanceof JavaToSQLValueNode || node instanceof UnaryDateTimestampOperatorNode) {
+            return ((ValueNode) node).bindExpression(fromList, subqList, aggrList);
+        }
+        return node;
+    }
+
+    public boolean stopTraversal() 
+    {
+        return false;
+    }
+
+    public boolean skipChildren(Visitable node) 
+    {
+        return false;
+    }
+
+    public boolean visitChildrenFirst(Visitable node)
+    {
+        return false;
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/v1/V1ScanCostEstimator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/v1/V1ScanCostEstimator.java
@@ -166,6 +166,14 @@ public class V1ScanCostEstimator extends AbstractScanCostEstimator {
         double scannedRowCount = totalRowCount * baseTableSelectivity;
         baseCost += (numFirstIndexColumnProbes*2)*localLatency*(1+congAverageWidth/100d);
         baseCost += (Math.max(scannedRowCount, 1)*localLatency*(1+congAverageWidth/100d));
+        if (isIndexOnExpression && baseColumnsInLookup == null) {
+            // covering index on expression
+            // This is a trick to prefer a covering index on expressions over table scan. We have to
+            // do it this way because in current optimizer framework, best plan is decided in costing
+            // from tables. But an index expression may be evaluated later, for example, as a grouping
+            // expression or a select expression.
+            baseCost *= 0.9999;
+        }
         assert congAverageWidth >= 0 : "congAverageWidth cannot be negative -> " + congAverageWidth;
         assert baseCost >= 0 : "baseCost cannot be negative -> " + baseCost;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/v2/V2ScanCostEstimator.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/v2/V2ScanCostEstimator.java
@@ -197,6 +197,14 @@ public class V2ScanCostEstimator extends AbstractScanCostEstimator {
             double olapReductionFactor = Math.max(2, Math.min(Math.log(numPartitions), Math.log(parallelism)));
             baseCost = baseCost / olapReductionFactor + OLAP_START_OVERHEAD;
         }
+        if (isIndexOnExpression && baseColumnsInLookup == null) {
+            // covering index on expression
+            // This is a trick to prefer a covering index on expressions over table scan. We have to
+            // do it this way because in current optimizer framework, best plan is decided in costing
+            // from tables. But an index expression may be evaluated later, for example, as a grouping
+            // expression or a select expression.
+            baseCost *= 0.9999;
+        }
         assert baseCost >= 0 : "baseCost cannot be negative -> " + baseCost;
 
         double fromBaseTableRowCount = totalRowCount * filterBaseTableSelectivity;

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/actions/index/IndexIT.java
@@ -1537,6 +1537,30 @@ public class IndexIT extends SpliceUnitTest{
     }
 
     @Test
+    public void testFullScanViaExpressionBasedIndexWithExpressionSelected() throws Exception {
+        String tableName = "TEST_FULL_SCAN_SELECT_INDEX_EXPR";
+        String indexExpr = "timestampdiff(SQL_TSI_FRAC_SECOND, timestamp('1970-01-01 00:00:00'), t)";
+        methodWatcher.executeUpdate(format("create table %s (t TIMESTAMP NOT NULL)", tableName));
+        methodWatcher.executeUpdate(format("insert into %s values ('2020-01-01 01:01:01')", tableName));
+
+        methodWatcher.executeUpdate(format("CREATE INDEX %1$s_IDX ON %1$s (%2$s)", tableName, indexExpr));
+        methodWatcher.executeUpdate(format("insert into %s values ('2020-02-02 02:02:02')", tableName));
+
+        String query = format("select %1$s from %2$s --splice-properties index=%2$s_IDX\n", indexExpr, tableName);
+
+        rowContainsQuery(new int[]{2,3}, "explain " + query, methodWatcher, "ScrollInsensitive", "IndexScan[TEST_FULL_SCAN_SELECT_INDEX_EXPR_IDX");
+
+        String expected = "1          |\n" +
+                "---------------------\n" +
+                "1577840461000000000 |\n" +
+                "1580608922000000000 |";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.assertEquals(expected, TestUtils.FormattedResult.ResultFactory.toString(rs));
+        }
+    }
+
+    @Test
     public void testScansStarStopKeyFromIndexExpressionPredicate() throws Exception {
         String tableName = "TEST_START_STOP_KEY_EXPR_INDEX";
         methodWatcher.executeUpdate(format("create table %s (c char(4), i int)", tableName));
@@ -1789,7 +1813,8 @@ public class IndexIT extends SpliceUnitTest{
         methodWatcher.executeUpdate("create table TEST_IN_LIST_RHS_2(b1 int, b2 int)");
         methodWatcher.executeUpdate("insert into TEST_IN_LIST_RHS_2 values(0,0),(3,30),(5,50)");
 
-        String query = "select b1, a2 from TEST_IN_LIST_RHS --splice-properties index=TEST_IN_LIST_RHS_IDX\n, " +
+        String query = "select b1, a2 from --splice-properties joinOrder=fixed\n" +
+                "TEST_IN_LIST_RHS --splice-properties index=TEST_IN_LIST_RHS_IDX\n, " +
                 "TEST_IN_LIST_RHS_2 where b1 in (1, a1 * 3)";
 
         String[] expectedOps = new String[]{


### PR DESCRIPTION
See https://github.com/splicemachine/spliceengine/pull/5535.

Note that the same change made to V1 cost model is applied to V2 cost model in this change, too.