### PR TITLE
DB-12051 Add support for additional constant folding

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataValue.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/types/NumberDataValue.java
@@ -39,134 +39,134 @@ import static com.splicemachine.db.iapi.reference.Limits.DB2_MAX_DECIMAL_PRECISI
 
 public interface NumberDataValue extends DataValueDescriptor
 {
-	/**
-	 * The minimum scale when dividing Decimals
-	 */
-	int MIN_DECIMAL_DIVIDE_SCALE = 4;
-	int MIN_DECIMAL_MULTIPLICATION_SCALE = 6;
-	int MAX_DECIMAL_PRECISION_SCALE = DB2_MAX_DECIMAL_PRECISION_SCALE;
-	int OLD_MAX_DECIMAL_PRECISION_SCALE = 31;
-	int MAX_DECIMAL_PRECISION_WITH_RESERVE_FOR_SCALE = MAX_DECIMAL_PRECISION_SCALE - MIN_DECIMAL_DIVIDE_SCALE;
-	int OLD_MAX_DECIMAL_PRECISION_WITH_RESERVE_FOR_SCALE = OLD_MAX_DECIMAL_PRECISION_SCALE - MIN_DECIMAL_DIVIDE_SCALE;
+    /**
+     * The minimum scale when dividing Decimals
+     */
+    int MIN_DECIMAL_DIVIDE_SCALE = 4;
+    int MIN_DECIMAL_MULTIPLICATION_SCALE = 6;
+    int MAX_DECIMAL_PRECISION_SCALE = DB2_MAX_DECIMAL_PRECISION_SCALE;
+    int OLD_MAX_DECIMAL_PRECISION_SCALE = 31;
+    int MAX_DECIMAL_PRECISION_WITH_RESERVE_FOR_SCALE = MAX_DECIMAL_PRECISION_SCALE - MIN_DECIMAL_DIVIDE_SCALE;
+    int OLD_MAX_DECIMAL_PRECISION_WITH_RESERVE_FOR_SCALE = OLD_MAX_DECIMAL_PRECISION_SCALE - MIN_DECIMAL_DIVIDE_SCALE;
 
-	/**
-	 * The SQL + operator.
-	 *
-	 * @param addend1	One of the addends
-	 * @param addend2	The other addend
-	 * @param result	The result of the previous call to this method, null
-	 *					if not called yet.
-	 *
-	 * @return	The sum of the two addends
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue plus(NumberDataValue addend1,
-						 NumberDataValue addend2,
-						 NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL + operator.
+     *
+     * @param addend1    One of the addends
+     * @param addend2    The other addend
+     * @param result    The result of the previous call to this method, null
+     *                    if not called yet.
+     *
+     * @return    The sum of the two addends
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue plus(NumberDataValue addend1,
+                         NumberDataValue addend2,
+                         NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * The SQL - operator.
-	 *
-	 * @param left		The left operand
-	 * @param right		The right operand
-	 * @param result	The result of the previous call to this method, null
-	 *					if not called yet.
-	 *
-	 * @return	left - right
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue minus(NumberDataValue left,
-						  NumberDataValue right,
-						  NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL - operator.
+     *
+     * @param left        The left operand
+     * @param right        The right operand
+     * @param result    The result of the previous call to this method, null
+     *                    if not called yet.
+     *
+     * @return    left - right
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue minus(NumberDataValue left,
+                          NumberDataValue right,
+                          NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * The SQL * operator.
-	 *
-	 * @param left		The left operand
-	 * @param right		The right operand
-	 * @param result	The result of the previous call to this method, null
-	 *					if not called yet.
-	 *
-	 * @return	left * right
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue times(NumberDataValue left,
-						  NumberDataValue right,
-						  NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL * operator.
+     *
+     * @param left        The left operand
+     * @param right        The right operand
+     * @param result    The result of the previous call to this method, null
+     *                    if not called yet.
+     *
+     * @return    left * right
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue times(NumberDataValue left,
+                          NumberDataValue right,
+                          NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * The SQL / operator.
-	 *
-	 * @param dividend		The numerator
-	 * @param divisor		The denominator
-	 * @param result		The result of the previous call to this method, null
-	 *						if not called yet.
-	 *
-	 * @return	dividend / divisor
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue divide(NumberDataValue dividend,
-						   NumberDataValue divisor,
-						   NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL / operator.
+     *
+     * @param dividend        The numerator
+     * @param divisor        The denominator
+     * @param result        The result of the previous call to this method, null
+     *                        if not called yet.
+     *
+     * @return    dividend / divisor
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue divide(NumberDataValue dividend,
+                           NumberDataValue divisor,
+                           NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * The SQL / operator.
-	 *
-	 * @param dividend		The numerator
-	 * @param divisor		The denominator
-	 * @param result		The result of the previous call to this method, null
-	 *						if not called yet.
-	 * @param scale			The scale of the result, for decimal type.  If pass
-	 *						in value < 0, can calculate it dynamically.
-	 *
-	 * @return	dividend / divisor
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue divide(NumberDataValue dividend,
-						   NumberDataValue divisor,
-						   NumberDataValue result,
-						   int scale)
-							throws StandardException;
+    /**
+     * The SQL / operator.
+     *
+     * @param dividend        The numerator
+     * @param divisor        The denominator
+     * @param result        The result of the previous call to this method, null
+     *                        if not called yet.
+     * @param scale            The scale of the result, for decimal type.  If pass
+     *                        in value < 0, can calculate it dynamically.
+     *
+     * @return    dividend / divisor
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue divide(NumberDataValue dividend,
+                           NumberDataValue divisor,
+                           NumberDataValue result,
+                           int scale)
+                            throws StandardException;
 
 
-	/**
-	 * The SQL mod operator.
-	 *
-	 * @param dividend		The numerator
-	 * @param divisor		The denominator
-	 * @param result		The result of the previous call to this method, null
-	 *						if not called yet.
-	 *
-	 * @return	dividend / divisor
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue mod(NumberDataValue dividend,
-						NumberDataValue divisor,
-						NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL mod operator.
+     *
+     * @param dividend        The numerator
+     * @param divisor        The denominator
+     * @param result        The result of the previous call to this method, null
+     *                        if not called yet.
+     *
+     * @return    dividend / divisor
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue mod(NumberDataValue dividend,
+                        NumberDataValue divisor,
+                        NumberDataValue result)
+                            throws StandardException;
 
-	/**
-	 * The SQL unary - operator.  Negates this NumberDataValue.
-	 *
-	 * @param result	The result of the previous call to this method, null
-	 *					if not called yet.
-	 *
-	 * @return	- operand
-	 *
-	 * @exception StandardException		Thrown on error, if result is non-null then its value will be unchanged.
-	 */
-	NumberDataValue minus(NumberDataValue result)
-							throws StandardException;
+    /**
+     * The SQL unary - operator.  Negates this NumberDataValue.
+     *
+     * @param result    The result of the previous call to this method, null
+     *                    if not called yet.
+     *
+     * @return    - operand
+     *
+     * @exception StandardException        Thrown on error, if result is non-null then its value will be unchanged.
+     */
+    NumberDataValue minus(NumberDataValue result)
+                            throws StandardException;
 
     /**
      * The SQL ABSOLUTE operator.  Absolute value of this NumberDataValue.
@@ -176,7 +176,7 @@ public interface NumberDataValue extends DataValueDescriptor
      *
      * @exception StandardException     Thrown on error, if result is non-null then its value will be unchanged.
      */
-	NumberDataValue absolute(NumberDataValue result)
+    NumberDataValue absolute(NumberDataValue result)
                             throws StandardException;
 
     /**
@@ -187,57 +187,57 @@ public interface NumberDataValue extends DataValueDescriptor
      * 
      * @exception StandardException     Thrown on error (a negative number), if result is non-null then its value will be unchanged.
      */
-	NumberDataValue sqrt(NumberDataValue result)
+    NumberDataValue sqrt(NumberDataValue result)
                             throws StandardException;
 
-	/**
-	 * Set the value of this NumberDataValue to the given value.
-	   This is only intended to be called when mapping values from
-	   the Java space into the SQL space, e.g. parameters and return
-	   types from procedures and functions. Each specific type is only
-	   expected to handle the explicit type according the JDBC.
-	   <UL>
-	   <LI> SMALLINT from java.lang.Integer
-	   <LI> INTEGER from java.lang.Integer
-	   <LI> LONG from java.lang.Long
-	   <LI> FLOAT from java.lang.Float
-	   <LI> DOUBLE from java.lang.Double
-	   <LI> DECIMAL from java.math.BigDecimal
-	   </UL>
-	 *
-	 * @param theValue	An Number containing the value to set this
-	 *					NumberDataValue to.  Null means set the value
-	 *					to SQL null.
-	 *
-	 */
-	void setValue(Number theValue) throws StandardException;
+    /**
+     * Set the value of this NumberDataValue to the given value.
+       This is only intended to be called when mapping values from
+       the Java space into the SQL space, e.g. parameters and return
+       types from procedures and functions. Each specific type is only
+       expected to handle the explicit type according the JDBC.
+       <UL>
+       <LI> SMALLINT from java.lang.Integer
+       <LI> INTEGER from java.lang.Integer
+       <LI> LONG from java.lang.Long
+       <LI> FLOAT from java.lang.Float
+       <LI> DOUBLE from java.lang.Double
+       <LI> DECIMAL from java.math.BigDecimal
+       </UL>
+     *
+     * @param theValue    An Number containing the value to set this
+     *                    NumberDataValue to.  Null means set the value
+     *                    to SQL null.
+     *
+     */
+    void setValue(Number theValue) throws StandardException;
 
-	/**
-		Return the SQL precision of this specific DECIMAL value.
-		This does not match the return from BigDecimal.precision()
-		added in J2SE 5.0, which represents the precision of the unscaled value.
-		If the value does not represent a SQL DECIMAL then
-		the return is undefined.
-	*/
-	int getDecimalValuePrecision();
+    /**
+        Return the SQL precision of this specific DECIMAL value.
+        This does not match the return from BigDecimal.precision()
+        added in J2SE 5.0, which represents the precision of the unscaled value.
+        If the value does not represent a SQL DECIMAL then
+        the return is undefined.
+    */
+    int getDecimalValuePrecision();
 
-	/**
-		Return the SQL scale of this specific DECIMAL value.
-		This does not match the return from BigDecimal.scale()
-		since in J2SE 5.0 onwards that can return negative scales.
-		If the value does not represent a SQL DECIMAL then
-		the return is undefined.
-	*/
-	int getDecimalValueScale();
+    /**
+        Return the SQL scale of this specific DECIMAL value.
+        This does not match the return from BigDecimal.scale()
+        since in J2SE 5.0 onwards that can return negative scales.
+        If the value does not represent a SQL DECIMAL then
+        the return is undefined.
+    */
+    int getDecimalValueScale();
 
-	/**
-	 * Returns BigDecimal representation of value
-	 * @return BigDecimal value
-	 * @throws StandardException
-	 */
-	BigDecimal getBigDecimal() throws StandardException;
+    /**
+     * Returns BigDecimal representation of value
+     * @return BigDecimal value
+     * @throws StandardException
+     */
+    BigDecimal getBigDecimal() throws StandardException;
 
-	StringDataValue digits(NumberDataValue source, int len, StringDataValue result) throws StandardException;
+    StringDataValue digits(NumberDataValue source, int len, StringDataValue result) throws StandardException;
 }
 
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -477,6 +477,7 @@ public class GenericStatement implements Statement{
         setMulticolumnInlistProbeOnSparkEnabled(lcc, cc);
         setConvertMultiColumnDNFPredicatesToInList(lcc, cc);
         setDisablePredicateSimplification(lcc, cc);
+        setDisableConstantFolding(lcc, cc);
         setNativeSparkAggregationMode(lcc, cc);
         setAllowOverflowSensitiveNativeSparkExpressions(lcc, cc);
         setNewMergeJoin(lcc, cc);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -43,6 +43,7 @@ package com.splicemachine.db.impl.sql.compile;
  import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
  import com.splicemachine.db.iapi.store.access.ScanController;
  import com.splicemachine.db.iapi.store.access.StoreCostController;
+ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
  import com.splicemachine.db.iapi.types.DataValueDescriptor;
  import com.splicemachine.db.iapi.types.Orderable;
  import com.splicemachine.db.iapi.types.TypeId;
@@ -1170,11 +1171,10 @@ public class BinaryRelationalOperatorNode
             ConstantNode leftOp=(ConstantNode)getLeftOperand();
             ConstantNode rightOp=(ConstantNode)getRightOperand();
 
-            if (leftOp.isNull()) {
-                return getLeftOperand();
-            }
-            if (rightOp.isNull()) {
-                return getRightOperand();
+            if (leftOp.isNull() || rightOp.isNull()) {
+                ValueNode newNull = new UntypedNullConstantNode(getContextManager());
+                newNull.setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN));
+                return newNull;
             }
 
             DataValueDescriptor leftVal = leftOp.getValue();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryRelationalOperatorNode.java
@@ -1169,10 +1169,18 @@ public class BinaryRelationalOperatorNode
                 getRightOperand() instanceof ConstantNode){
             ConstantNode leftOp=(ConstantNode)getLeftOperand();
             ConstantNode rightOp=(ConstantNode)getRightOperand();
-            DataValueDescriptor leftVal=leftOp.getValue();
-            DataValueDescriptor rightVal=rightOp.getValue();
 
-            if(leftVal != null && !leftVal.isNull() && rightVal != null && !rightVal.isNull()){
+            if (leftOp.isNull()) {
+                return getLeftOperand();
+            }
+            if (rightOp.isNull()) {
+                return getRightOperand();
+            }
+
+            DataValueDescriptor leftVal = leftOp.getValue();
+            DataValueDescriptor rightVal = rightOp.getValue();
+
+            if(leftVal != null && !leftVal.isNull() && rightVal != null && !rightVal.isNull()) {
                 int comp=leftVal.compare(rightVal);
                 switch(operatorType){
                     case EQUALS_RELOP:

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConcatenationOperatorNode.java
@@ -93,7 +93,7 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
             StringDataValue leftValue = (StringDataValue) leftOp.getValue();
             StringDataValue rightValue = (StringDataValue) rightOp.getValue();
 
-            StringDataValue resultValue = null;
+            StringDataValue resultValue;
             DataTypeDescriptor resultDTD = getTypeServices();
             if (resultDTD == null) {
                 TypeId resultTypeId =
@@ -106,6 +106,7 @@ public class ConcatenationOperatorNode extends BinaryOperatorNode {
             else
                 resultValue = (StringDataValue) resultDTD.getNull();
 
+            assert resultValue != null;
             resultValue.concatenate(leftValue, rightValue, resultValue);
 
             return (ValueNode) getNodeFactory().getNode(

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ConstantNode.java
@@ -31,6 +31,7 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.types.TypeId;
 import com.splicemachine.db.iapi.error.StandardException;
@@ -99,6 +100,10 @@ public abstract class ConstantNode extends ValueNode
     ConstantNode()
     {
         super();
+    }
+
+    ConstantNode(ContextManager cm) {
+        super(cm);
     }
 
     /**

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/InListOperatorNode.java
@@ -45,6 +45,7 @@ import com.splicemachine.db.iapi.sql.compile.Optimizable;
 import com.splicemachine.db.iapi.types.*;
 
 import java.lang.reflect.Modifier;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -983,7 +984,9 @@ public final class InListOperatorNode extends BinaryListOperatorNode
 
         DataValueDescriptor lhs = ((ConstantNode) getLeftOperand()).getValue();
         if (lhs == null || lhs.isNull()) {
-            return this;
+            ValueNode newNull = new UntypedNullConstantNode(getContextManager());
+            newNull.setType(DataTypeDescriptor.getBuiltInDataTypeDescriptor(Types.BOOLEAN));
+            return newNull;
         }
         boolean constantResult = false;
         for (int i = 0; i < getRightOperandList().size(); ++i) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NotNode.java
@@ -95,7 +95,23 @@ public final class NotNode extends UnaryLogicalOperatorNode
     /** @see ValueNode#evaluateConstantExpressions */
     @Override
     ValueNode evaluateConstantExpressions() throws StandardException {
-        return (getOperand() instanceof UntypedNullConstantNode) ? getOperand() : this;
+        if (getOperand() instanceof ConstantNode) {
+            ConstantNode op = (ConstantNode) getOperand();
+            if (op.isNull()) {
+                return getOperand();
+            } else if (op instanceof BooleanConstantNode) {
+                if (op.isBooleanTrue()) {
+                    return (ValueNode) getNodeFactory().getNode(C_NodeTypes.BOOLEAN_CONSTANT_NODE,
+                            Boolean.FALSE,
+                            getContextManager());
+                } else {
+                    return (ValueNode) getNodeFactory().getNode(C_NodeTypes.BOOLEAN_CONSTANT_NODE,
+                            Boolean.TRUE,
+                            getContextManager());
+                }
+            }
+        }
+        return this;
     }
 
     public void generateExpression(ExpressionClassBuilder acb,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/NumericConstantNode.java
@@ -46,11 +46,23 @@ import java.sql.Types;
 public final class NumericConstantNode extends ConstantNode
 {
     public NumericConstantNode() {}
-    public NumericConstantNode(ContextManager cm, int nodeType, Object arg1) throws StandardException {
+
+    private NumericConstantNode(ContextManager cm, int nodeType) {
         setContextManager(cm);
         setNodeType(nodeType);
+    }
+
+    public NumericConstantNode(ContextManager cm, int nodeType, Object arg1) throws StandardException {
+        this(cm, nodeType);
         init(arg1);
     }
+
+    public NumericConstantNode(ContextManager cm, int nodeType, NumberDataValue numberDataValue, DataTypeDescriptor type) throws StandardException {
+        this(cm, nodeType);
+        this.setValue(numberDataValue);
+        this.setType(type);
+    }
+
     /**
      * Initializer for a typed null node
      *
@@ -80,7 +92,6 @@ public final class NumericConstantNode extends ConstantNode
             isNullable = Boolean.FALSE;
             valueInP = true;
         }
-
 
         switch (getNodeType())
         {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryArithmeticOperatorNode.java
@@ -38,11 +38,14 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
+import com.splicemachine.db.iapi.types.NumberDataValue;
 import com.splicemachine.db.iapi.types.TypeId;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.sql.Types;
 import java.util.List;
+
+import static com.splicemachine.db.iapi.reference.ClassName.NumberDataValue;
 
 /**
  * This node represents a unary arithmetic operator
@@ -122,7 +125,22 @@ public class UnaryArithmeticOperatorNode extends UnaryOperatorNode{
     @Override
     ValueNode evaluateConstantExpressions() throws StandardException {
         if(operatorType == UNARY_MINUS || operatorType == UNARY_PLUS) {
-            return (getOperand() instanceof UntypedNullConstantNode) ? getOperand() : this;
+            if (getOperand() instanceof ConstantNode) {
+                ConstantNode op = (ConstantNode) getOperand();
+                if (op.isNull()) {
+                    return op;
+                } else if (op instanceof NumericConstantNode) {
+                    if (operatorType == UNARY_PLUS) {
+                        return getOperand();
+                    } else {
+                        return new NumericConstantNode(
+                                getContextManager(),
+                                op.getNodeType(),
+                                ((NumberDataValue) op.getValue()).minus(null),
+                                null);
+                    }
+                }
+            }
         }
         return this;
     }
@@ -183,8 +201,8 @@ public class UnaryArithmeticOperatorNode extends UnaryOperatorNode{
             checkOperandIsNumeric(getOperand().getTypeId());
         }
         /*
-		** The result type of a +, -, SQRT, ABS is the same as its operand.
-		*/
+        ** The result type of a +, -, SQRT, ABS is the same as its operand.
+        */
         super.setType(getOperand().getTypeServices());
         return this;
     }
@@ -213,7 +231,7 @@ public class UnaryArithmeticOperatorNode extends UnaryOperatorNode{
     public void generateExpression(ExpressionClassBuilder acb,
                                    MethodBuilder mb)
             throws StandardException{
-		/* Unary + doesn't do anything.  Just return the operand */
+        /* Unary + doesn't do anything.  Just return the operand */
         if(operatorType==UNARY_PLUS)
             getOperand().generateExpression(acb,mb);
         else
@@ -230,29 +248,29 @@ public class UnaryArithmeticOperatorNode extends UnaryOperatorNode{
         TypeId operandType;
         int jdbcType;
 
-		/*
-		** Check the type of the operand 
-		*/
+        /*
+        ** Check the type of the operand
+        */
         operandType=getOperand().getTypeId();
 
-		/*
-	 	 * If the operand is not a build-in type, generate a bound conversion
-		 * tree to build-in types.
-		 */
+        /*
+         * If the operand is not a build-in type, generate a bound conversion
+         * tree to build-in types.
+         */
         if(operandType.userType()){
             setOperand(getOperand().genSQLJavaSQLTree());
         }
-		/* DB2 doesn't cast string types to numeric types for numeric functions  */
+        /* DB2 doesn't cast string types to numeric types for numeric functions  */
 
         jdbcType=operandType.getJDBCTypeId();
 
-		/* Both SQRT and ABS are only allowed on numeric types */
+        /* Both SQRT and ABS are only allowed on numeric types */
         if(!operandType.isNumericTypeId())
             throw StandardException.newException(
                     SQLState.LANG_UNARY_FUNCTION_BAD_TYPE,
                     getOperatorString(),operandType.getSQLTypeName());
 
-		/* For SQRT, if operand is not a DOUBLE, convert it to DOUBLE */
+        /* For SQRT, if operand is not a DOUBLE, convert it to DOUBLE */
         if(operatorType==SQRT && jdbcType!=Types.DOUBLE){
             castOperandAndBindCast(new DataTypeDescriptor(TypeId.getBuiltInTypeId(Types.DOUBLE),true));
         }
@@ -264,7 +282,7 @@ public class UnaryArithmeticOperatorNode extends UnaryOperatorNode{
      * binding. The setType method will call the binding code after setting
      * the type of the parameter
      */
-    public void setType(DataTypeDescriptor descriptor) throws StandardException{
+    public void setType(DataTypeDescriptor descriptor) throws StandardException {
         if(getOperand().requiresTypeFromContext() && getOperand().getTypeServices()==null){
             checkOperandIsNumeric(descriptor.getTypeId());
             getOperand().setType(descriptor);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UntypedNullConstantNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UntypedNullConstantNode.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.iapi.services.compiler.MethodBuilder;
+import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
@@ -47,72 +48,76 @@ import java.util.Vector;
 
 public final class UntypedNullConstantNode extends ConstantNode
 {
-	/**
-	 * Constructor for an UntypedNullConstantNode.  Untyped constants
-	 * contain no state (not too surprising).
-	 */
+    /**
+     * Constructor for an UntypedNullConstantNode.  Untyped constants
+     * contain no state (not too surprising).
+     */
 
-	public UntypedNullConstantNode()
-	{
-		super();
-	}
+    public UntypedNullConstantNode()
+    {
+        super();
+    }
 
-	/**
-	 * Return the length
-	 *
-	 * @return	The length of the value this node represents
-	 *
-	 */
+    public UntypedNullConstantNode(ContextManager cm) {
+        super(cm);
+    }
 
-	//public int	getLength()
-	//{
-	//	if (SanityManager.DEBUG)
-	//	SanityManager.ASSERT(false,
-	//	  "Unimplemented method - should not be called on UntypedNullConstantNode");
-	//	return 0;
-	//}
+    /**
+     * Return the length
+     *
+     * @return    The length of the value this node represents
+     *
+     */
 
-	/**
-	 * Should never be called for UntypedNullConstantNode because
-	 * we shouldn't make it to generate
-	 *
-	 * @param acb	The ExpressionClassBuilder for the class being built
-	 * @param mb	The method the expression will go into
-	 */
-	void generateConstant(ExpressionClassBuilder acb, MethodBuilder mb)
-	{
-		if (SanityManager.DEBUG)
-		{
-			SanityManager.THROWASSERT("generateConstant() not expected to be called for UntypedNullConstantNode because we have implemented our own generateExpression().");
-		}
-	}
+    //public int    getLength()
+    //{
+    //    if (SanityManager.DEBUG)
+    //    SanityManager.ASSERT(false,
+    //      "Unimplemented method - should not be called on UntypedNullConstantNode");
+    //    return 0;
+    //}
 
-	/**
-	 * Translate a Default node into a default value, given a type descriptor.
-	 *
-	 * @param typeDescriptor	A description of the required data type.
-	 *
-	 */
-	public DataValueDescriptor convertDefaultNode(DataTypeDescriptor typeDescriptor)
-	throws StandardException
-	{
-		/*
-		** The default value is null, so set nullability to TRUE
-		*/
-		return typeDescriptor.getNull();
-	}
-	
-	/** @see ValueNode#bindExpression(FromList, SubqueryList, Vector)
-	 * @see ResultColumnList#bindUntypedNullsToResultColumns
-	 * This does nothing-- the node is actually bound when
-	 * bindUntypedNullsToResultColumns is called.
-	 */
-	public ValueNode bindExpression(FromList fromList, SubqueryList	subqueryList, List<AggregateNode> aggregateVector)
-	{
-		return this;
-	}
-	
-	public int hashCode(){
-		return value==null? 0: value.hashCode();
-	}
+    /**
+     * Should never be called for UntypedNullConstantNode because
+     * we shouldn't make it to generate
+     *
+     * @param acb    The ExpressionClassBuilder for the class being built
+     * @param mb    The method the expression will go into
+     */
+    void generateConstant(ExpressionClassBuilder acb, MethodBuilder mb)
+    {
+        if (SanityManager.DEBUG)
+        {
+            SanityManager.THROWASSERT("generateConstant() not expected to be called for UntypedNullConstantNode because we have implemented our own generateExpression().");
+        }
+    }
+
+    /**
+     * Translate a Default node into a default value, given a type descriptor.
+     *
+     * @param typeDescriptor    A description of the required data type.
+     *
+     */
+    public DataValueDescriptor convertDefaultNode(DataTypeDescriptor typeDescriptor)
+    throws StandardException
+    {
+        /*
+        ** The default value is null, so set nullability to TRUE
+        */
+        return typeDescriptor.getNull();
+    }
+
+    /** @see ValueNode#bindExpression(FromList, SubqueryList, Vector)
+     * @see ResultColumnList#bindUntypedNullsToResultColumns
+     * This does nothing-- the node is actually bound when
+     * bindUntypedNullsToResultColumns is called.
+     */
+    public ValueNode bindExpression(FromList fromList, SubqueryList    subqueryList, List<AggregateNode> aggregateVector)
+    {
+        return this;
+    }
+
+    public int hashCode(){
+        return value==null? 0: value.hashCode();
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ConstantFoldingIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ConstantFoldingIT.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.db.impl.sql.compile;
+
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.homeless.TestUtils;
+import com.splicemachine.test.SerialTest;
+import com.splicemachine.test_tools.TableCreator;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import splice.com.google.common.collect.Lists;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static com.splicemachine.test_tools.Rows.row;
+import static com.splicemachine.test_tools.Rows.rows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test constant folding
+ */
+@RunWith(Parameterized.class)
+@Category(SerialTest.class)
+public class ConstantFoldingIT extends SpliceUnitTest {
+
+    private Boolean disableConstantFolding;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = Lists.newArrayListWithCapacity(2);
+        params.add(new Object[]{false});
+        params.add(new Object[]{true});
+        return params;
+    }
+
+    @Parameterized.BeforeParam
+    public static void beforeParam(boolean disableConstantFolding) throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute(format("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', '%s')", disableConstantFolding));
+    }
+
+    @Parameterized.AfterParam
+    public static void afterParam() throws Exception {
+        classWatcher.execute("CALL SYSCS_UTIL.SYSCS_EMPTY_GLOBAL_STATEMENT_CACHE()");
+        classWatcher.execute("CALL SYSCS_UTIL.INVALIDATE_GLOBAL_DICTIONARY_CACHE()");
+        classWatcher.execute("call syscs_util.syscs_set_global_database_property('splice.database.disableConstantFolding', null)");
+    }
+
+    private static final String SCHEMA = ConstantFoldingIT.class.getSimpleName();
+
+    @ClassRule
+    public static SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(SCHEMA);
+
+    @ClassRule
+    public static SpliceWatcher classWatcher = new SpliceWatcher(SCHEMA);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher(SCHEMA);
+
+    public ConstantFoldingIT(Boolean disableConstantFolding) {
+        this.disableConstantFolding = disableConstantFolding;
+    }
+
+    private void assertSkipTableScan(String query) throws Exception {
+        testExplainContains(query, methodWatcher, Collections.singletonList("Values"), Collections.singletonList("TableScan"));
+    }
+
+    private void assertTableScan(String query) throws Exception {
+        testExplainContains(query, methodWatcher, Collections.singletonList("TableScan"), null);
+    }
+
+    private String buildCountQuery(String predicate) {
+        return format("select count(*) from sysibm.sysdummy1 where %s", predicate);
+    }
+
+    private void checkFalsePredicates(List<String> predicates) throws Exception {
+        for (String p: predicates) {
+            String q = buildCountQuery(p);
+            checkIntExpression(q, 0, methodWatcher);
+            if (!disableConstantFolding) {
+                assertSkipTableScan(q);
+            }
+        }
+    }
+
+    private void checkTruePredicates(List<String> predicates) throws Exception {
+        for (String p: predicates) {
+            String q = buildCountQuery(p);
+            checkIntExpression(q, 1, methodWatcher);
+        }
+    }
+
+    @Test
+    public void testNot() throws Exception {
+        checkFalsePredicates(Arrays.asList(
+                "(not true) = true",
+                "(not false) = false",
+                "(not false) = case when 1=0 then true end"
+        ));
+        checkTruePredicates(Arrays.asList(
+                "not true = false",
+                "not false = true"
+        ));
+    }
+
+    @Test
+    public void testConditional() throws Exception {
+        checkFalsePredicates(Arrays.asList(
+                "case when 1 = 0 then true else false end",
+                "case when 1 = 1 then false else true end",
+                "case when case when 1 = 0 then false end then true else true end"
+        ));
+        checkTruePredicates(Arrays.asList(
+                "case when 1 = 1 then true else false end",
+                "case when 1 = 0 then false else true end",
+                "case when 1 = 1 then true end"
+        ));
+    }
+
+    @Test
+    public void testBinaryRelationOperator() throws Exception {
+        checkFalsePredicates(Arrays.asList(
+                "1 = 0",
+                "1 < 0",
+                "0 > 1",
+                "1 <= 0",
+                "0 >= 1",
+                "1 <> 1",
+                "1 = case when 1 = 0 then 1 end",
+                "'abc' > 'def'",
+                "true = false"
+
+        ));
+        checkTruePredicates(Arrays.asList(
+                "1 <> 0",
+                "1 > 0",
+                "0 < 1",
+                "1 >= 0",
+                "0 <= 1",
+                "1 = 1",
+                "'abc' = 'abc'",
+                "false = false"
+        ));
+    }
+
+    @Test
+    public void testUnaryMinusPlus() throws Exception {
+        checkFalsePredicates(Arrays.asList(
+                "1 = - (0)",
+                "1 = + (0)"
+        ));
+        checkTruePredicates(Arrays.asList(
+                "-1 = - (1)",
+                "1 = + (1)"
+        ));
+    }
+}
+
+
+

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateSimplificationIT.java
@@ -219,7 +219,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         List<String> containedStrings = Arrays.asList("MultiProbeIndexScan", "(A1[0:1] IN (1,2,3,4,5,6)");
         List<String> notContainedStrings = null;
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -234,7 +234,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
 
         containedStrings = Arrays.asList("MultiProbeIndexScan", "(A1[0:1] IN (4,5,6)");
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -246,7 +246,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("Values(");
         notContainedStrings = Arrays.asList("TableScan");
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -288,14 +288,14 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("MultiProbeIndexScan", "preds");
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
             "where (true or a1 in (1,2,3) and a2 in (10,20,30) and a3 in (100,200,300)) ", useSpark);
 
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select 1 from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -314,7 +314,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
             containedStrings = Arrays.asList("MultiProbeIndexScan", "[((A1[0:1],A2[0:2]) IN ((4,40),(4,50),(4,60),(5,40),(5,50),(5,60),(6,40),(6,50),(6,60)))]");
         notContainedStrings = null;
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
     }
 
@@ -337,7 +337,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         String query;
         List<String> containedStrings;
         List<String> notContainedStrings;
-        if (!disablePredicateSimpification) {
+        if (!disablePredicateSimpification && !disableConstantFolding) {
             query = format("select 1 from A, B --SPLICE-PROPERTIES joinStrategy=MERGE, useSpark=%s\n" +
                     "where a1 = b1 or false ", useSpark);
 
@@ -358,7 +358,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         notContainedStrings = Arrays.asList("preds");;
         testQuery(query, expected);
 
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -408,7 +408,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("preds");;
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -416,7 +416,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
             "a1 in (select d1 from D) ", useSpark);
 
         testQuery(query, expected);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testExplainContains(query, containedStrings, notContainedStrings);
     }
 
@@ -439,7 +439,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         List<String> notContainedStrings = null;
         List<Integer> paramList = Arrays.asList(1,2,3,4,5,6);
         testPreparedQuery(query, expected, paramList);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         containedStrings = Arrays.asList("Values(");
@@ -475,7 +475,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -501,7 +501,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s\n" +
@@ -528,7 +528,7 @@ public class PredicateSimplificationIT  extends SpliceUnitTest {
         containedStrings = Arrays.asList("");
         notContainedStrings = Arrays.asList("Values", "preds");
         testPreparedQuery(query, expected, paramList);
-        if (!disablePredicateSimpification)
+        if (!disablePredicateSimpification && !disableConstantFolding)
             testParameterizedExplainContains(query, containedStrings, notContainedStrings, paramList);
 
         query = format("select count(*) from A --SPLICE-PROPERTIES useSpark=%s, index=pred_simpl_a1_a2\n" +

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -1318,6 +1318,26 @@ public class SpliceUnitTest {
         }
     }
 
+    protected void checkIntExpression(String input, int expectedOutput, TestConnection conn) throws SQLException {
+        String sql = addPotentiallyMissingSelect(input);
+        try(ResultSet rs = conn.query(sql)) {
+            rs.next();
+            Assert.assertEquals(expectedOutput, rs.getInt(1));
+        }
+    }
+
+    protected void checkIntExpression(String input, int expectedOutput, SpliceWatcher methodWatcher) throws SQLException {
+        checkIntExpression(input, expectedOutput, methodWatcher.getOrCreateConnection());
+    }
+
+    private String addPotentiallyMissingSelect(String input) {
+        if (!input.toLowerCase().startsWith("select")) {
+            return format("select %s", input);
+        } else {
+            return input;
+        }
+    }
+
     public static boolean isMemPlatform(SpliceWatcher watcher) throws Exception{
         try (ResultSet rs = watcher.executeQuery("CALL SYSCS_UTIL.SYSCS_IS_MEM_PLATFORM()")) {
             rs.next();


### PR DESCRIPTION
## Short Description
Support NOT, unary minus, conditional and binary relational operator constant folding


## Long Description
- **DB-12145** NOT: Support for constant folding added for null and non null operands

- **DB-12148** Conditional node: Support for constant folding added for null and non null operands. If the condition is constant but then or else isn't, remove the condition and return the correct underlying operand

- **DB-12146** Unary plus / minus: Support for constant folding added for nulls and non null number operand.

- **DB-12147** BinaryRelationalOperatorNode: Support added for null operands. Non null operand constant folding was already implemented.

## How to test
This can be tested via an explain on a simple select: 
```
explain select * from sysibm.sysdummy1 where 1 = -(1)
```
will return a plan without a table scan because `1 = -(1)` is evaluated to be false at compile time
The same principle will apply to `true = not false`, `true = case when true then true else false end`, etc.
A new IT was created and should be referred to for more details. 