### PR TITLE
DB-12094 Fix TriggerHandler cleanup

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -761,6 +761,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         if (triggeringResultSet != null)
         {
             triggeringResultSet.close();
+            triggeringResultSet = null;
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -57,14 +57,15 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         if (outerCost != null && outerCost.getJoinType() == JoinNode.FULLOUTERJOIN)
             return false;
 
-        if (isJoinWithTriggerRows(innerTable, optimizer))
+        if (hasTriggerRowsAsInnerTableOfJoin(innerTable, optimizer))
             return false;
 
         return innerTable.isMaterializable() || innerTable.supportsMultipleInstantiations();
     }
 
     // Nested loop join on Spark does not work correctly when using a common
-    // Dataset to access the trigger REFERENCING NEW/OLD TABLE rows:
+    // Dataset to access the trigger REFERENCING NEW/OLD TABLE rows as the
+    // inner table of the join:
     //         see useCommonDataSet in TriggerNewTransitionRows.
     // The compilation of a trigger is saved as a stored prepared statement in
     // the data dictionary, and reloaded/reused by each new triggering statement.
@@ -75,17 +76,12 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
     // OLTP-compiled trigger which uses nested loop join would need to be
     // recompiled as forced-OLAP, and avoid choosing nested loop join.
     // Therefore we must always avoid nested loop join for statement triggers
-    // with a REFERENCING clause, even if compiled for OLTP execution.
-    private boolean isJoinWithTriggerRows(Optimizable innerTable, Optimizer optimizer) {
+    // with a REFERENCING clause when the trigger VTI is the inner table of
+    // the join, even if compiled for OLTP execution.
+    private boolean hasTriggerRowsAsInnerTableOfJoin(Optimizable innerTable, Optimizer optimizer) {
         if (!isSingleTableScan(optimizer)) {
             if (innerTable.isTriggerVTI())
                 return true;
-            ResultSetNode outerTable = optimizer.getOuterTable();
-            if (outerTable instanceof Optimizable) {
-                Optimizable outerOptimizable = (Optimizable)outerTable;
-                if (outerOptimizable.isTriggerVTI())
-                    return true;
-            }
         }
         return false;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
@@ -544,15 +544,33 @@ public class TriggerRowHolderImpl implements TemporaryRowHolder, Externalizable
 
         if (conglomCreated)
             dropConglomerate();
-        else
-        {
-             if (SanityManager.DEBUG) {
-                 SanityManager.ASSERT(CID == 0, "CID(" + CID + ")==0");
+        else {
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(CID == 0, "CID(" + CID + ")==0");
+            }
         }
-     }
-     state = STATE_UNINIT;
-     lastArraySlot = -1;
-     numRowsIn = 0;
+        state = STATE_UNINIT;
+        lastArraySlot = -1;
+        numRowsIn = 0;
+        writeCoordinator = null;
+        triggerTempPartition = null;
+        triggerTempTableWriteBuffer = null;
+        triggerTempTableflushCallback = null;
+        pipelineBufferCreated = false;
+        conglomCreated = false;
+    }
+
+    public boolean canBeReused(boolean isSpark, long conglomID) {
+        if (CID != conglomID)
+            return false;
+        if (this.isSpark != isSpark)
+            return false;
+        if (conglomCreated || pipelineBufferCreated)
+            return false;
+        if (numRowsIn != 0 || lastArraySlot != -1 || state != STATE_UNINIT)
+            return false;
+
+        return true;
     }
 
     public int getLastArraySlot() { return lastArraySlot; }

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
@@ -794,15 +794,16 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
             s.execute("drop trigger mytrig");
 
             // Nested loop join should be illegal on spark
-            // when the NEW TABLE or OLD TABLE is involved.
+            // when the NEW TABLE or OLD TABLE is the inner table.
             testFail("42Y69",
                      "CREATE TRIGGER mytrig\n" +
                         "   AFTER UPDATE OF a,b\n" +
                         "   ON t1\n" +
                         "   REFERENCING OLD TABLE AS OLD NEW TABLE AS NEW\n" +
                         "   FOR EACH STATEMENT\n" +
-                        "   INSERT INTO T2 SELECT NEW.A, NEW.B from NEW --splice-properties joinStrategy=nestedloop \n" +
-                        "   , T1 --splice-properties joinStrategy=nestedloop \n", s);
+                        "   INSERT INTO T2 SELECT NEW.A, NEW.B from --splice-properties joinOrder=fixed \n" +
+                        "   T1, " +
+                        "   NEW --splice-properties joinStrategy=nestedloop \n", s);
         }
     }
 


### PR DESCRIPTION
## Short Description
TriggerHandler does not clean up the trigger rows result sets properly for prepared statements.

## Long Description
TriggerHandler -> triggerActivator -> tec (TriggerExecutionContext) may accumulate ResultSets in the resultSetVector of TriggerExecutionContext because TriggerHandler.cleanup() skips calling triggerActivator.cleanup when cleanup1Done is true. The specialized cleanup logic was originally added to avoid calling cleanup code repetitively in case it's called through different code flows.  When prepared statements are used, the same TriggerHandler may be used over and over again.  cleanup1Done doesn't get reset in between uses of the TriggerHandler, so any subsequent executions of the prepared statement may skip cleanup of the ResultSet which holds the trigger rows that were inserted/updated/deleted.

The fix is to restore the old TriggerHandler cleanup code and always call the cleanup routines.

Also, DB-11580 disallowed nested loop join for statement triggers.  Really, only the inner table of a nested loop join may not be the trigger VTI because the right side is executed in a separate thread, but not the left side (left == outer, right == inner).  So, the trigger VTI restriction on the outer table is removed.  This restriction was causing the updateHistoryTableConcurrently test in the FeatureStoreTriggerBenchmark not to run.

A canBeReused method is also added to TriggerRowHolderImpl.  Now, TriggerHandler will attempt to reuse a previously allocated trigger row holder on subsequent statement executions to avoid allocating the row buffer over and over again, which should help avoid unnecessary memory pressure.

## How to test
Run FeatureStoreTriggerBenchmark#updateHistoryTableConcurrently multiple times with a memory profiler or debugger attached and verify there is no leak of ResultSets.
