### PR TITLE
DB-12109 Favor NLJ for PK joins with the trigger VTI

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/execute/TriggerExecutionContext.java
@@ -761,6 +761,7 @@ public class TriggerExecutionContext implements ExecutionStmtValidator, External
         if (triggeringResultSet != null)
         {
             triggeringResultSet.close();
+            triggeringResultSet = null;
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/catalog/TriggerNewTransitionRows.java
@@ -88,7 +88,7 @@ import static com.splicemachine.derby.impl.sql.execute.operations.ScanOperation.
 public class TriggerNewTransitionRows
                    implements DatasetProvider, VTICosting, AutoCloseable {
 
-        private static final double DUMMY_ROWCOUNT_ESTIMATE = 1000;
+        private static final double DUMMY_ROWCOUNT_ESTIMATE = 1;
         private static final double DUMMY_COST_ESTIMATE = 1000;
 	private ResultSet resultSet;
 	private DataSet<ExecRow> sourceSet;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/NestedLoopJoinStrategy.java
@@ -57,14 +57,15 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
         if (outerCost != null && outerCost.getJoinType() == JoinNode.FULLOUTERJOIN)
             return false;
 
-        if (isJoinWithTriggerRows(innerTable, optimizer))
+        if (hasTriggerRowsAsInnerTableOfJoin(innerTable, optimizer))
             return false;
 
         return innerTable.isMaterializable() || innerTable.supportsMultipleInstantiations();
     }
 
     // Nested loop join on Spark does not work correctly when using a common
-    // Dataset to access the trigger REFERENCING NEW/OLD TABLE rows:
+    // Dataset to access the trigger REFERENCING NEW/OLD TABLE rows as the
+    // inner table of the join:
     //         see useCommonDataSet in TriggerNewTransitionRows.
     // The compilation of a trigger is saved as a stored prepared statement in
     // the data dictionary, and reloaded/reused by each new triggering statement.
@@ -75,17 +76,12 @@ public class NestedLoopJoinStrategy extends BaseJoinStrategy{
     // OLTP-compiled trigger which uses nested loop join would need to be
     // recompiled as forced-OLAP, and avoid choosing nested loop join.
     // Therefore we must always avoid nested loop join for statement triggers
-    // with a REFERENCING clause, even if compiled for OLTP execution.
-    private boolean isJoinWithTriggerRows(Optimizable innerTable, Optimizer optimizer) {
+    // with a REFERENCING clause when the trigger VTI is the inner table of
+    // the join, even if compiled for OLTP execution.
+    private boolean hasTriggerRowsAsInnerTableOfJoin(Optimizable innerTable, Optimizer optimizer) {
         if (!isSingleTableScan(optimizer)) {
             if (innerTable.isTriggerVTI())
                 return true;
-            ResultSetNode outerTable = optimizer.getOuterTable();
-            if (outerTable instanceof Optimizable) {
-                Optimizable outerOptimizable = (Optimizable)outerTable;
-                if (outerOptimizable.isTriggerVTI())
-                    return true;
-            }
         }
         return false;
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1NestedLoopJoinCostEstimationModel.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1NestedLoopJoinCostEstimationModel.java
@@ -20,10 +20,7 @@ import com.splicemachine.db.iapi.sql.compile.*;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.conn.SessionProperties;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
-import com.splicemachine.db.impl.sql.compile.FromBaseTable;
-import com.splicemachine.db.impl.sql.compile.Predicate;
-import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
-import com.splicemachine.db.impl.sql.compile.SelectivityUtil;
+import com.splicemachine.db.impl.sql.compile.*;
 
 import static com.splicemachine.db.impl.sql.compile.JoinNode.INNERJOIN;
 
@@ -51,6 +48,11 @@ public class V1NestedLoopJoinCostEstimationModel implements StrategyJoinCostEsti
             return;
         }
 
+        double joinCostScaleFactor = 1.0d;
+        // Favor nested loop join for triggers that can utilize an index.
+        if (outerTableIsTriggerVTI(optimizer) && hasJoinPredicateWithIndexKeyLookup(predList))
+            joinCostScaleFactor = 0.1d;
+
         //set the base costs for the join
         innerCost.setBase(innerCost.cloneMe());
         double totalRowCount = outerCost.rowCount() * innerCost.rowCount();
@@ -65,9 +67,20 @@ public class V1NestedLoopJoinCostEstimationModel implements StrategyJoinCostEsti
         innerCost.setRemoteCostPerParallelTask(remoteCostPerPartition);
         double joinCost = nestedLoopJoinStrategyLocalCost(innerCost, outerCost, totalRowCount, optimizer.isForSpark());
         joinCost += nljOnSparkPenalty;
+        joinCost *= joinCostScaleFactor;
         innerCost.setLocalCost(joinCost);
         innerCost.setLocalCostPerParallelTask(joinCost);
         innerCost.setSingleScanRowCount(innerCost.getEstimatedRowCount());
+    }
+
+    private boolean outerTableIsTriggerVTI(Optimizer optimizer) {
+        ResultSetNode outerTable = optimizer.getOuterTable();
+        if (outerTable instanceof Optimizable) {
+            Optimizable outerOptimizable = (Optimizable)outerTable;
+            if (outerOptimizable.isTriggerVTI())
+                return true;
+        }
+        return false;
     }
 
     // Nested loop join is most useful if it can be used to

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/TriggerRowHolderImpl.java
@@ -544,15 +544,33 @@ public class TriggerRowHolderImpl implements TemporaryRowHolder, Externalizable
 
         if (conglomCreated)
             dropConglomerate();
-        else
-        {
-             if (SanityManager.DEBUG) {
-                 SanityManager.ASSERT(CID == 0, "CID(" + CID + ")==0");
+        else {
+            if (SanityManager.DEBUG) {
+                SanityManager.ASSERT(CID == 0, "CID(" + CID + ")==0");
+            }
         }
-     }
-     state = STATE_UNINIT;
-     lastArraySlot = -1;
-     numRowsIn = 0;
+        state = STATE_UNINIT;
+        lastArraySlot = -1;
+        numRowsIn = 0;
+        writeCoordinator = null;
+        triggerTempPartition = null;
+        triggerTempTableWriteBuffer = null;
+        triggerTempTableflushCallback = null;
+        pipelineBufferCreated = false;
+        conglomCreated = false;
+    }
+
+    public boolean canBeReused(boolean isSpark, long conglomID) {
+        if (CID != conglomID)
+            return false;
+        if (this.isSpark != isSpark)
+            return false;
+        if (conglomCreated || pipelineBufferCreated)
+            return false;
+        if (numRowsIn != 0 || lastArraySlot != -1 || state != STATE_UNINIT)
+            return false;
+
+        return true;
     }
 
     public int getLastArraySlot() { return lastArraySlot; }

--- a/splice_machine/src/test/java/com/splicemachine/benchmark/FeatureStoreTriggerBenchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/benchmark/FeatureStoreTriggerBenchmark.java
@@ -375,7 +375,7 @@ public class FeatureStoreTriggerBenchmark extends Benchmark {
                         "FOR EACH STATEMENT " +
                         "INSERT INTO FeatureTable (entity_key, last_update_ts, feature1, feature2) --splice-properties insertMode=UPSERT\n" +
                         "SELECT n.entity_key, n.asof_ts, n.feature1, n.feature2 " +
-                        "FROM NEWW n LEFT JOIN FeatureTable o --splice-properties joinStrategy=nestedloop\n" +
+                        "FROM NEWW n LEFT JOIN FeatureTable o \n" +
                         "ON n.entity_key = o.entity_key WHERE (o.last_update_ts IS NULL OR o.last_update_ts < n.asof_ts)"
         );
     }

--- a/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/triggers/Trigger_Referencing_Clause_IT.java
@@ -794,15 +794,16 @@ public class Trigger_Referencing_Clause_IT extends SpliceUnitTest {
             s.execute("drop trigger mytrig");
 
             // Nested loop join should be illegal on spark
-            // when the NEW TABLE or OLD TABLE is involved.
+            // when the NEW TABLE or OLD TABLE is the inner table.
             testFail("42Y69",
                      "CREATE TRIGGER mytrig\n" +
                         "   AFTER UPDATE OF a,b\n" +
                         "   ON t1\n" +
                         "   REFERENCING OLD TABLE AS OLD NEW TABLE AS NEW\n" +
                         "   FOR EACH STATEMENT\n" +
-                        "   INSERT INTO T2 SELECT NEW.A, NEW.B from NEW --splice-properties joinStrategy=nestedloop \n" +
-                        "   , T1 --splice-properties joinStrategy=nestedloop \n", s);
+                        "   INSERT INTO T2 SELECT NEW.A, NEW.B from --splice-properties joinOrder=fixed \n" +
+                        "   T1, " +
+                        "   NEW --splice-properties joinStrategy=nestedloop \n", s);
         }
     }
 


### PR DESCRIPTION
### https://github.com/splicemachine/spliceengine/pull/5544 must merge before this PR.

## Short Description
Improve performance of joins between NEW TABLE or OLD TABLE and a splice internal table in a statement trigger.

## Long Description
A join between a single-row NEW TABLE and a base table on the primary key chose broadcast join instead of nested loop join, resulting in poor throughput.  Triggers are precompiled, so we have no way of knowing how many rows will be updated/inserted/deleted in the triggering statement, so no way to cost joins accurately.  The feature store use cases may involve single row inserts/updates or batch updates of thousands of rows.  We need to handle both efficiently and hopefully also avoid trigger recompilation.  The solution in this case is to adjust the DUMMY_ROWCOUNT_ESTIMATE in TriggerNewTransitionRows from 1000 down to 1 and also scale the join cost of nested loop join by a factor of 0.1 when the outer table is the trigger VTI and there are join predicates that can be used as start/stop keys.  Nested loop join on the base table PK will be fast for both small updates and large updates.  In the updateHistoryTableConcurrently test of FeatureStoreTriggerBenchmark the joinStrategy hint in the trigger of test FeatureStoreTriggerBenchmark is removed and no longer required.  Nested loop join is now picked without the hint.

In the future maybe there is something we can do to dynamically detect the number of rows in NEW/OLD TABLE, and force a trigger recompilation when this value differs significantly from the row count estimate used in the last trigger compilation.  This would be a large change though and would require tuning to avoid recompiling triggers too often.

## How to test
Run the updateHistoryTableConcurrently test of FeatureStoreTriggerBenchmark and observe that the ops/second throughput is high (above 2000) and matches the result when hinting nested loop join.
