### PR TITLE
DB-11930 Fix SpliceMultiRowRangeFilter for hdp3.1.0 (3.1)

### DIFF
--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
@@ -98,7 +98,12 @@ public class SpliceMultiRowRangeFilter extends MultiRowRangeFilter {
     public Cell getNextCellHint(Cell currentKV) {
         // skip to the next range's start row
         // #getComparisonData lets us avoid the `if (reversed)` branch
-        byte[] comparisonData = range.getComparisonData();
+        byte[] comparisonData;
+        if (reversed) {
+            comparisonData = range.getStopRow();
+        } else  {
+            comparisonData = range.getStartRow();
+        }
         return PrivateCellUtil.createFirstOnRow(comparisonData, 0, (short) comparisonData.length);
     }
 
@@ -236,7 +241,8 @@ public class SpliceMultiRowRangeFilter extends MultiRowRangeFilter {
             return insertionPosition;
           }
           // the row key equals one of the start keys, and the the range exclude the start key
-          if(ranges.get(index).isSearchRowInclusive() == false) {
+          // We do not support reverse scan, so we can check for start row inclusive here
+          if(!ranges.get(index).isStartRowInclusive() == false) {
             exclusive = true;
           }
           return index;

--- a/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
+++ b/hbase_storage/src/main/java/com/splicemachine/derby/hbase/SpliceMultiRowRangeFilter.java
@@ -242,7 +242,7 @@ public class SpliceMultiRowRangeFilter extends MultiRowRangeFilter {
           }
           // the row key equals one of the start keys, and the the range exclude the start key
           // We do not support reverse scan, so we can check for start row inclusive here
-          if(!ranges.get(index).isStartRowInclusive() == false) {
+          if(!ranges.get(index).isStartRowInclusive()) {
             exclusive = true;
           }
           return index;


### PR DESCRIPTION
## Description

Fix for DB-11930 that is necessary because we cannot use getComparisonData and isSearchRowInclusive since they were introduced in hbase 2.1