### PR TITLE
DB-12032 FeatureStoreTriggerBenchmark: improve performance of batch updates 

### DIFF
--- a/splice_machine/src/test/java/com/splicemachine/benchmark/FeatureStoreTriggerBenchmark.java
+++ b/splice_machine/src/test/java/com/splicemachine/benchmark/FeatureStoreTriggerBenchmark.java
@@ -209,6 +209,8 @@ public class FeatureStoreTriggerBenchmark extends Benchmark {
         taskId.set(0);
         runBenchmark(connections, () -> populateStagingTable(curTimestamp, nextTimestamp));
         curTimestamp = nextTimestamp;
+
+        testStatement.execute("ANALYZE TABLE FeatureStaging");
     }
 
     public void insertAndUpdateFromBatches() {


### PR DESCRIPTION
## Short Description
A pre-populated staging table is used in batch updates of FeatureTable or FeatureHistoryTable. How the table is generated is crucial for batch update performance.

## Long Description
The staging table is populated by batched inserts from multiple concurrent connections. It's important to turn autocommit off in those connections in order to avoid generating a large number of small transactions which will need to be resolved when the table is queried.
TRUNCATE does not preserve pre-split points specified at table creation time. Had to replace with DROP and re-CREATE.
ANALYZE the staging table to get better load balance for Spark tasks scanning the table. 

## How to test
Run FeatureStoreTriggerBenchmark as an integration test either in standalone or cluster environment.