### PR TITLE
DB-12132 Put cost model property into GlobalDBProperties, add an IT

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -832,9 +832,13 @@ public class GenericStatement implements Statement{
     }
 
     private void setCostModelName(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
-        String costModelString = PropertyUtil.getCachedDatabaseProperty(lcc, Property.COST_MODEL);
-        if (costModelString != null && CostModelRegistry.exists(costModelString)) {
+        String costModelString = PropertyUtil.getCached(lcc, GlobalDBProperties.COST_MODEL);
+        if (costModelString == null) {
+            cc.setCostModelName(CompilerContext.DEFAULT_COST_MODEL_NAME);
+        } else if (CostModelRegistry.exists(costModelString)) {
             cc.setCostModelName(costModelString);
+        } else if (costModelString.equalsIgnoreCase("null")) {
+            cc.setCostModelName(CompilerContext.DEFAULT_COST_MODEL_NAME);
         }
     }
 

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
@@ -136,4 +136,9 @@ public class GlobalDBProperties {
             new PropertyType("splice.execution.newMergeJoin",
                     "use new merge join. possible values: on, off, forced",
                     new Validator.MultipleOptions(new String[]{"on", "off", "forced"}));
+
+    public static PropertyType COST_MODEL =
+            new PropertyType("costModel",
+                             "cost model version, usable versions are v1 and v2",
+                             new Validator.MultipleOptions(new String[]{"v1", "v2"}));
 }

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
@@ -139,6 +139,6 @@ public class GlobalDBProperties {
 
     public static PropertyType COST_MODEL =
             new PropertyType("costModel",
-                             "cost model version, usable versions are v1 and v2",
+                             "cost model version, available versions are v1 and v2",
                              new Validator.MultipleOptions(new String[]{"v1", "v2"}));
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/GlobalDatabasePropertyIT.java
@@ -78,4 +78,24 @@ public class GlobalDatabasePropertyIT extends SpliceUnitTest {
             setProperty("derby.database.selectivityEstimationIncludingSkewedDefault", "NULL");
         }
     }
+
+    @Test
+    public void testCostModel() throws Exception {
+        String getPropertyQuery = "call syscs_util.syscs_get_global_database_property('costModel')";
+        String testQuery = "explain select * from sys.systables";
+        try (TestConnection conn = methodWatcher.getOrCreateConnection()) {
+            setProperty("costModel", "v2");
+            try (Statement s = conn.createStatement();
+                ResultSet rs = s.executeQuery(getPropertyQuery)) {
+                while (rs.next()) {
+                    String result = rs.getString("PROPERTY_VALUE");
+                    Assert.assertTrue(result.compareToIgnoreCase("v2") == 0);
+                }
+            }
+            rowContainsQuery(3, testQuery, "costModel=v2", methodWatcher);
+        } finally {
+            setProperty("costModel", "NULL");
+            rowContainsQuery(3, testQuery, "costModel=v1", methodWatcher);
+        }
+    }
 }


### PR DESCRIPTION
## Short Description
This PR refactors `costModel` database property to be part of `GlobalDBProperties` class, using its capability of having a validator. Also, an IT `testCostModel()` is added to `GlobalDatabasePropertyIT`.

## Long Description
No long description needed for this PR.

## How to test
```
call syscs_util.syscs_set_global_database_property('costModel', 'v2');
call syscs_util.syscs_get_global_database_property('costModel');  -- should see v2 as the value
explain select * from sys.systables;  -- should see costModel=v2 in plan, no need to drop current session

call syscs_util.syscs_set_global_database_property('costModel', 'NULL');
call syscs_util.syscs_get_global_database_property('costModel');  -- should see NULL as the value
explain select * from sys.systables;  -- should see costModel=v1 in plan since v1 is the default value, no need to drop current session
```
