### PR TITLE
DB-11855 Fix index corruption caused by foreign key on delete set null action (3.0)

### DIFF
--- a/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
+++ b/pipeline_api/src/main/java/com/splicemachine/pipeline/PipelineWriter.java
@@ -279,7 +279,8 @@ public class PipelineWriter{
                 case INSERT:
                     privileges.add(Authorizer.INSERT_PRIV);
                     break;
-                case UPDATE:
+                case UPDATE: // fallthrough
+                case BLIND_UPDATE:
                     privileges.add(Authorizer.UPDATE_PRIV);
                     break;
                 case UPSERT:

--- a/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
+++ b/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
@@ -31,7 +31,13 @@ public class KVPair implements Comparable<KVPair> {
         EMPTY_COLUMN((byte)0x04),
         UPSERT((byte)0x05),
         /* For import process to cancel out an inserted row that violates a unique constraint */
-        CANCEL((byte)0x08);
+        CANCEL((byte)0x08),
+        /* Very similar to UPDATE, however it hints the index handler to perform a base table lookup
+        * if necessary to reconstruct the missing index columns, this could happen e.g. when deleting
+        * a row from a parent table causes an indirect update of its child table(s), in this situation
+        * we do not have upfront the old data of the updated child table(s) row(s) and we need to perform
+        * a base table lookup to construct each one of them. */
+        BLIND_UPDATE((byte)0x09);
 
         private final byte typeCode;
 
@@ -49,7 +55,7 @@ public class KVPair implements Comparable<KVPair> {
         }
 
         public boolean isUpdateOrUpsert() {
-            return UPDATE.equals(this) || UPSERT.equals(this);
+            return UPDATE.equals(this) || UPSERT.equals(this) || BLIND_UPDATE.equals(this) ;
         }
     }
 

--- a/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
+++ b/splice_encoding/src/main/java/com/splicemachine/kvpair/KVPair.java
@@ -32,7 +32,7 @@ public class KVPair implements Comparable<KVPair> {
         UPSERT((byte)0x05),
         /* For import process to cancel out an inserted row that violates a unique constraint */
         CANCEL((byte)0x08),
-        /* Very similar to UPDATE, however it hints the index handler to perform a base table lookup
+        /* Similar to UPDATE, however it hints the index handler to perform a base table lookup
         * if necessary to reconstruct the missing index columns, this could happen e.g. when deleting
         * a row from a parent table causes an indirect update of its child table(s), in this situation
         * we do not have upfront the old data of the updated child table(s) row(s) and we need to perform

--- a/splice_encoding/src/main/java/com/splicemachine/storage/Utils.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/Utils.java
@@ -55,14 +55,20 @@ public class Utils {
                 if(toBitIndex.isSet(i)) {
                     to.seekForward(toDecoder,i);
                 }
+                if(buffer == null) {
+                    multiFieldEncoder.encodeEmpty();
+                } else {
+                    buffer = buffer.slice();
+                    multiFieldEncoder.setRawBytes(buffer.array(), buffer.arrayOffset(), buffer.limit());
+                }
             } else if(toBitIndex.isSet(i)) {
                 buffer = to.nextAsBuffer(toDecoder, i);
-            }
-            if(buffer == null) {
-                multiFieldEncoder.encodeEmpty();
-            } else {
-                buffer = buffer.slice();
-                multiFieldEncoder.setRawBytes(buffer.array(), buffer.arrayOffset(), buffer.limit());
+                if(buffer == null) {
+                    multiFieldEncoder.encodeEmpty();
+                } else {
+                    buffer = buffer.slice();
+                    multiFieldEncoder.setRawBytes(buffer.array(), buffer.arrayOffset(), buffer.limit());
+                }
             }
         }
     }

--- a/splice_encoding/src/main/java/com/splicemachine/storage/Utils.java
+++ b/splice_encoding/src/main/java/com/splicemachine/storage/Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.storage;
+
+import com.splicemachine.encoding.MultiFieldDecoder;
+import com.splicemachine.encoding.MultiFieldEncoder;
+import com.splicemachine.storage.index.BitIndex;
+
+import java.nio.ByteBuffer;
+
+public class Utils {
+    public static void meld(EntryDecoder to, EntryDecoder from, EntryEncoder encoder) {
+        BitIndex toBitIndex = to.getCurrentIndex();
+        BitIndex fromBitIndex = from.getCurrentIndex();
+        MultiFieldDecoder toDecoder = to.getEntryDecoder();
+        MultiFieldDecoder fromDecoder = from.getEntryDecoder();
+        MultiFieldEncoder multiFieldEncoder = encoder.getEntryEncoder();
+        int i = 0;
+        int length = Integer.max(toBitIndex.length(), fromBitIndex.length());
+        for (i = 0; i < length; ++i) {
+            if(fromBitIndex.isSet(i)) {
+                ByteBuffer buffer = from.nextAsBuffer(fromDecoder, i).slice();
+                multiFieldEncoder.setRawBytes(buffer.array(), buffer.arrayOffset(), buffer.limit());
+            } else if(toBitIndex.isSet(i)) {
+                ByteBuffer buffer = to.nextAsBuffer(toDecoder, i).slice();
+                multiFieldEncoder.setRawBytes(buffer.array(), buffer.arrayOffset(), buffer.limit());
+            }
+        }
+    }
+}

--- a/splice_encoding/src/test/java/com/splicemachine/encoding/TestType.java
+++ b/splice_encoding/src/test/java/com/splicemachine/encoding/TestType.java
@@ -177,6 +177,11 @@ public enum TestType  {
         public void check(MultiFieldDecoder decoder, Object correct) {
             Assert.assertEquals("Incorrect Float encode/decode", (Float) correct, decoder.decodeNextFloat(),FLOAT_SIZE);
         }
+
+        @Override
+        public boolean isFloatType() {
+            return true;
+        }
     },
     DOUBLE{
         @Override public Object generateRandom(Random random) { return random.nextDouble(); }
@@ -198,6 +203,11 @@ public enum TestType  {
         @Override
         public void check(MultiFieldDecoder decoder, Object correct) {
             Assert.assertEquals("Incorrect Double encode/decode", (Double) correct, decoder.decodeNextDouble(),DOUBLE_SIZE);
+        }
+
+        @Override
+        public boolean isDoubleType() {
+            return true;
         }
     },
     DECIMAL{
@@ -381,6 +391,10 @@ public enum TestType  {
             decoder.skipFloat();
         }
 
+        @Override
+        public boolean isFloatType() {
+            return true;
+        }
     },
     NULL_DOUBLE{
         @Override
@@ -408,6 +422,11 @@ public enum TestType  {
         public void check(MultiFieldDecoder decoder, Object correct) {
             Assert.assertTrue("Value is not null!",decoder.nextIsNullDouble());
             decoder.skipDouble();
+        }
+
+        @Override
+        public boolean isDoubleType() {
+            return true;
         }
     };
 
@@ -438,6 +457,14 @@ public enum TestType  {
     }
 
     public boolean isScalarType() {
+        return false;
+    }
+
+    public boolean isFloatType() {
+        return false;
+    }
+
+    public boolean isDoubleType() {
         return false;
     }
 }

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
@@ -133,4 +133,40 @@ public class EntryEncoderTest {
         Assert.assertTrue("expected: "+ correct+", actual: "+ next,correct.compareTo(next)==0);
 
     }
+
+    @Test
+    public void testEncoderMeld() throws Exception {
+        BitSet fromBits = new BitSet(3);
+        fromBits.set(1);
+        BitSet fromScalarBits = new BitSet();
+        fromScalarBits.set(1);
+        EntryEncoder fromEncoder = EntryEncoder.create(defaultPool,3, fromBits, fromScalarBits, null, null);
+        fromEncoder.getEntryEncoder().encodeNext(42);
+        EntryDecoder fromDecoder = new EntryDecoder();
+        fromDecoder.set(fromEncoder.encode());
+
+        BitSet toBits = new BitSet(3);
+        toBits.set(0);
+        toBits.set(1);
+        toBits.set(2);
+        BitSet toScalarBits = new BitSet();
+        toScalarBits.set(0);
+        toScalarBits.set(1);
+        toScalarBits.set(2);
+        EntryEncoder toEncoder = EntryEncoder.create(defaultPool,3, toBits, toScalarBits, null, null);
+        toEncoder.getEntryEncoder().encodeNext(100).encodeNext(200).encodeNext(300);
+        EntryDecoder toDecoder = new EntryDecoder();
+        toDecoder.set(toEncoder.encode());
+
+        EntryEncoder resultEncoder = EntryEncoder.create(defaultPool, toEncoder.getBitIndex());
+
+        Utils.meld(toDecoder, fromDecoder, resultEncoder);
+
+        EntryDecoder resultDecoder = new EntryDecoder();
+        resultDecoder.set(resultEncoder.encode());
+        MultiFieldDecoder resultMultiFieldDecoder = resultDecoder.getEntryDecoder();
+        Assert.assertEquals(100, resultMultiFieldDecoder.decodeNextInt());
+        Assert.assertEquals(42, resultMultiFieldDecoder.decodeNextInt());
+        Assert.assertEquals(200, resultMultiFieldDecoder.decodeNextInt());
+    }
 }

--- a/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
+++ b/splice_encoding/src/test/java/com/splicemachine/storage/EntryEncoderTest.java
@@ -16,11 +16,22 @@ package com.splicemachine.storage;
 
 import com.splicemachine.encoding.MultiFieldDecoder;
 import com.splicemachine.encoding.MultiFieldEncoder;
+import com.splicemachine.encoding.TestType;
+import com.splicemachine.utils.Pair;
 import com.splicemachine.utils.kryo.KryoPool;
 import org.junit.Assert;
 import org.junit.Test;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.carrotsearch.hppc.BitSet;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 /**
  * @author Scott Fines
@@ -135,38 +146,216 @@ public class EntryEncoderTest {
     }
 
     @Test
-    public void testEncoderMeld() throws Exception {
-        BitSet fromBits = new BitSet(3);
-        fromBits.set(1);
-        BitSet fromScalarBits = new BitSet();
-        fromScalarBits.set(1);
-        EntryEncoder fromEncoder = EntryEncoder.create(defaultPool,3, fromBits, fromScalarBits, null, null);
-        fromEncoder.getEntryEncoder().encodeNext(42);
-        EntryDecoder fromDecoder = new EntryDecoder();
-        fromDecoder.set(fromEncoder.encode());
+    public void testMelding() throws Exception {
+        meldTest(asList(TestType.BOOLEAN, TestType.INTEGER), asList(Boolean.TRUE, 100),
+                 singletonList(TestType.INTEGER), singletonList(42), singletonList(1),
+                 asList(TestType.BOOLEAN, TestType.INTEGER), asList(Boolean.TRUE, 42));
+    }
 
-        BitSet toBits = new BitSet(3);
-        toBits.set(0);
-        toBits.set(1);
-        toBits.set(2);
-        BitSet toScalarBits = new BitSet();
-        toScalarBits.set(0);
-        toScalarBits.set(1);
-        toScalarBits.set(2);
-        EntryEncoder toEncoder = EntryEncoder.create(defaultPool,3, toBits, toScalarBits, null, null);
-        toEncoder.getEntryEncoder().encodeNext(100).encodeNext(200).encodeNext(300);
-        EntryDecoder toDecoder = new EntryDecoder();
-        toDecoder.set(toEncoder.encode());
+    @Test
+    public void testMeldingRandomData() throws Exception {
+        for(int i = 0; i < 100; i++) {
+            List<Pair<TestType, Object>> orig = generateRandomEncoder(200);
+            Pair<List<Pair<TestType, Object>>, List<Integer>> blindUpdate = generateBlindUpdate(orig, 100);
+            List<Pair<TestType, Object>> expected = generateExpectedResult(orig,blindUpdate);
+            meldTest(orig, blindUpdate.getFirst(), blindUpdate.getSecond(), expected);
+        }
+    }
 
-        EntryEncoder resultEncoder = EntryEncoder.create(defaultPool, toEncoder.getBitIndex());
+    ////////////////////////////// helper functions //////////////////////////////////////////////////
+
+    /**
+     * Generates a random list of {@link TestType} and values for simulating an encoded row
+     * with {@code colCount} columns.
+     * @param colCount The number of columns.
+     * @return randomly generated list of {@link TestType} and values.
+     */
+    private List<Pair<TestType, Object>> generateRandomEncoder(int colCount) {
+        assert colCount > 0;
+
+        List<Pair<TestType, Object>> result = new ArrayList<>(colCount);
+        Random random = new Random(0L);
+        for(int i = 0; i < colCount; ++i) {
+            TestType type = TestType.values()[random.nextInt(TestType.values().length)];
+            Object value = type.generateRandom(random);
+            result.add(new Pair<>(type, value));
+        }
+        return result;
+    }
+
+    /**
+     * Simulates a blind update where some columns from the passed {@code orig} are updated. The updated columns are
+     * randomly picked.
+     *
+     * @param orig the list of {@link TestType} and values representing the row which we want to blindly update.
+     * @param updatedColCount the desired number of updated columns.
+     *
+     * @return a {@link Pair} of randomly picked update columns and a list of the updated column indices.
+     *
+     * Example:
+     *    orig = { {INTEGER, 42}, {STRING, "foo"}, {Byte, 0x14}, {FLOAT, 3.14} }
+     *    updatedColCount = 2
+     *    possible output:
+     *    < {{STRING, "bar"}, {FLOAT, 6.28}}, {1,3}  >
+     */
+    private Pair<List<Pair<TestType, Object>>, List<Integer>> generateBlindUpdate(List<Pair<TestType, Object>> orig,
+                                                                          int updatedColCount) {
+        List<Pair<TestType, Object>> list = new ArrayList<>(updatedColCount);
+        List<Integer> updatedColIndices = new ArrayList<>(updatedColCount);
+        Random random = new Random(0L);
+        for(int i = 0; i < updatedColCount; ++i) {
+            int pickedColIndex = random.nextInt(orig.size());
+            while(updatedColIndices.contains(pickedColIndex)) {
+                pickedColIndex = random.nextInt(orig.size());
+            }
+            updatedColIndices.add(pickedColIndex);
+        }
+        updatedColIndices.sort(Integer::compareTo);
+
+        for(int i = 0; i < updatedColCount; i++) {
+            int pickedColIndex = updatedColIndices.get(i);
+            Pair<TestType, Object> pickedCol = orig.get(pickedColIndex);
+            Object newValue = pickedCol.getFirst().generateRandom(random);
+            list.add(new Pair<>(pickedCol.getFirst(), newValue));
+        }
+        return new Pair<>(list, updatedColIndices);
+    }
+
+    /**
+     * Generates a list of expected melding result.
+     *
+     * @param orig the list of {@link TestType} and values representing the row which we want to blindly update.
+     * @param blindUpdate the blind update, i.e. list of randomly chosen columns' {@link TestType} and values and their
+     *                    indices.
+     * @return the list of {@link TestType} and values representing the resulting melded row.
+     *
+     * Example:
+     *    orig = { {INTEGER, 42}, {STRING, "foo"}, {Byte, 0x14}, {FLOAT, 3.14} }
+     *    blinkUpdate = < {{STRING, "bar"}, {FLOAT, 6.28}}, {1,3}  >
+     *    result:
+     *   { {INTEGER, 42}, {STRING, "bar"}, {Byte, 0x14}, {FLOAT, 6.28} }
+     */
+    private static List<Pair<TestType, Object>> generateExpectedResult(List<Pair<TestType, Object>> orig,
+                                                                       Pair<List<Pair<TestType, Object>>, List<Integer>> blindUpdate) {
+        assert orig != null;
+        assert blindUpdate != null;
+        assert blindUpdate.getFirst() != null && blindUpdate.getFirst().size() < orig.size();
+        assert blindUpdate.getSecond() != null;
+
+        List<Pair<TestType, Object>> result = new ArrayList<>(orig);
+
+        int cnt = 0;
+        for(int updateColIndex : blindUpdate.getSecond()) {
+            result.set(updateColIndex, blindUpdate.getFirst().get(cnt++));
+        }
+
+        return result;
+    }
+
+    private static void meldTest(List<TestType> toTypes, List<Object> toValues,
+                                 List<TestType> fromTypes, List<Object> fromValues, List<Integer> fromSetBits,
+                                 List<TestType> expectedTypes, List<Object> expectedValues) {
+        assert toTypes != null && toValues != null && toTypes.size() == toValues.size();
+        assert fromTypes != null && fromValues != null && fromTypes.size() == fromValues.size();
+        assert expectedTypes != null && expectedValues != null && expectedTypes.size() == expectedValues.size();
+        assert fromTypes.size() <= toTypes.size();
+        assert fromSetBits != null && fromSetBits.size() <= fromTypes.size();
+
+        meldTest(zip(toTypes, toValues), zip(fromTypes, fromValues),fromSetBits, zip(expectedTypes, expectedValues));
+    }
+
+    private static void meldTest(List<Pair<TestType, Object>> toDecoderData,
+                                 List<Pair<TestType, Object>> fromDecoderData, List<Integer> fromSetBits,
+                                 List<Pair<TestType, Object>> expectedData ) {
+
+        BitSet bitSet = new BitSet();
+        for(Integer setBit : fromSetBits) {
+            bitSet.set(setBit);
+        }
+
+        EntryDecoder toDecoder = generateDecoder(toDecoderData, toDecoderData.size());
+        EntryDecoder fromDecoder = generateDecoder(fromDecoderData, fromDecoderData.size(), bitSet);
+
+        EntryEncoder resultEncoder = EntryEncoder.create(defaultPool, toDecoder.getCurrentIndex());
 
         Utils.meld(toDecoder, fromDecoder, resultEncoder);
 
-        EntryDecoder resultDecoder = new EntryDecoder();
-        resultDecoder.set(resultEncoder.encode());
-        MultiFieldDecoder resultMultiFieldDecoder = resultDecoder.getEntryDecoder();
-        Assert.assertEquals(100, resultMultiFieldDecoder.decodeNextInt());
-        Assert.assertEquals(42, resultMultiFieldDecoder.decodeNextInt());
-        Assert.assertEquals(200, resultMultiFieldDecoder.decodeNextInt());
+        valuesShouldBe(expectedData,resultEncoder);
+    }
+
+    public static <A, B> List<Pair<A, B>> zip(List<A> as, List<B> bs) {
+        assert as != null && bs != null && as.size() == bs.size();
+        return IntStream.range(0, as.size())
+                .mapToObj(i -> new Pair<>(as.get(i), bs.get(i)))
+                .collect(Collectors.toList());
+    }
+
+    private static EntryDecoder generateDecoder(List<Pair<TestType, Object>> data,
+                                                int colCount) {
+        return generateDecoder(data, colCount, null);
+    }
+
+    /**
+     * Generates an {@link EntryDecoder} from a list of given {@link TestType} and values.
+     *
+     * @param data The {@link EntryDecoder}'s data.
+     * @param colCount The number of columns, note that it could be different from the data size.
+     * @param setBits A bitset of all set columns from pair-wise data.
+     * @return a {@link EntryDecoder} with all {@code data} encoded properly and bitset indexes generated correctly.
+     */
+    private static EntryDecoder generateDecoder(List<Pair<TestType, Object>> data,
+                                                int colCount,
+                                                BitSet setBits) {
+         boolean withSetBits = false;
+        if(setBits == null) {
+            setBits = new BitSet();
+            withSetBits = true;
+        }
+        BitSet scalarBitSet = new BitSet();
+        BitSet floatBitSet = new BitSet();
+        BitSet doubleBitSet = new BitSet();
+        int cnt = 0;
+        if(!withSetBits) {
+            for (int i = setBits.nextSetBit(0); i >= 0; i = setBits.nextSetBit(i + 1)) {
+                TestType testType = data.get(cnt++).getFirst();
+                if(testType.isScalarType()) {
+                    scalarBitSet.set(i);
+                } else if(testType.isDoubleType()) {
+                    doubleBitSet.set(i);
+                } else if(testType.isFloatType()) {
+                    floatBitSet.set(i);
+                }
+            }
+        } else {
+            for (int i = 0; i < data.size(); ++i) {
+                TestType testType = data.get(i).getFirst();
+                if (testType.isScalarType()) {
+                    scalarBitSet.set(i);
+                } else if (testType.isDoubleType()) {
+                    doubleBitSet.set(i);
+                } else if (testType.isFloatType()) {
+                    floatBitSet.set(i);
+                }
+                setBits.set(i);
+            }
+        }
+        EntryEncoder entryEncoder = EntryEncoder.create(defaultPool, data.size(), setBits, scalarBitSet, floatBitSet, doubleBitSet);
+        MultiFieldEncoder encoder = entryEncoder.getEntryEncoder();
+        for (Pair<TestType, Object> datum : data) {
+            datum.getFirst().load(encoder, datum.getSecond());
+        }
+        EntryDecoder result = new EntryDecoder();
+        result.set(entryEncoder.encode());
+        return result;
+    }
+
+    private static void valuesShouldBe(List<Pair<TestType, Object>> data,
+                                       EntryEncoder encoder) {
+        EntryDecoder decoder = new EntryDecoder();
+        decoder.set(encoder.encode());
+        MultiFieldDecoder multiFieldDecoder = decoder.getEntryDecoder();
+        for(Pair<TestType, Object> datum : data) {
+            datum.getFirst().check(multiFieldDecoder,datum.getSecond(), false);
+        }
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
@@ -254,7 +254,7 @@ public class IndexTransformer {
         if (ignore)
             return null;
 
-        //add the row key to the end of the index key
+        //add the row key to the end of the index key if the index is not unique.
         byte[] srcRowKey = Encoding.encodeBytesUnsorted(execRow.getKey());
 
         EntryEncoder rowEncoder = getRowEncoder();
@@ -266,11 +266,29 @@ public class IndexTransformer {
         if (index.getUnique()) {
             boolean nonUnique = index.getUniqueWithDuplicateNulls() && (hasNullKeyFields || !keyAccumulator.isFinished());
             indexRowKey = getIndexRowKey(srcRowKey, nonUnique);
-        } else
+        } else {
             indexRowKey = getIndexRowKey(srcRowKey, true);
+        }
         return new KVPair(indexRowKey, indexValue, KVPair.Type.INSERT);
     }
 
+    public KVPair amendBlindUpdate(KVPair mutation, WriteContext ctx, BitSet indexedColumns) throws IOException {
+        DataResult result = fetchBaseRow(mutation, ctx, indexedColumns);
+        if(result!=null && !result.isEmpty() && result.userData() != null){
+            DataCell resultValue = result.userData();
+            EntryDecoder decoder = getSrcValueDecoder();
+            decoder.set(resultValue.valueArray(),resultValue.valueOffset(),resultValue.valueLength());
+            EntryDecoder mutationdecoder = getSrcValueDecoder();
+            mutationdecoder.set(mutation.getValue());
+            EntryEncoder resultEncoder = EntryEncoder.create(SpliceKryoRegistry.getInstance(), decoder.getCurrentIndex());
+            Utils.meld(decoder, mutationdecoder, resultEncoder);
+            byte[] value = resultEncoder.encode();
+            return new KVPair(
+                    resultValue.keyArray(),resultValue.keyOffset(),resultValue.keyLength(),
+                    value,0,value.length,mutation.getType());
+        }
+        return mutation;
+    }
 
     /**
      * Translate the given base table record mutation into its associated, referencing index record.<br/>
@@ -493,6 +511,19 @@ public class IndexTransformer {
         return false;
     }
 
+    /**
+     * Constructs the index row key by finishing off the key accumulator and, if the index
+     * is not unique, it appends the passed `rowLocation` to it, see example below:
+     *          non-unique index row key = \x00\x01\x02\x03
+     *          row location = \x0a\x0b\x0c
+     *          => the resulting non-unique index row key: \x00\x01\x02\x03\x00\x0a\x0b\x0c
+     *
+     * warning: this method has side-effects.
+     *
+     * @param rowLocation the base table corresponding row key.
+     * @param nonUnique true if the index is not unique, otherwise false.
+     * @return the index row key.
+     */
     private byte[] getIndexRowKey(byte[] rowLocation, boolean nonUnique) {
         byte[] data = indexKeyAccumulator.finish();
         if (nonUnique) {
@@ -547,12 +578,48 @@ public class IndexTransformer {
 
     }
 
-    private void accumulate(EntryAccumulator keyAccumulator, int pos,
+    /**
+     * Accumulates an index row into the index's key accumulator. i.e. it serializes the given
+     * index column into the index key byte array.
+     * @param keyAccumulator The index accumulator that holds the index key byte array.
+     * @param pos the position of the newly added column.
+     * @param type the type of the newly added column.
+     * @param reverseOrder true if the column is descending, otherwise false (affects column
+     *                     representation in the byte array).
+     * @param array the array holding the newly added column.
+     * @param offset the offset of the newly added column bytes in @array.
+     * @param length the length of the newly added column bytes.
+     * @throws IOException if accumulation of the column fails.
+     */
+    private void accumulate(EntryAccumulator keyAccumulator,
+                            int pos,
                             int type,
                             boolean reverseOrder,
                             byte[] array, int offset, int length) throws IOException {
         byte[] data = array;
         int off = offset;
+        excludeDefaultValues(pos, type, length, data, off);
+
+        if (reverseOrder) {
+            //TODO -sf- could we cache these byte[] somehow?
+            data = new byte[length];
+            System.arraycopy(array, offset, data, 0, length);
+            for (int i = 0; i < data.length; i++) {
+                data[i] ^= 0xff;
+            }
+            off = 0;
+        }
+        if (typeProvider.isScalar(type))
+            keyAccumulator.addScalar(pos, data, off, length);
+        else if (typeProvider.isDouble(type))
+            keyAccumulator.addDouble(pos, data, off, length);
+        else if (typeProvider.isFloat(type))
+            keyAccumulator.addFloat(pos, data, off, length);
+        else
+            keyAccumulator.add(pos, data, off, length);
+    }
+
+    private void excludeDefaultValues(int pos, int type, int length, byte[] data, int off) throws IOException {
         if (excludeDefaultValues && pos == 0 && defaultValue != null) { // Exclude Default Values
             ExecRowAccumulator era =  getExecRowAccumulator();
             era.reset();
@@ -573,25 +640,6 @@ public class IndexTransformer {
             }
 
         }
-
-
-        if (reverseOrder) {
-            //TODO -sf- could we cache these byte[] somehow?
-            data = new byte[length];
-            System.arraycopy(array, offset, data, 0, length);
-            for (int i = 0; i < data.length; i++) {
-                data[i] ^= 0xff;
-            }
-            off = 0;
-        }
-        if (typeProvider.isScalar(type))
-            keyAccumulator.addScalar(pos, data, off, length);
-        else if (typeProvider.isDouble(type))
-            keyAccumulator.addDouble(pos, data, off, length);
-        else if (typeProvider.isFloat(type))
-            keyAccumulator.addFloat(pos, data, off, length);
-        else
-            keyAccumulator.add(pos, data, off, length);
     }
 
     private boolean skip(MultiFieldDecoder keyDecoder, int sourceKeyColumnType) {
@@ -652,7 +700,7 @@ public class IndexTransformer {
     }
 
 
-    private DataResult fetchBaseRow(KVPair mutation,WriteContext ctx,BitSet indexedColumns) throws IOException{
+    public DataResult fetchBaseRow(KVPair mutation,WriteContext ctx,BitSet indexedColumns) throws IOException{
         baseGet =SIDriver.driver().getOperationFactory().newDataGet(ctx.getTxn(),mutation.getRowKey(),baseGet);
 
         EntryPredicateFilter epf;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
@@ -32,7 +32,6 @@ import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.store.ExecRowAccumulator;
 import com.splicemachine.derby.jdbc.SpliceTransactionResourceImpl;
 import com.splicemachine.derby.utils.DerbyBytesUtil;
-import com.splicemachine.derby.utils.EngineUtils;
 import com.splicemachine.derby.utils.marshall.EntryDataHash;
 import com.splicemachine.derby.utils.marshall.dvd.DescriptorSerializer;
 import com.splicemachine.derby.utils.marshall.dvd.TypeProvider;
@@ -59,7 +58,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static splice.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.curator.shaded.com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Builds an index table KVPair given a base table KVPair.
@@ -85,21 +84,22 @@ import static splice.com.google.common.base.Preconditions.checkArgument;
  */
 @NotThreadSafe
 public class IndexTransformer {
-    private TypeProvider typeProvider;
+    private final TypeProvider typeProvider;
     private MultiFieldDecoder srcKeyDecoder;
     private EntryDecoder srcValueDecoder;
+    private EntryDecoder blindUpdateMutationDecoder;
     private ByteEntryAccumulator indexKeyAccumulator;
     private EntryEncoder indexValueEncoder;
-    private DDLMessage.Index index;
-    private DDLMessage.Table table;
-    private int [] mainColToIndexPosMap;  // 0-based
-    private BitSet indexedCols;   // 0-based
-    private byte[] indexConglomBytes;
-    private int[] indexFormatIds;
+    private final DDLMessage.Index index;
+    private final DDLMessage.Table table;
+    private final int [] mainColToIndexPosMap;  // 0-based
+    private final BitSet indexedCols;   // 0-based
+    private final byte[] indexConglomBytes;
+    private final int[] indexFormatIds;
     private DescriptorSerializer[] indexRowSerializers;
     private DescriptorSerializer[] baseRowSerializers;
-    private boolean excludeNulls;
-    private boolean excludeDefaultValues;
+    private final boolean excludeNulls;
+    private final boolean excludeDefaultValues;
     private DataValueDescriptor defaultValue;
     private ValueRow defaultValuesExecRow;
     private ExecRowAccumulator execRowAccumulator;
@@ -109,7 +109,7 @@ public class IndexTransformer {
     protected EntryDataHash entryEncoder;
     private final int numIndexExprs;
     private final BaseExecutableIndexExpression[] executableExprs;
-    private final LanguageConnectionContext lcc;
+    private LanguageConnectionContext lcc;
 
     public IndexTransformer(DDLMessage.TentativeIndex tentativeIndex) throws StandardException {
         index = tentativeIndex.getIndex();
@@ -175,25 +175,28 @@ public class IndexTransformer {
             throws IOException, StandardException
     {
         // do a Get() on all the indexed columns of the base table
-        DataResult result =fetchBaseRow(mutation,ctx,indexedColumns);
-        if(result==null || result.isEmpty()){
-            // we can't find the old row, may have been deleted already
-            return null;
-        }
-
-        DataCell resultValue = result.userData();
-        if(resultValue==null){
-            // we can't find the old row, may have been deleted already
-            return null;
-        }
-
+        DataResult result = fetchBaseRow(mutation,ctx,indexedColumns);
         // transform the results into an index row (as if we were inserting it) but create a delete for it
-
-        KVPair toTransform = new KVPair(
-                resultValue.keyArray(),resultValue.keyOffset(),resultValue.keyLength(),
-                resultValue.valueArray(),resultValue.valueOffset(),resultValue.valueLength(),KVPair.Type.DELETE);
-        return translate(toTransform);
+        KVPair kvPair = toKVPair(result);
+        return translate(kvPair);
     }
+
+     private KVPair toKVPair(final DataResult result) {
+         if (result == null || result.isEmpty()) {
+             // we can't find the old row, may have been deleted already
+             return null;
+         }
+
+         DataCell resultValue = result.userData();
+         if (resultValue == null) {
+             // we can't find the old row, may have been deleted already
+             return null;
+         }
+
+         return new KVPair(
+                 resultValue.keyArray(), resultValue.keyOffset(), resultValue.keyLength(),
+                 resultValue.valueArray(), resultValue.valueOffset(), resultValue.valueLength(), KVPair.Type.DELETE);
+     }
 
     public KVPair encodeSystemTableIndex(ExecRow execRow) throws StandardException, IOException {
 
@@ -216,9 +219,8 @@ public class IndexTransformer {
         byte[] key = DerbyBytesUtil.generateIndexKey(dvds, order,tableVersion,false);
 
         if(entryEncoder==null){
-            int[] validCols= EngineUtils.bitSetToMap(null);
             DescriptorSerializer[] serializers=VersionedSerializers.forVersion(tableVersion,true).getSerializers(execRow);
-            entryEncoder=new EntryDataHash(validCols,null,serializers);
+            entryEncoder=new EntryDataHash(null,null,serializers);
         }
         ValueRow rowToEncode=new ValueRow(execRow.getRowArray().length);
         rowToEncode.setRowArray(execRow.getRowArray());
@@ -229,7 +231,7 @@ public class IndexTransformer {
 
     public KVPair writeDirectIndex(ExecRow execRow) throws IOException, StandardException {
         assert execRow != null: "ExecRow passed in is null";
-        getIndexRowSerializers(execRow);
+        setIndexRowSerializers(execRow);
         EntryAccumulator keyAccumulator = getKeyAccumulator();
         keyAccumulator.reset();
         ignore = false;
@@ -272,22 +274,28 @@ public class IndexTransformer {
         return new KVPair(indexRowKey, indexValue, KVPair.Type.INSERT);
     }
 
-    public KVPair amendBlindUpdate(KVPair mutation, WriteContext ctx, BitSet indexedColumns) throws IOException {
-        DataResult result = fetchBaseRow(mutation, ctx, indexedColumns);
-        if(result!=null && !result.isEmpty() && result.userData() != null){
-            DataCell resultValue = result.userData();
-            EntryDecoder decoder = getSrcValueDecoder();
-            decoder.set(result.userData().value());
-            EntryDecoder mutationdecoder = new EntryDecoder();
-            mutationdecoder.set(mutation.getValue());
-            EntryEncoder resultEncoder = EntryEncoder.create(SpliceKryoRegistry.getInstance(), decoder.getCurrentIndex());
-            Utils.meld(decoder, mutationdecoder, resultEncoder);
-            byte[] value = resultEncoder.encode();
-            return new KVPair(
-                    resultValue.keyArray(),resultValue.keyOffset(),resultValue.keyLength(),
-                    value,0,value.length,mutation.getType());
+    public KVPair amendBlindUpdate(KVPair mutation, WriteContext ctx, DataResult baseResult) throws IOException {
+        if (baseResult == null || baseResult.isEmpty()) {
+            // we can't find the old row, may have been deleted already
+            return null;
         }
-        return mutation;
+
+        DataCell baseResultValue = baseResult.userData();
+        if (baseResultValue == null) {
+            // we can't find the old row, may have been deleted already
+            return null;
+        }
+
+        EntryDecoder decoder = getSrcValueDecoder();
+        decoder.set(baseResult.userData().value());
+        EntryDecoder mutationDecoder = getBlindUpdateMutationDecoder();
+        mutationDecoder.set(mutation.getValue());
+        EntryEncoder baseResultEncoder = EntryEncoder.create(SpliceKryoRegistry.getInstance(), decoder.getCurrentIndex());
+        Utils.meld(decoder, mutationDecoder, baseResultEncoder);
+        byte[] value = baseResultEncoder.encode();
+        return new KVPair(
+                baseResultValue.keyArray(), baseResultValue.keyOffset(), baseResultValue.keyLength(),
+                value, 0, value.length, mutation.getType());
     }
 
     /**
@@ -693,25 +701,36 @@ public class IndexTransformer {
         return srcValueDecoder;
     }
 
-    private DescriptorSerializer[] getIndexRowSerializers(ExecRow execRow) {
-        if (indexRowSerializers ==null)
-            indexRowSerializers = VersionedSerializers.forVersion(table.getTableVersion(),true).getSerializers(execRow);
-        return indexRowSerializers;
+    private EntryDecoder getBlindUpdateMutationDecoder() {
+        if (blindUpdateMutationDecoder == null)
+            blindUpdateMutationDecoder = new EntryDecoder();
+        return blindUpdateMutationDecoder;
     }
 
+    private void setIndexRowSerializers(ExecRow execRow) {
+        if (indexRowSerializers ==null) {
+            indexRowSerializers = VersionedSerializers.forVersion(table.getTableVersion(), true).getSerializers(execRow);
+        }
+    }
 
-    public DataResult fetchBaseRow(KVPair mutation,WriteContext ctx,BitSet indexedColumns) throws IOException{
-        baseGet =SIDriver.driver().getOperationFactory().newDataGet(ctx.getTxn(),mutation.getRowKey(),baseGet);
+    private DataResult fetchBaseRow(KVPair mutation,WriteContext ctx,BitSet indexedColumns) throws IOException {
+        baseGet = SIDriver.driver().getOperationFactory().newDataGet(ctx.getTxn(), mutation.getRowKey(), baseGet);
 
         EntryPredicateFilter epf;
-        if(indexedColumns!=null && !indexedColumns.isEmpty()){
+        if (indexedColumns != null && !indexedColumns.isEmpty()) {
             epf = new EntryPredicateFilter(indexedColumns);
-        }else epf = EntryPredicateFilter.emptyPredicate();
+        } else {
+            epf = EntryPredicateFilter.emptyPredicate();
+        }
 
-        TransactionalRegion region=ctx.txnRegion();
-        TxnFilter txnFilter=region.packedFilter(ctx.getTxn(),epf,false);
+        TransactionalRegion region = ctx.txnRegion();
+        TxnFilter txnFilter = region.packedFilter(ctx.getTxn(), epf, false);
         baseGet.setFilter(txnFilter);
-        baseResult =ctx.getRegion().get(baseGet,baseResult);
+        baseResult = ctx.getRegion().get(baseGet, baseResult);
+        return baseResult;
+    }
+
+    public DataResult getBaseResult() {
         return baseResult;
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/index/IndexTransformer.java
@@ -277,8 +277,8 @@ public class IndexTransformer {
         if(result!=null && !result.isEmpty() && result.userData() != null){
             DataCell resultValue = result.userData();
             EntryDecoder decoder = getSrcValueDecoder();
-            decoder.set(resultValue.valueArray(),resultValue.valueOffset(),resultValue.valueLength());
-            EntryDecoder mutationdecoder = getSrcValueDecoder();
+            decoder.set(result.userData().value());
+            EntryDecoder mutationdecoder = new EntryDecoder();
             mutationdecoder.set(mutation.getValue());
             EntryEncoder resultEncoder = EntryEncoder.create(SpliceKryoRegistry.getInstance(), decoder.getCurrentIndex());
             Utils.meld(decoder, mutationdecoder, resultEncoder);

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
@@ -99,7 +99,7 @@ public class IndexWriteHandler extends RoutingWriteHandler{
                 }
                 return true; // No index columns modified, ignore...
             case BLIND_UPDATE:
-                if(transformer.areIndexKeysModified(mutation)) {
+                if(transformer.areIndexKeysModified(mutation, indexedColumns)) {
                     delete = deleteIndexRecord(mutation, ctx, true);
                     return createIndexRecord(mutation, ctx, delete);
                 }

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
@@ -97,10 +97,13 @@ public class IndexWriteHandler extends RoutingWriteHandler{
                     delete = deleteIndexRecord(mutation, ctx, false);
                     return createIndexRecord(mutation, ctx, delete);
                 }
-                return true; // No index columns modifies ignore...
+                return true; // No index columns modified, ignore...
             case BLIND_UPDATE:
-                delete = deleteIndexRecord(mutation, ctx, false);
-                return createIndexRecord(mutation, ctx, delete);
+                if(transformer.areIndexKeysModified(mutation)) {
+                    delete = deleteIndexRecord(mutation, ctx, true);
+                    return createIndexRecord(mutation, ctx, delete);
+                }
+                return true; // No index columns modified, ignore ...
             case UPSERT:
                 delete = deleteIndexRecord(mutation, ctx, false);
                 return createIndexRecord(mutation, ctx,delete);

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/IndexWriteHandler.java
@@ -125,7 +125,7 @@ public class IndexWriteHandler extends RoutingWriteHandler{
             boolean add=true;
             KVPair newIndex;
             if(mutation.getType() == KVPair.Type.BLIND_UPDATE) {
-                KVPair amended = transformer.amendBlindUpdate(mutation, ctx,indexedColumns);
+                KVPair amended = transformer.amendBlindUpdate(mutation, ctx, transformer.getBaseResult());
                 newIndex = transformer.translate(amended);
             } else {
                 newIndex = transformer.translate(mutation);

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/ForeignKeyChildInterceptWriteHandler.java
@@ -82,7 +82,8 @@ public class ForeignKeyChildInterceptWriteHandler implements WriteHandler{
 
     /* This WriteHandler doesn't do anything when, for example, we delete from the FK backing index. */
     private boolean isForeignKeyInterceptNecessary(KVPair.Type type) {
-        return type == KVPair.Type.INSERT || type == KVPair.Type.UPDATE || type == KVPair.Type.UPSERT;
+        return type == KVPair.Type.INSERT || type == KVPair.Type.UPDATE ||
+               type == KVPair.Type.BLIND_UPDATE || type == KVPair.Type.UPSERT;
     }
 
     @Override

--- a/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/actions/OnDeleteSetNullOrCascade.java
+++ b/splice_machine/src/main/java/com/splicemachine/pipeline/foreignkey/actions/OnDeleteSetNullOrCascade.java
@@ -96,7 +96,7 @@ public class OnDeleteSetNullOrCascade extends OnDeleteAbstractAction {
         int deleteRule = constraintInfo.getDeleteRule();
         assert deleteRule == StatementType.RA_SETNULL || deleteRule == StatementType.RA_CASCADE;
         if(deleteRule == StatementType.RA_SETNULL) {
-            return KVPair.Type.UPDATE;
+            return KVPair.Type.BLIND_UPDATE; // force index row rebuilding via base table lookup.
         } else { // CASCADE
             return KVPair.Type.DELETE;
         }

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
@@ -736,6 +736,7 @@ public class ForeignKeyActionIT {
         s.executeUpdate("create index " + tableName + "i1  on " + tableName + "(col2, col3)");
         s.executeUpdate("create index " + tableName + "i2  on " + tableName + "(col3)");
         s.executeUpdate("create index " + tableName + "i3  on " + tableName + "(col1, col3)");
+        s.executeUpdate("create index " + tableName + "i4  on " + tableName + "(col1, col2, col3)");
 
         s.executeUpdate("insert into psn values (1,1)");
         s.executeUpdate("insert into " + tableName + " values (10, 1, 100)");
@@ -746,16 +747,21 @@ public class ForeignKeyActionIT {
         queryShouldContain("select * from " + tableName + " order by col1 asc", expectedResult);
         queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult);
         queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult);
+        queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i3 \norder by col1 asc", expectedResult);
+        queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i4 \norder by col1 asc", expectedResult);
 
         Integer[][] expectedResult2 = new Integer[][]{{10}, {20}};
         queryShouldContain("select col1 from " + tableName + " order by col1 asc", expectedResult2);
         queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult2);
         queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult2);
+        queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i3 \norder by col1 asc", expectedResult2);
+        queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i4 \norder by col1 asc", expectedResult2);
 
         Integer[][] expectedResult3 = new Integer[][]{{100}, {200}};
         queryShouldContain("select col3 from " + tableName + " order by col1 asc", expectedResult3);
         queryShouldContain("select col3 from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult3);
         queryShouldContain("select col3 from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult3);
+        queryShouldContain("select col3 from " + tableName + " --splice-properties index=" + tableName + "i3 \norder by col1 asc", expectedResult3);
     }
 
 }

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
@@ -30,6 +30,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Statement;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -61,7 +63,8 @@ public class ForeignKeyActionIT {
         new TableDAO(conn).drop(SCHEMA, "SNGC2", "SNGC1", "SNC", "SNP", "RP", "RC",
                                 "DHC10", "DHC9", "DHC8", "DHC7", "DHC6", "DHC5", "DHC4", "DHC3", "DHC2", "DHC1",
                                 "FC", "FP", "SRT2", "GC2", "GC1", "CC", "CP", "C1I", "C2I", "PI","SRT", "LC", "YAC", "AC", "AP", "C2", "C", "P",
-                                "cc1", "cc2", "cc3", "cc4", "cc6", "cc7");
+                                "cc1", "cc2", "cc3", "cc4", "cc6", "cc7",
+                                "PSN", "CSN1", "CSN2");
     }
 
     @After
@@ -673,13 +676,57 @@ public class ForeignKeyActionIT {
         }
     }
 
+    @Test
+    public void onDeleteSetNullChildIndexUpdatedCorrectly() throws Exception {
+        try(Statement s = conn.createStatement()){
+            s.executeUpdate("create table psn(col1 int primary key, col2 int)");
+            s.executeUpdate("create table csn1(col1 int, col2 int references psn(col1) on delete set null)");
+            s.executeUpdate("create index isn11 on csn1(col1, col2)");
+            s.executeUpdate("create index isn12 on csn1(col2)");
+            s.executeUpdate("create table csn2(col1 int references psn(col1) on delete set null, col2 int )");
+            s.executeUpdate("create index isn21 on csn2(col1, col2)");
+            s.executeUpdate("create index isn22 on csn2(col2)");
+
+            s.executeUpdate("insert into psn values (1,1)");
+            s.executeUpdate("insert into csn1 values (10, 1)");
+            s.executeUpdate("insert into csn1 values (20, 1)");
+            s.executeUpdate("insert into csn2 values (1, 30)");
+            s.executeUpdate("insert into csn2 values (1, 40)");
+
+            s.executeUpdate("delete from psn");
+
+            Integer[][] expectedResult = new Integer[][]{{10, null}, {20, null}};
+            queryShouldContain("select * from csn1 order by col1 asc", expectedResult);
+            queryShouldContain("select * from csn1 --splice-properties index=isn11\norder by col1 asc", expectedResult);
+            queryShouldContain("select * from csn1 --splice-properties index=isn12\norder by col1 asc", expectedResult);
+
+            expectedResult = new Integer[][]{{null, 30}, {null, 40}};
+            queryShouldContain("select * from csn2 order by col2 asc", expectedResult);
+            queryShouldContain("select * from csn2 --splice-properties index=isn11\norder by col1 asc", expectedResult);
+            queryShouldContain("select * from csn2 --splice-properties index=isn12\norder by col1 asc", expectedResult);
+        }
+    }
+
+    ///// helper functions.
+
     private void shouldContain(String child, int[][] rows) throws SQLException {
+        queryShouldContain(String.format("select * from %s order by col1 asc", child),
+                           Stream.of(rows)
+                                 .map(array -> IntStream.of(array).boxed().toArray(Integer[]::new))
+                                 .toArray(Integer[][]::new));
+    }
+
+    private void queryShouldContain(String query, Integer[][] rows) throws SQLException {
         try(Statement s = conn.createStatement()) {
-            ResultSet rs = s.executeQuery(String.format("select * from %s order by col1 asc", child));
-            for(int[] row : rows) {
+            ResultSet rs = s.executeQuery(query);
+            for(Integer[] row : rows) {
                 Assert.assertTrue(rs.next());
                 for(int i = 0; i < row.length; ++i) {
-                    Assert.assertEquals(row[i], rs.getInt(i+1));
+                    if(row[i] == null) {
+                        rs.getInt(i+1); Assert.assertTrue(rs.wasNull());
+                    } else {
+                        Assert.assertEquals((int)row[i], rs.getInt(i+1));
+                    }
                 }
             }
             Assert.assertFalse(rs.next());

--- a/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/foreignkeys/ForeignKeyActionIT.java
@@ -680,30 +680,8 @@ public class ForeignKeyActionIT {
     public void onDeleteSetNullChildIndexUpdatedCorrectly() throws Exception {
         try(Statement s = conn.createStatement()){
             s.executeUpdate("create table psn(col1 int primary key, col2 int)");
-            s.executeUpdate("create table csn1(col1 int, col2 int references psn(col1) on delete set null)");
-            s.executeUpdate("create index isn11 on csn1(col1, col2)");
-            s.executeUpdate("create index isn12 on csn1(col2)");
-            s.executeUpdate("create table csn2(col1 int references psn(col1) on delete set null, col2 int )");
-            s.executeUpdate("create index isn21 on csn2(col1, col2)");
-            s.executeUpdate("create index isn22 on csn2(col2)");
-
-            s.executeUpdate("insert into psn values (1,1)");
-            s.executeUpdate("insert into csn1 values (10, 1)");
-            s.executeUpdate("insert into csn1 values (20, 1)");
-            s.executeUpdate("insert into csn2 values (1, 30)");
-            s.executeUpdate("insert into csn2 values (1, 40)");
-
-            s.executeUpdate("delete from psn");
-
-            Integer[][] expectedResult = new Integer[][]{{10, null}, {20, null}};
-            queryShouldContain("select * from csn1 order by col1 asc", expectedResult);
-            queryShouldContain("select * from csn1 --splice-properties index=isn11\norder by col1 asc", expectedResult);
-            queryShouldContain("select * from csn1 --splice-properties index=isn12\norder by col1 asc", expectedResult);
-
-            expectedResult = new Integer[][]{{null, 30}, {null, 40}};
-            queryShouldContain("select * from csn2 order by col2 asc", expectedResult);
-            queryShouldContain("select * from csn2 --splice-properties index=isn11\norder by col1 asc", expectedResult);
-            queryShouldContain("select * from csn2 --splice-properties index=isn12\norder by col1 asc", expectedResult);
+            testForeignKeyWithIndexInternal("csn1", true, s);
+            testForeignKeyWithIndexInternal("csn2", false, s);
         }
     }
 
@@ -751,6 +729,33 @@ public class ForeignKeyActionIT {
                 Assert.assertFalse(rs.next());
             }
         }
+    }
+
+    private void testForeignKeyWithIndexInternal(String tableName, boolean withPk, Statement s) throws SQLException {
+        s.executeUpdate("create table " + tableName + "(col1 int " + (withPk ? "primary key" : "") + ", col2 int references psn(col1) on delete set null, col3 int)");
+        s.executeUpdate("create index " + tableName + "i1  on " + tableName + "(col2, col3)");
+        s.executeUpdate("create index " + tableName + "i2  on " + tableName + "(col3)");
+        s.executeUpdate("create index " + tableName + "i3  on " + tableName + "(col1, col3)");
+
+        s.executeUpdate("insert into psn values (1,1)");
+        s.executeUpdate("insert into " + tableName + " values (10, 1, 100)");
+        s.executeUpdate("insert into " + tableName + " values (20, 1, 200)");
+        s.executeUpdate("delete from psn");
+
+        Integer[][] expectedResult = new Integer[][]{{10, null, 100}, {20, null, 200}};
+        queryShouldContain("select * from " + tableName + " order by col1 asc", expectedResult);
+        queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult);
+        queryShouldContain("select * from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult);
+
+        Integer[][] expectedResult2 = new Integer[][]{{10}, {20}};
+        queryShouldContain("select col1 from " + tableName + " order by col1 asc", expectedResult2);
+        queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult2);
+        queryShouldContain("select col1 from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult2);
+
+        Integer[][] expectedResult3 = new Integer[][]{{100}, {200}};
+        queryShouldContain("select col3 from " + tableName + " order by col1 asc", expectedResult3);
+        queryShouldContain("select col3 from " + tableName + " --splice-properties index=" + tableName + "i1 \norder by col1 asc", expectedResult3);
+        queryShouldContain("select col3 from " + tableName + " --splice-properties index=" + tableName + "i2 \norder by col1 asc", expectedResult3);
     }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

In this PR an index corruption caused by foreign key action on the child table is fixed.

## Long Description
Let us say we have a parent table `p` and child table `c` have a foreign key relationship with `on delete set null action`. If we delete a row from the parent the is referenced by row(s) in the child, then we generate an `UPDATE` mutation on the child table and its indices to set all referenced columns to `null`.

However, while doing so, we incorrectly set all other columns in the child indices to null as well! this is because the generated `update` mutation does not have the values of the non-fk index columns and we simply set them to `null`.

To fix this problem, a new mutation type is added `0x09` under the name `BLIND_UPDATE`. This mutation type is leveraged in situations where we don't have the full overview of the update's scope, as for example in the case where we update some descendant table deep down in a foreign key hierarchy; unlike normal updates where we know about both old and new columns at the moment of update allowing us to eliminate an extra base table lookup to reconstruct the not-updated index columns (see #5391 for more information).

When we receive a `BLIND_UPDATE` mutation in `IndexWriteHandler`, we perform a base table lookup on the affected row, meld the column values of the mutation with the base table row, and continue to perform the index update (delete + insert).

I implemented a new method `Utils.meld` that allows melding two `EntryDecoder` columns into one. This method is used to above to reconstruct the "blindly" updated row.

## How to test

Here is a simple test:

```sql
create table p_a(a int, d int primary key, e int);
create table c_a (x int primary key, y int references p_a(d) on delete set null, z int);
create index c_ix on c_a(y, z);
insert into p_a values (22, 98, 66);
insert into c_a values (4 , 98, 4);

-- delete from the parent table to trigger child table update via the foreign key action
delete from p_a;

-- previously, querying c_a columns via the index was returning wrong results
-- because the index is corrupted
select z from c_a --splice-properties index=c_ix
;
Z
-
NULL

-- with this PR, the index is not corrupted any more , it is working as expected
select z from c_a --splice-properties index=c_ix
;
Z
-
4
```

I added an extensive randomized test suite for `Utils.meld` and a number of ITs in `ForeignKeyActionIT` for testing the index update patch fix.