### PR TITLE
DB-11106 Defer executing code that could cause a warning in ProjectRestrictOperation

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ProjectRestrictOperation.java
@@ -75,6 +75,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
     private        String[]                          expressions                   = null;
     private        boolean                           hasGroupingFunction;
     private        String                            subqueryText;
+    private        boolean                           constantRestrictionEvaluated;
 
     protected static final String NAME = ProjectRestrictOperation.class.getSimpleName().replaceAll("Operation", "");
 
@@ -145,6 +146,7 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
         this.expressions = expressions;
         this.hasGroupingFunction = hasGroupingFunction;
         this.subqueryText = subqueryText;
+        this.constantRestrictionEvaluated = false;
         init();
     }
 
@@ -167,7 +169,6 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
             mappedResultRow = activation.getExecutionFactory().getValueRow(projectMapping.length);
         }
         cloneMap = ((boolean[]) statement.getSavedObject(cloneMapItem));
-        evaluateConstantRestriction();
 
         if (restrictionMethodName != null)
             restriction = new SpliceMethod<>(restrictionMethodName, activation);
@@ -325,6 +326,9 @@ public class ProjectRestrictOperation extends SpliceBaseOperation {
 
         if (parameterInConstantRestriction) {
             evaluateConstantRestriction();
+        } else if (!constantRestrictionEvaluated) {
+            evaluateConstantRestriction();
+            constantRestrictionEvaluated = true;
         }
         if (alwaysFalse) {
             return dsp.getEmpty();


### PR DESCRIPTION
## Short Description
This PR fixes a problem that `Activation.resultSet` is `null` when a `SQLChar.setWidth()` needs to set a SQL warning. 

## Long Description
Currently, SQL warnings in execution are propagated to client by setting the warnings in the result set in current activation. However, sometimes the result set is `null`, causing an NPE when setting a warning. DB-11089 suppresses the problem by not propagating a warning if result set is null. But the question is then whether the result set can be null and if yes, how should we propagate a warning properly.

My current understanding of the DRDA connection workflow based on debugging is the following.

Sending a select statement through a DRDA connection always contains two steps:

1. Client send a `PRPSQLSTT` code point (prepare SQL statement?) first. In this step, server calls `parsePRPSQLSTT()` which in turns calls `Database.newDRDAStatement()`. This call, however, doesn’t necessarily constructs a new `DRDAStatement` object but tries to reuse the current object by resetting its states. Doing so eventually calls `BaseActivation.close()`, which sets `resultSet` to `null`. Server generally sends a `SQLCARD` code point back to the client.

2. The client then sends a `OPNQRY` code point (open query?) with the actual SQL statement to be executed. The `resultSet` field in the activation is `null` (due to step 1) through the whole execution process until the `execute()` call in generated code has returned. The NPE described in this ticket happens during the `execute()` call in generated code, in `fillResultSet()`:

  ```
  ResultSet var10000 = super.resultSet == null ? (super.resultSet = this.fillResultSet()) : super.resultSet;
  ```

So the problem seems to be that `SQLChar.setWidth()` is called too early. To propagate a warning properly, we need to make sure this call is never called in `execute()`'s call tree, meaning constructors and `init()` methods of various splice operation classes.

## Solution

Further investigation showed that `SQLChar.setWidth()` is called early because in `ProjectRestrictOperation`, we call `evaluateConstantRestriction()` in `init()`. According to the discussion above, code execution like `evaluateConstantRestriction()` has to be done later in `getDataSet()` so that `resultSet` in activation is properly initialized.

But we also don't want to call this method every time when calling `getDataSet()` because it's needed only once in most cases. For this reason, a new flag `constantRestrictionEvaluated` is introduced. Note that in case of `parameterInConstantRestriction == true`, we do need to evaluate the constant restriction because it contains a parameter node, and it's possible that arguments passed in are different each time.

## How to test
Test query:
```
SELECT * FROM sysibm.sysdummy1 WHERE '?2,BL' NOT IN ( CAST('1969-12-16 17:40:41' AS VARCHAR(16)));
```
- Before this fix, the test query returns the following result without a warning:
  ```
  IBMREQD
  -------
  Y
  ```
- After this fix, the test query should return exactly the same result together with a warning:
  ```
  IBMREQD
  -------
  Y
  WARNING 01004: Data truncation
  ```
