### PR TITLE
DB-11420 DB-10555 Fix multi-column IN subquery issues

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -87,7 +87,13 @@ public abstract class BinaryListOperatorNode extends ValueNode{
                      Object operator,Object methodName) throws StandardException{
         singleLeftOperand = false;
         if (leftOperand != null) {
-            if (leftOperand instanceof ValueNode) {
+            if (leftOperand instanceof ValueTupleNode) {
+                this.leftOperandList = ((ValueTupleNode) leftOperand).toValueNodeList();
+                if (this.leftOperandList.size() == 1) {
+                    singleLeftOperand = true;
+                }
+            }
+            else if (leftOperand instanceof ValueNode) {
                 ValueNodeList vnl = (ValueNodeList) getNodeFactory().getNode(
                                      C_NodeTypes.VALUE_NODE_LIST,
                                      getContextManager());
@@ -226,8 +232,10 @@ public abstract class BinaryListOperatorNode extends ValueNode{
                 leftOperandList.setElementAt(getLeftOperand().genSQLJavaSQLTree(), 0);
             }
         }
-        else
-            THROWASSERT("Multicolumn IN list in SQL statement not currently supported.");
+        else {
+            throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR,
+                                                 "Multicolumn IN predicate requires a subquery on the right-hand side.");
+        }
 
         /* Generate bound conversion trees for those elements in the rightOperandList
          * that are not built-in types.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryListOperatorNode.java
@@ -234,7 +234,7 @@ public abstract class BinaryListOperatorNode extends ValueNode{
         }
         else {
             throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR,
-                                                 "Multicolumn IN predicate requires a subquery on the right-hand side.");
+                                                 "Multicolumn IN predicate requires a subquery on the right-hand side");
         }
 
         /* Generate bound conversion trees for those elements in the rightOperandList

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ResultColumnList.java
@@ -772,10 +772,14 @@ public class ResultColumnList extends QueryTreeNodeVector<ResultColumn>{
             if( index >= firstOrderByIndex )
                 fromList.useAliases();
 
-            ValueNode vn=elementAt(index);
-            vn=vn.bindExpression(fromList,subqueryList,aggregateVector);
+            ValueNode vn = elementAt(index);
+            vn = vn.bindExpression(fromList,subqueryList,aggregateVector);
             //-sf- this cast is safe because ResultColumn returns a ResultColumn from bindExpression()
             ResultColumn rc = (ResultColumn)vn;
+            if (rc.getExpression() instanceof ValueTupleNode) {
+                throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR,
+                                                     "Tuple values as a column in select list is not supported");
+            }
             setElementAt((ResultColumn)vn,index);
 
             // if we have aliases in the SELECT part, add them, so ORDER BY can resolve them later

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ValueTupleNode.java
@@ -154,4 +154,12 @@ public class ValueTupleNode extends ValueNode {
         }
         return false;
     }
+
+    public ValueNodeList toValueNodeList() {
+        ValueNodeList vnl = new ValueNodeList();
+        for (ValueNode vn : tuple) {
+            vnl.addValueNode(vn);
+        }
+        return vnl;
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ValueTupleIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ValueTupleIT.java
@@ -26,19 +26,18 @@ import splice.com.google.common.collect.Lists;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
-import java.sql.Types;
 import java.util.Collection;
-import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.containsString;
 
 /**
- * Test predicate with tuples
+ * Test value tuples
  */
 @RunWith(Parameterized.class)
-public class PredicateTupleIT extends SpliceUnitTest {
+public class ValueTupleIT extends SpliceUnitTest {
 
     private Boolean useSpark;
 
@@ -49,7 +48,7 @@ public class PredicateTupleIT extends SpliceUnitTest {
         params.add(new Object[]{false});
         return params;
     }
-    private static final String SCHEMA = PredicateTupleIT.class.getSimpleName();
+    private static final String SCHEMA = ValueTupleIT.class.getSimpleName();
 
     @ClassRule
     public static SpliceSchemaWatcher schemaWatcher = new SpliceSchemaWatcher(SCHEMA);
@@ -75,7 +74,7 @@ public class PredicateTupleIT extends SpliceUnitTest {
         }
     }
 
-    public PredicateTupleIT(Boolean useSpark) {
+    public ValueTupleIT(Boolean useSpark) {
         this.useSpark = useSpark;
     }
 
@@ -158,5 +157,17 @@ public class PredicateTupleIT extends SpliceUnitTest {
                 " 1 |10 |100 |\n" +
                 " 2 |20 |200 |";
         testQuery(query, expected);
+    }
+
+    @Test
+    public void testTupleAsAColumnInvalid() throws Exception {
+        String query = "select (a1, a2), a3 from A";
+
+        try (ResultSet rs = methodWatcher.executeQuery(query)) {
+            Assert.fail("should fail because tuple as a column is not supported");
+        } catch (SQLException e) {
+            Assert.assertEquals("42X01", e.getSQLState());
+            Assert.assertTrue(e.getMessage().contains("Tuple values as a column in select list is not supported"));
+        }
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -493,4 +493,24 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
                               sql, ONE_SUBQUERY_NODE , expected);
     }
+
+    @Test
+    public void testMultiColumnInListWithoutSubqueryInvalid() throws Exception {
+        String sql = "select a1, a2 from A\n" +
+                "WHERE (a1, a2) in %s";
+
+        try (ResultSet rs = methodWatcher.executeQuery(format(sql, "(1, 1)"))) {
+            Assert.fail("should fail due to invalid syntax");
+        } catch (SQLException e) {
+            Assert.assertEquals("42X01", e.getSQLState());
+            Assert.assertTrue(e.getMessage().contains("Multicolumn IN predicate requires a subquery"));
+        }
+
+        try (ResultSet rs = methodWatcher.executeQuery(format(sql, "((1, 1), (2, 2))"))) {
+            Assert.fail("should fail due to invalid syntax");
+        } catch (SQLException e) {
+            Assert.assertEquals("42X01", e.getSQLState());
+            Assert.assertTrue(e.getMessage().contains("Multicolumn IN predicate requires a subquery"));
+        }
+    }
 }


### PR DESCRIPTION
## Short Description
This change fixes two NPEs occur in queries with multi-column IN subquery predicates. Also, this change fixes join predicate generation for multi-column NOT IN subquery case to handle NULL data. Queries in this case should return correct results after this fix.

## Long Description
The reported NPEs happen in invalid syntax of using tuple in a query. This change fixes the following two cases:
- `select ... from ... where (a, b) in (1, 2)`
  Currently, we support only multi-column IN subquery. IN tuple list is not supported. Instead of having an NPE, an syntax error exception is now thrown.
- `select (a, b) from ...`
  We do not support tuple as a column type. Note that `select (a, b)` is not semantically equal to `select a, b`. The former results in a single column with tuple in it, while the latter results in two columns. This semantic makes more sense when mixed with usual select items, e.g., `select (a, b), c`. Try it out in PostgreSQL 9.6 and the semantic will be clear.

Other than the NPEs, this change fixes a wrong result issue due to incorrect join predicate generated for NOT IN case. To understand this problem, we have to start from a classic single-column NOT IN example:

```
create table T1 (c1 int);
insert into T1 values (1), (2), (3);

create table T2 (c2 int);
insert into T2 values (1), (3), (null);

select * from T1 where c1 NOT IN (select * from t2);
C1
--

0 rows selected
```

A common question is why value 2 is not in result. For a single-column NOT IN predicate, if the right list of values contains a `NULL` value, the result will be always empty despite of the content of the left table. To understand this, we need to logically expand the NOT IN predicate:
```
a NOT IN (x, y, NULL)
<=>
(a != x) && (a != y) && (a != NULL)
```

Note that in three-value logic, both `a == NULL` and `a != NULL` are false, despite the value of `a` (`NULL == NULL` is false, `3 != NULL` is false). So the expanded predicate can be simplified as just false without even looking into data.

In our system, a NOT IN predicate is not expanded as we see above. Instead, both IN and NOT IN predicates generate the same EQ predicate as the first step:
```
a IN (select x from ...) => a = x
a NOT IN (select x from ...) => a = x  // still EQ, not NE
```

Then we generate a null check on top:
```
a IN (select x from ...) => IS_NOT_NULL(select 1 from T1, T2 where a = x)
a NOT IN (select x from ...) => IS_NULL(select 1 from T1, T2 where a = x)
```

The negation is done by the null check. If a value of `a` is not in `x` column values, then `a = x` should join an empty result set, meaning `IS_NULL` is true, so this value of `a` qualifies the NOT IN predicate.

This approach, however, doesn't handle the NULL value case. If `x` column contains a `NULL`, the NOT IN result must be empty, meaning for each row in `a`, the input of `IS_NULL` must not be empty. For this reason, we have `fixPredicateForNotInAndAll()` method, which adapt `a = x` to
```
(a = x) OR (a is null) OR (x is null)
```

Now the issue with multi-column IN list predicate is, how do we extend this approach to multi-column comparison? The current approach is the following:
```
(a, b) IN (select x, y from ...) => (a == x) AND (b == y)
(a, b) NOT IN (select x, y from ...) => ((a == x) AND (b == y)) OR (a is null) OR (x is null) OR (b is null) OR (y is null)
```

and this is wrong. Let's use the following example to illustrate the problem.
```
create table T1 (a int, b int);
insert into T1 values (1, 1), (2, 2);

create table T2 (x int, y int);
insert into T2 values (1, 1), (4, 4), (null, 3);

select * from T1 where (a, b) not in (select x, y from t2);
A|B
---
2|2

1 row selected
```

Didn't we just say that if the right table contains `NULL`s, the result of NOT IN is always empty? Yes for single-column case, but no for multi-column. To understand why 2|2 is qualified, let's use the logical expansion again:
```
(2, 2) NOT IN (null, 3) <=>
(2 != NULL) OR (2 != 3) <=>
unknown OR true <=>
true
```

In plain text, although `2 != null` is effectively false, but we do know that for the second component of the tuple, `2 != 1` and `2 != 4` and `2 != 3`, thus tuple `(2, 2)` is not in `(x, y)` for sure. The `NULL` value leads to an unknown result just for one part of the OR, and the other part is clear enough to evaluate the whole OR to true.

Now it should be clear that our current expanded predicate
```
(a, b) NOT IN (select x, y from ...) => ((a == x) AND (b == y)) OR (a is null) OR (x is null) OR (b is null) OR (y is null)
```

is not correct because the IS_NULL tests are at levels too high. In our example above, `(null ,3)` will join with all rows from left because of `x is null`, resulting in an empty final result.

According the the logical expansion for multi-column NOT IN predicate, the correct predicate in our implementation should be
```
(a, b) NOT IN (select x, y from ...) => ((a == x) OR (a is null) OR (x is null)) AND ((b == y) OR (b is null) OR (y is null))
```

And this is the fix.

## How to test
It's long to copy the ITs here. Please refer to `testMultiColumnNotInWithNulls1` and `testMultiColumnNotInWithNulls2` in `Subquery_Flattening_InList_IT`.
