### PR TITLE
DB-10439 Improve no stats report from explain statement

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ExplainNode.java
@@ -251,7 +251,7 @@ public class ExplainNode extends DMLStatementNode {
         node.accept(cnv);
         List<FromBaseTable> baseTableNodes = cnv.getList();
         for (FromBaseTable t : baseTableNodes) {
-            String tableName = t.getExposedName();
+            String tableName = t.getTableDescriptor().getQualifiedName();
             if (!t.useRealTableStats()) {
                 noStatsTables.add(new SQLVarchar(tableName));
             } else if (!t.getNoStatsColumnIds().isEmpty()) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromTable.java
@@ -1383,6 +1383,9 @@ public abstract class FromTable extends ResultSetNode implements Optimizable{
      * @return TableName the original or unbound tablename
      */
     public TableName getOrigTableName(){
+        // Do not try to set schemaName if origTableName.schemaName == null.
+        // isTransitionTable() in CreateTriggerNode.java relies on this to
+        // distinguish normal tables from transition tables.
         return this.origTableName;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/GroupByNode.java
@@ -1409,7 +1409,7 @@ public class GroupByNode extends SingleChildResultSetNode{
         List<ColumnReference> columnRefNodes = cnv.getList();
         for (ColumnReference cr : columnRefNodes) {
             if (!cr.useRealColumnStatistics())
-                noStatsColumns.add(cr.getSource().getSchemaName() + "." + cr.getSource().getFullName());
+                noStatsColumns.add(cr.getSchemaQualifiedColumnName());
         }
         return noStatsColumns;
     }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/ExplainPlanIT.java
@@ -708,7 +708,7 @@ public class ExplainPlanIT extends SpliceUnitTest  {
         String query ="explain select * from t3";
         String[] expected = {
                 "Table statistics are missing or skipped for the following tables",
-                CLASS_NAME + ".T3"
+                "\"" + CLASS_NAME + "\".\"T3\""
         };
         rowContainsQuery(new int[]{4, 5}, query, spliceClassWatcher, expected);
 
@@ -726,7 +726,7 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
         String[] expected = {
                 "Table statistics are missing or skipped for the following tables",
-                CLASS_NAME + ".T5"
+                "\"" + CLASS_NAME + "\".\"T5\""
         };
         rowContainsQuery(new int[]{4, 5}, query, spliceClassWatcher, expected);
     }
@@ -739,7 +739,7 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
         String[] expected = {
                 "Column statistics are missing or skipped for the following columns",
-                CLASS_NAME + ".T5.E5"
+                "\"" + CLASS_NAME + "\".\"T5\".E5"
         };
 
         // only columns used for estimating selectivity/cost but missing statistics are reported
@@ -766,8 +766,8 @@ public class ExplainPlanIT extends SpliceUnitTest  {
 
         String[] expected = {
                 "Column statistics are missing or skipped for the following columns",
-                CLASS_NAME + ".T1.C2",
-                CLASS_NAME + ".T2.C1"
+                "\"" + CLASS_NAME + "\".\"T1\".C2",
+                "\"" + CLASS_NAME + "\".\"T2\".C1"
         };
 
         try (ResultSet rs  = methodWatcher.executeQuery(query)) {


### PR DESCRIPTION
## Short Description
This change fixes an issue in explain statement output that missing statistics objects may have duplicates and inconsistent names due to aliases.

## Long Description
The issue is mainly due to `FromBaseTable.getExposedTable()` method. It returns alias as the table name if a table has an alias.

The fix is to call `FromBaseTable.getTableDescriptor().getQualifiedName()` instead. This guarantees to use always the original table name with correct spelling.

Note that there is also a method `FromBaseTable.getOrigTableName()` which is not sufficient in this case because the `origTableName` field could have `schemaName == null` and code in `isTransitionTable()` in `CreateTriggerNode.java` relies on that...

## How to test
Setup:
```
create table if not exists t1 (a int, b int, c int);
create table if not exists t2 (a int, b int, c int);
create table if not exists t3 (a int, b int, c int);
```

Query:
```
explain
select *
from t1
         inner join t2 as aliast2 on (aliast2.c = t1.b)
where t1.b is null
  and aliast2.c = 0;
```

Before this fix:
```
Table statistics are missing or skipped for the following tables:
SPLICE.T1, ALIAST2
Column statistics are missing or skipped for the following columns:
ALIAST2.C, SPLICE.T2.C, SPLICE.T1.B
```

After this fix:
```
Table statistics are missing or skipped for the following tables:
"SPLICE"."T1", "SPLICE"."T2"
Column statistics are missing or skipped for the following columns:
SPLICE.T2.C, SPLICE.T1.B
```