### PR TITLE
DB-12232 Add Triggering Query Identifier to Log Output

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -1527,7 +1527,7 @@ public interface LanguageConnectionContext extends Context {
     void logEndFetching(String uuid, String statement, long fetchedRows);
     void logNextBatch(ParameterValueSet pvs);
     void logStartExecuting(String uuid, String engine, String stmt, ExecPreparedStatement ps,
-                           ParameterValueSet pvs);
+                           ParameterValueSet pvs, String parentId);
     void logEndExecuting(String uuid, long modifiedRows, long badRecords, long nanoTimeSpent);
 
     void setSessionProperties(Properties newProperties);

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/conn/LanguageConnectionContext.java
@@ -122,6 +122,7 @@ public interface LanguageConnectionContext extends Context {
     ArrayList<DisplayedTriggerInfo> getDisplayedTriggerInfo();
     void recordAdditionalDisplayedTriggerInfo(long elapsedTime, long modifiedRows, java.util.UUID queryId);
     void recordTriggerInfoWhileFiring(UUID triggerId);
+    java.util.UUID getLatestQueryId();
 
     /**
      * Initialize. For use after pushing the contexts that initialization needs.

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -617,6 +617,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
             triggerInfos = new ArrayList<>(queryIdToTriggerInfoMap.values());
         }
     }
+
+    @Override
+    public java.util.UUID getLatestQueryId() {
+        return null;
+    }
+
     @Override
     public void initialize() throws StandardException{
         interruptedException = null;

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -4108,12 +4108,12 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
 
     @Override
     public void logStartExecuting(String uuid, String engine, String stmt, ExecPreparedStatement ps,
-                                  ParameterValueSet pvs) {
+                                  ParameterValueSet pvs, String parentId) {
         if (stmtLogger.isInfoEnabled()) {
             stmtLogger.info(String.format(
-                "Start executing query. %s, uuid=%s, engine=%s, %s, paramsCount=%d, params=[ %s ], sessionProperties=[ %s ]",
+                "Start executing query. %s, uuid=%s, engine=%s, %s, paramsCount=%d, params=[ %s ], sessionProperties=[ %s ], triggeredBy=[ %s ]",
                 getLogHeader(), uuid, engine, formatLogStmt(stmt),
-                pvs.getParameterCount(), pvs.toString(), ps.getSessionPropertyValues()));
+                pvs.getParameterCount(), pvs.toString(), ps.getSessionPropertyValues(), parentId));
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -608,11 +608,19 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
                 stmtForLogging = ps.getSourceTxt();
         }
 
+        UUID parentId = null;
+
+        try {
+            parentId = getCurrentTransaction().getParentForTrigger().getCurrentQueryId();
+        } catch (Exception ignored) {}
+
+        String parentIdString = parentId == null ? "" : parentId.toString();
+
         activation.getLanguageConnectionContext().logStartExecuting(
                 uuid.toString(), dsp.getType().toString(), stmtForLogging,
                 ps,
-                activation.getParameterValueSet()
-        );
+                activation.getParameterValueSet(),
+                parentIdString);
     }
 
     private void logExecutionEnd() {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/SpliceBaseOperation.java
@@ -487,6 +487,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
             if (!(this instanceof ExplainOperation || activation.isMaterialized()))
                 activation.materialize();
             long txnId=getCurrentTransaction().getTxnId();
+            getCurrentTransaction().setCurrentQueryId(uuid);
 
             // initialize displayed trigger info
             if (getTriggerHandler() != null) {
@@ -611,7 +612,7 @@ public abstract class SpliceBaseOperation implements SpliceOperation, ScopeNamed
         UUID parentId = null;
 
         try {
-            parentId = getCurrentTransaction().getParentForTrigger().getCurrentQueryId();
+            parentId = getCurrentTransaction().getParentQueryIdForTrigger();
         } catch (Exception ignored) {}
 
         String parentIdString = parentId == null ? "" : parentId.toString();

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
@@ -16,6 +16,7 @@ package com.splicemachine.si.api.txn;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.splicemachine.primitives.Bytes;
+import com.splicemachine.si.impl.txn.AbstractTxn;
 import com.splicemachine.utils.ByteSlice;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/Txn.java
@@ -16,7 +16,6 @@ package com.splicemachine.si.api.txn;
 
 import com.carrotsearch.hppc.LongHashSet;
 import com.splicemachine.primitives.Bytes;
-import com.splicemachine.si.impl.txn.AbstractTxn;
 import com.splicemachine.utils.ByteSlice;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -210,6 +209,21 @@ public interface Txn extends TxnView{
 
         @Override
         public TaskId getTaskId() {
+            return null;
+        }
+
+        @Override
+        public UUID getParentQueryIdForTrigger() {
+            return null;
+        }
+
+        @Override
+        public void setCurrentQueryId(UUID uuid) {
+
+        }
+
+        @Override
+        public UUID getCurrentQueryId() {
             return null;
         }
     };

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
@@ -14,6 +14,7 @@
 
 package com.splicemachine.si.api.txn;
 
+import com.splicemachine.si.impl.txn.AbstractTxn;
 import com.splicemachine.utils.ByteSlice;
 
 import java.io.Externalizable;

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/txn/TxnView.java
@@ -14,11 +14,11 @@
 
 package com.splicemachine.si.api.txn;
 
-import com.splicemachine.si.impl.txn.AbstractTxn;
 import com.splicemachine.utils.ByteSlice;
 
 import java.io.Externalizable;
 import java.util.Iterator;
+import java.util.UUID;
 
 /**
  * Represents an unmodifiable view of a transaction.
@@ -226,5 +226,10 @@ public interface TxnView extends Externalizable {
     boolean hasActiveWriteableOrRolledBackTransactionInLineage(TxnView ancestor, boolean checkForRollbackOnly);
 
     TaskId getTaskId();
-    
+
+    UUID getParentQueryIdForTrigger();
+
+    void setCurrentQueryId(UUID uuid);
+
+    UUID getCurrentQueryId();
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/AbstractTxnView.java
@@ -404,4 +404,19 @@ public abstract class AbstractTxnView implements TxnView {
     public TaskId getTaskId() {
         return null;
     }
+
+    @Override
+    public UUID getParentQueryIdForTrigger() {
+        return null;
+    }
+
+    @Override
+    public void setCurrentQueryId(UUID uuid) {
+
+    }
+
+    @Override
+    public UUID getCurrentQueryId() {
+        return null;
+    }
 }

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/LazyTxnView.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/txn/LazyTxnView.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Iterator;
+import java.util.UUID;
 
 /**
  * @author Scott Fines
@@ -108,6 +109,21 @@ public class LazyTxnView implements TxnView {
     public TaskId getTaskId() {
         lookup(false);
         return delegate.getTaskId();
+    }
+
+    @Override
+    public UUID getParentQueryIdForTrigger() {
+        return null;
+    }
+
+    @Override
+    public void setCurrentQueryId(UUID uuid) {
+
+    }
+
+    @Override
+    public UUID getCurrentQueryId() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Add Triggering Query Identifier to Log Output

## Long Description
Add an addtional field to Execution Start log record about a query’s tringerring query if exists. 

Sample Log record:

'''
2021-06-16 11:13:56,501 Thread[DRDAConnThread_1402] Start executing query. XID=SpliceTransaction[ACTIVE,WritableTxn(14848,ACTIVE)], SessionID=4, Database=splicedb, DRDAID=��������.����-738307240056184952{2}, UserID=SPLICE, uuid=f4cf0d28-8f9a-92d9-8ab2-fb9ed7dec384, engine=CONTROL, sqlHash=2bd3289e34490a73cc1feab46f664956, statement=[ insert into tableb values (CAST (com.splicemachine.db.iapi.db.Factory::getTriggerExecutionContext().getNewRow().cloneColumn(1).getObject() AS INTEGER) *40) ], paramsCount=0, params=[  ], sessionProperties=[ null ], triggeredBy=[ 84a8a5db-9b8c-709b-ffec-9293f4a29ac5 ]
'''