### PR TITLE
DB-12097 better SQL errors (3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
@@ -42,7 +42,9 @@ package com.splicemachine.db.impl.sql.compile;
  */
 public class ParseException extends Exception {
 
-  /**
+    private static final long serialVersionUID = -4112778850759062139L;
+
+    /**
    * This constructor is used by the method "generateParseException"
    * in the generated parser.  Calling this constructor generates
    * a new object of this type with the fields "currentToken",
@@ -108,11 +110,20 @@ public class ParseException extends Exception {
   public int[][] expectedTokenSequences;
 
   /**
+   * default maximum number of possible tokens to print when printing an error (@sa getMessage)
+   */
+  private static final int MAX_SUGGESTED_TOKENS = 15;
+
+  /**
    * This is a reference to the "tokenImage" array of the generated
    * parser within which the parse error occurred.  This array is
    * defined in the generated ...Constants interface.
    */
   public String[] tokenImage;
+
+  public String getMessage() {
+    return getMessage(true, MAX_SUGGESTED_TOKENS);
+  }
 
   /**
    * This method has the standard behavior when this object has been
@@ -123,14 +134,24 @@ public class ParseException extends Exception {
    * from the parser), then this method is called during the printing
    * of the final stack trace, and hence the correct error message
    * gets displayed.
-   */
-  public String getMessage() {
+   *
+   * @param showExpected For output compatibility with previous releases, it might be beneficial
+   *                     to not show expected tokens. In this case, set showExpected=false.
+   * @param maxTokens print only a limited number of expected tokens, otherwise list can get long (100 items);
+   * @return error message
+   * */
+  public String getMessage(boolean showExpected, int maxTokens) {
     if (!specialConstructor) {
       return super.getMessage();
     }
     StringBuilder expected = new StringBuilder();
     int maxSize = 0;
+    int N = 0;
       for (int[] expectedTokenSequence : expectedTokenSequences) {
+          if(N++ > maxTokens) {
+              expected.append("...\n");
+              break;
+          }
           if (maxSize < expectedTokenSequence.length) {
               maxSize = expectedTokenSequence.length;
           }
@@ -154,17 +175,17 @@ public class ParseException extends Exception {
       tok = tok.next;
     }
     retval.append("\" at line ").append(currentToken.next.beginLine).append(", column ").append(currentToken.next.beginColumn);
- /*
-  * For output compatibility with previous releases, do not report expected tokens.
-  *
-    retval += "." + eol;
-    if (expectedTokenSequences.length == 1) {
-      retval += "Was expecting:" + eol + "    ";
-    } else {
-      retval += "Was expecting one of:" + eol + "    ";
-    }
-    retval += expected;
-  */
+
+   if(showExpected) {
+     retval.append("." + eol);
+     if (expectedTokenSequences.length == 1) {
+         retval.append("Was expecting:" + eol + "    ");
+     } else {
+         retval.append("Was expecting one of:" + eol + "    ");
+     }
+     retval.append(expected);
+  }
+  /**/
     return retval.toString();
   }
 
@@ -221,5 +242,4 @@ public class ParseException extends Exception {
       }
       return retval.toString();
    }
-
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
@@ -40,6 +40,15 @@ package com.splicemachine.db.impl.sql.compile;
  * You can modify this class to customize your error reporting
  * mechanisms so long as you retain the public fields.
  */
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value={
+    // SpotBugs can't see that currentToken.next is initialized
+    "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+    "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
+},
+    justification = ".")
 public class ParseException extends Exception {
 
     private static final long serialVersionUID = -4112778850759062139L;
@@ -139,6 +148,7 @@ public class ParseException extends Exception {
      * @param maxTokens    print only a limited number of expected tokens, otherwise list can get long (100 items);
      * @return error message
      */
+    @SuppressFBWarnings(value={"NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
     public String getMessage(boolean showExpected, int maxTokens) {
         if (!specialConstructor) {
             return super.getMessage();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
@@ -43,12 +43,6 @@ package com.splicemachine.db.impl.sql.compile;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-@SuppressFBWarnings(value={
-    // SpotBugs can't see that currentToken.next is initialized
-    "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
-    "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
-},
-    justification = ".")
 public class ParseException extends Exception {
 
     private static final long serialVersionUID = -4112778850759062139L;
@@ -148,7 +142,7 @@ public class ParseException extends Exception {
      * @param maxTokens    print only a limited number of expected tokens, otherwise list can get long (100 items);
      * @return error message
      */
-    @SuppressFBWarnings(value={"NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
+    @SuppressFBWarnings(value={"NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"})
     public String getMessage(boolean showExpected, int maxTokens) {
         if (!specialConstructor) {
             return super.getMessage();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParseException.java
@@ -45,201 +45,199 @@ public class ParseException extends Exception {
     private static final long serialVersionUID = -4112778850759062139L;
 
     /**
-   * This constructor is used by the method "generateParseException"
-   * in the generated parser.  Calling this constructor generates
-   * a new object of this type with the fields "currentToken",
-   * "expectedTokenSequences", and "tokenImage" set.  The boolean
-   * flag "specialConstructor" is also set to true to indicate that
-   * this constructor was used to create this object.
-   * This constructor calls its super class with the empty string
-   * to force the "toString" method of parent class "Throwable" to
-   * print the error message in the form:
-   *     ParseException: <result of getMessage>
-   */
-  public ParseException(Token currentTokenVal,
-                        int[][] expectedTokenSequencesVal,
-                        String[] tokenImageVal
-                       )
-  {
-    super("");
-    specialConstructor = true;
-    currentToken = currentTokenVal;
-    expectedTokenSequences = expectedTokenSequencesVal;
-    tokenImage = tokenImageVal;
-  }
-
-  /**
-   * The following constructors are for use by you for whatever
-   * purpose you can think of.  Constructing the exception in this
-   * manner makes the exception behave in the normal way - i.e., as
-   * documented in the class "Throwable".  The fields "errorToken",
-   * "expectedTokenSequences", and "tokenImage" do not contain
-   * relevant information.  The JavaCC generated code does not use
-   * these constructors.
-   */
-
-  public ParseException() {
-    super();
-    specialConstructor = false;
-  }
-
-  public ParseException(String message) {
-    super(message);
-    specialConstructor = false;
-  }
-
-  /**
-   * This variable determines which constructor was used to create
-   * this object and thereby affects the semantics of the
-   * "getMessage" method (see below).
-   */
-  protected boolean specialConstructor;
-
-  /**
-   * This is the last token that has been consumed successfully.  If
-   * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
-   */
-  public Token currentToken;
-
-  /**
-   * Each entry in this array is an array of integers.  Each array
-   * of integers represents a sequence of tokens (by their ordinal
-   * values) that is expected at this point of the parse.
-   */
-  public int[][] expectedTokenSequences;
-
-  /**
-   * default maximum number of possible tokens to print when printing an error (@sa getMessage)
-   */
-  private static final int MAX_SUGGESTED_TOKENS = 15;
-
-  /**
-   * This is a reference to the "tokenImage" array of the generated
-   * parser within which the parse error occurred.  This array is
-   * defined in the generated ...Constants interface.
-   */
-  public String[] tokenImage;
-
-  public String getMessage() {
-    return getMessage(true, MAX_SUGGESTED_TOKENS);
-  }
-
-  /**
-   * This method has the standard behavior when this object has been
-   * created using the standard constructors.  Otherwise, it uses
-   * "currentToken" and "expectedTokenSequences" to generate a parse
-   * error message and returns it.  If this object has been created
-   * due to a parse error, and you do not catch it (it gets thrown
-   * from the parser), then this method is called during the printing
-   * of the final stack trace, and hence the correct error message
-   * gets displayed.
-   *
-   * @param showExpected For output compatibility with previous releases, it might be beneficial
-   *                     to not show expected tokens. In this case, set showExpected=false.
-   * @param maxTokens print only a limited number of expected tokens, otherwise list can get long (100 items);
-   * @return error message
-   * */
-  public String getMessage(boolean showExpected, int maxTokens) {
-    if (!specialConstructor) {
-      return super.getMessage();
+     * This constructor is used by the method "generateParseException"
+     * in the generated parser.  Calling this constructor generates
+     * a new object of this type with the fields "currentToken",
+     * "expectedTokenSequences", and "tokenImage" set.  The boolean
+     * flag "specialConstructor" is also set to true to indicate that
+     * this constructor was used to create this object.
+     * This constructor calls its super class with the empty string
+     * to force the "toString" method of parent class "Throwable" to
+     * print the error message in the form:
+     * ParseException: <result of getMessage>
+     */
+    public ParseException(Token currentTokenVal,
+                          int[][] expectedTokenSequencesVal,
+                          String[] tokenImageVal)
+    {
+        super("");
+        specialConstructor = true;
+        currentToken = currentTokenVal;
+        expectedTokenSequences = expectedTokenSequencesVal;
+        tokenImage = tokenImageVal;
     }
-    StringBuilder expected = new StringBuilder();
-    int maxSize = 0;
-    int N = 0;
-      for (int[] expectedTokenSequence : expectedTokenSequences) {
-          if(N++ > maxTokens) {
-              expected.append("...\n");
-              break;
-          }
-          if (maxSize < expectedTokenSequence.length) {
-              maxSize = expectedTokenSequence.length;
-          }
-          for (int j = 0; j < expectedTokenSequence.length; j++) {
-              expected.append(tokenImage[expectedTokenSequence[j]]).append(" ");
-          }
-          if (expectedTokenSequence[expectedTokenSequence.length - 1] != 0) {
-              expected.append("...");
-          }
-          expected.append(eol).append("    ");
-      }
-    StringBuilder retval = new StringBuilder("Encountered \"");
-    Token tok = currentToken.next;
-    for (int i = 0; i < maxSize; i++) {
-      if (i != 0) retval.append(" ");
-      if (tok.kind == 0) {
-        retval.append(tokenImage[0]);
-        break;
-      }
-      retval.append(add_escapes(tok.image));
-      tok = tok.next;
+
+    /**
+     * The following constructors are for use by you for whatever
+     * purpose you can think of.  Constructing the exception in this
+     * manner makes the exception behave in the normal way - i.e., as
+     * documented in the class "Throwable".  The fields "errorToken",
+     * "expectedTokenSequences", and "tokenImage" do not contain
+     * relevant information.  The JavaCC generated code does not use
+     * these constructors.
+     */
+
+    public ParseException() {
+        super();
+        specialConstructor = false;
     }
-    retval.append("\" at line ").append(currentToken.next.beginLine).append(", column ").append(currentToken.next.beginColumn);
 
-   if(showExpected) {
-     retval.append("." + eol);
-     if (expectedTokenSequences.length == 1) {
-         retval.append("Was expecting:" + eol + "    ");
-     } else {
-         retval.append("Was expecting one of:" + eol + "    ");
-     }
-     retval.append(expected);
-  }
-  /**/
-    return retval.toString();
-  }
+    public ParseException(String message) {
+        super(message);
+        specialConstructor = false;
+    }
 
-  /**
-   * The end of line string for this machine.
-   */
-  protected String eol = System.getProperty("line.separator", "\n");
+    /**
+     * This variable determines which constructor was used to create
+     * this object and thereby affects the semantics of the
+     * "getMessage" method (see below).
+     */
+    protected boolean specialConstructor;
 
-  /**
-   * Used to convert raw characters to their escaped version
-   * when these raw version cannot be used as part of an ASCII
-   * string literal.
-   */
-  protected String add_escapes(String str) {
-      StringBuilder retval = new StringBuilder();
-      char ch;
-      for (int i = 0; i < str.length(); i++) {
-        switch (str.charAt(i))
-        {
-           case 0 :
-              continue;
-           case '\b':
-              retval.append("\\b");
-              continue;
-           case '\t':
-              retval.append("\\t");
-              continue;
-           case '\n':
-              retval.append("\\n");
-              continue;
-           case '\f':
-              retval.append("\\f");
-              continue;
-           case '\r':
-              retval.append("\\r");
-              continue;
-           case '\"':
-              retval.append("\\\"");
-              continue;
-           case '\'':
-              retval.append("\\\'");
-              continue;
-           case '\\':
-              retval.append("\\\\");
-              continue;
-           default:
-              if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
-                 String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
-              } else {
-                 retval.append(ch);
-              }
+    /**
+     * This is the last token that has been consumed successfully.  If
+     * this object has been created due to a parse error, the token
+     * followng this token will (therefore) be the first error token.
+     */
+    public Token currentToken;
+
+    /**
+     * Each entry in this array is an array of integers.  Each array
+     * of integers represents a sequence of tokens (by their ordinal
+     * values) that is expected at this point of the parse.
+     */
+    public int[][] expectedTokenSequences;
+
+    /**
+     * default maximum number of possible tokens to print when printing an error (@sa getMessage)
+     */
+    private static final int MAX_SUGGESTED_TOKENS = 15;
+
+    /**
+     * This is a reference to the "tokenImage" array of the generated
+     * parser within which the parse error occurred.  This array is
+     * defined in the generated ...Constants interface.
+     */
+    public String[] tokenImage;
+
+    public String getMessage() {
+        return getMessage(true, MAX_SUGGESTED_TOKENS);
+    }
+
+    /**
+     * This method has the standard behavior when this object has been
+     * created using the standard constructors.  Otherwise, it uses
+     * "currentToken" and "expectedTokenSequences" to generate a parse
+     * error message and returns it.  If this object has been created
+     * due to a parse error, and you do not catch it (it gets thrown
+     * from the parser), then this method is called during the printing
+     * of the final stack trace, and hence the correct error message
+     * gets displayed.
+     *
+     * @param showExpected For output compatibility with previous releases, it might be beneficial
+     *                     to not show expected tokens. In this case, set showExpected=false.
+     * @param maxTokens    print only a limited number of expected tokens, otherwise list can get long (100 items);
+     * @return error message
+     */
+    public String getMessage(boolean showExpected, int maxTokens) {
+        if (!specialConstructor) {
+            return super.getMessage();
         }
-      }
-      return retval.toString();
-   }
+        StringBuilder expected = new StringBuilder();
+        int maxSize = 0;
+        int N = 0;
+        for (int[] expectedTokenSequence : expectedTokenSequences) {
+            if (N++ > maxTokens) {
+                expected.append("...\n");
+                break;
+            }
+            if (maxSize < expectedTokenSequence.length) {
+                maxSize = expectedTokenSequence.length;
+            }
+            for (int j = 0; j < expectedTokenSequence.length; j++) {
+                expected.append(tokenImage[expectedTokenSequence[j]]).append(" ");
+            }
+            if (expectedTokenSequence[expectedTokenSequence.length - 1] != 0) {
+                expected.append("...");
+            }
+            expected.append(eol).append("    ");
+        }
+        StringBuilder retval = new StringBuilder("Encountered \"");
+        Token tok = currentToken.next;
+        for (int i = 0; i < maxSize; i++) {
+            if (i != 0) retval.append(" ");
+            if (tok.kind == 0) {
+                retval.append(tokenImage[0]);
+                break;
+            }
+            retval.append(add_escapes(tok.image));
+            tok = tok.next;
+        }
+        retval.append("\" at line ").append(currentToken.next.beginLine).append(", column ").append(currentToken.next.beginColumn);
+
+        if (showExpected) {
+            retval.append("." + eol);
+            if (expectedTokenSequences.length == 1) {
+                retval.append("Was expecting:" + eol + "    ");
+            } else {
+                retval.append("Was expecting one of:" + eol + "    ");
+            }
+            retval.append(expected);
+        }
+        /**/
+        return retval.toString();
+    }
+
+    /**
+     * The end of line string for this machine.
+     */
+    protected String eol = System.getProperty("line.separator", "\n");
+
+    /**
+     * Used to convert raw characters to their escaped version
+     * when these raw version cannot be used as part of an ASCII
+     * string literal.
+     */
+    protected String add_escapes(String str) {
+        StringBuilder retval = new StringBuilder();
+        char ch;
+        for (int i = 0; i < str.length(); i++) {
+            switch (str.charAt(i)) {
+                case 0:
+                    continue;
+                case '\b':
+                    retval.append("\\b");
+                    continue;
+                case '\t':
+                    retval.append("\\t");
+                    continue;
+                case '\n':
+                    retval.append("\\n");
+                    continue;
+                case '\f':
+                    retval.append("\\f");
+                    continue;
+                case '\r':
+                    retval.append("\\r");
+                    continue;
+                case '\"':
+                    retval.append("\\\"");
+                    continue;
+                case '\'':
+                    retval.append("\\\'");
+                    continue;
+                case '\\':
+                    retval.append("\\\\");
+                    continue;
+                default:
+                    if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
+                        String s = "0000" + Integer.toString(ch, 16);
+                        retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
+                    } else {
+                        retval.append(ch);
+                    }
+            }
+        }
+        return retval.toString();
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
@@ -37,198 +37,183 @@ import com.splicemachine.db.iapi.sql.compile.Visitable;
 
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.error.StandardException;
+
 import java.io.StringReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ParserImpl implements Parser
-{
-	/*
-	** We will use the following constant to pass in to
-	** our CharStream.  It is the size of the internal
-	** buffers that are used to buffer tokens.  It
-	** should be set to what is typically around the
-	** largest token that is likely to be hit.  Note
-	** that if the size is exceeded, the buffer will
-	** automatically be expanded by 2048, so it is ok
-	** to choose something that is smaller than the
-	** max token supported.
-	**
-	** Since, JavaCC generates parser and tokenmanagers classes
-	** tightly connected, to use another parser or tokenmanager
-	** inherit this class, override the following methods
-	** to use specific instances:<ul>
-	** <li>getTokenManager()</li>
-	** <li>getParser()</li>
-	** <li>parseGoalProduction(...)</li>
-	** </ul>
-	**
-	*/
-	static final int LARGE_TOKEN_SIZE = 128;
+public class ParserImpl implements Parser {
+    /*
+     ** We will use the following constant to pass in to
+     ** our CharStream.  It is the size of the internal
+     ** buffers that are used to buffer tokens.  It
+     ** should be set to what is typically around the
+     ** largest token that is likely to be hit.  Note
+     ** that if the size is exceeded, the buffer will
+     ** automatically be expanded by 2048, so it is ok
+     ** to choose something that is smaller than the
+     ** max token supported.
+     **
+     ** Since, JavaCC generates parser and tokenmanagers classes
+     ** tightly connected, to use another parser or tokenmanager
+     ** inherit this class, override the following methods
+     ** to use specific instances:<ul>
+     ** <li>getTokenManager()</li>
+     ** <li>getParser()</li>
+     ** <li>parseGoalProduction(...)</li>
+     ** </ul>
+     **
+     */
+    static final int LARGE_TOKEN_SIZE = 128;
 
-        /* Don't ever access these objects directly, call getParser(), and getTokenManager() */
-        private SQLParser cachedParser; 
-	protected Object cachedTokenManager;
+    /* Don't ever access these objects directly, call getParser(), and getTokenManager() */
+    private SQLParser cachedParser;
+    protected Object cachedTokenManager;
 
-	protected CharStream charStream;
-        protected String SQLtext;
+    protected CharStream charStream;
+    protected String SQLtext;
 
-        protected final CompilerContext cc;
+    protected final CompilerContext cc;
 
-	/**
-	 * Constructor for Parser
-	 */
+    /**
+     * Constructor for Parser
+     */
+    public ParserImpl(CompilerContext cc) {
+        this.cc = cc;
+    }
 
-	public ParserImpl(CompilerContext cc)
-	{
-		this.cc = cc;
-	}
+    public Visitable parseStatement(String statementSQLText)
+            throws StandardException {
+        return parseStatement(statementSQLText, (Object[]) null);
+    }
 
-	public Visitable parseStatement(String statementSQLText)
-		throws StandardException
-	{
-		return parseStatement(statementSQLText, (Object[])null);
-	}
+    /**
+     * Returns a initialized (clean) TokenManager, paired w. the Parser in getParser,
+     * Appropriate for this ParserImpl object.
+     */
+    protected Object getTokenManager() {
+        /* returned a cached tokenmanager if already exists, otherwise create */
+        SQLParserTokenManager tm = (SQLParserTokenManager) cachedTokenManager;
+        if (tm == null) {
+            tm = new SQLParserTokenManager(charStream);
+            cachedTokenManager = tm;
+        } else {
+            tm.ReInit(charStream);
+        }
+        return tm;
+    }
 
-        /**
-	 * Returns a initialized (clean) TokenManager, paired w. the Parser in getParser,
-	 * Appropriate for this ParserImpl object.
-	 */
-        protected Object getTokenManager()
-        {
-	    /* returned a cached tokenmanager if already exists, otherwise create */
-	    SQLParserTokenManager tm = (SQLParserTokenManager) cachedTokenManager;
-	    if (tm == null) {
-		tm = new SQLParserTokenManager(charStream);
-		cachedTokenManager = tm;
-	    } else {
-		tm.ReInit(charStream);
-	    }
-	    return tm;
-	}
+    /**
+     * new parser, appropriate for the ParserImpl object.
+     */
+    private SQLParser getParser() {
+        SQLParserTokenManager tm = (SQLParserTokenManager) getTokenManager();
+        /* returned a cached Parser if already exists, otherwise create */
+        SQLParser p = (SQLParser) cachedParser;
+        if (p == null) {
+            p = new SQLParser(tm);
+            p.setCompilerContext(cc);
+            cachedParser = p;
+        } else {
+            p.ReInit(tm);
+        }
+        return p;
+    }
 
-     /**
-	 * new parser, appropriate for the ParserImpl object.
-	 */
-     private SQLParser getParser()
-        {
-	    SQLParserTokenManager tm = (SQLParserTokenManager) getTokenManager();
-	    /* returned a cached Parser if already exists, otherwise create */
-	    SQLParser p = (SQLParser) cachedParser;
-	    if (p == null) {
-		p = new SQLParser(tm);
-		p.setCompilerContext(cc);
-		cachedParser = p;
-	    } else {
-		p.ReInit(tm);
-	    }
-	    return p;
-	}
+    /**
+     * @param statementSQLText original statement to underly problem
+     * @return e.g. CREATE TABEL (i INTEGER);
+     * ^^^^^--------------
+     */
+    String highlightProblematicSql(String statementSQLText,
+                                   int problematicLine, int beginColumn, int endColumn) {
+        StringBuilder sb = new StringBuilder();
+        String[] str = statementSQLText.split("\n"); // or \\\n?
+        int from = Math.max(problematicLine - 3, 0);
+        int end = Math.min(problematicLine + 3, str.length);
+        for (int i = from; i < end; i++) {
+            sb.append(i + ":\t");
+            sb.append(str[i] + "\n");
+            if (i + 1 == problematicLine) {
+                int j = 0;
+                sb.append("   \t");
+                for (; j < beginColumn - 1; j++)
+                    sb.append(" ");
+                for (; j < endColumn; j++)
+                    sb.append("^");
+                sb.append("---------\n");
+            }
+        }
+        return sb.toString();
+    }
 
-	/**
-	 * @param statementSQLText original statement to underly problem
-	 * @return e.g. CREATE TABEL (i INTEGER);
-	 *                     ^^^^^--------------
-	 */
-	String highlightProblematicSql(String statementSQLText,
-								   int problematicLine, int beginColumn, int endColumn) {
-		StringBuilder sb = new StringBuilder();
-		String[] str = statementSQLText.split("\n"); // or \\\n?
-		int from = Math.max(problematicLine-3, 0);
-		int end  = Math.min(problematicLine+3, str.length);
-		for(int i=from; i<end; i++) {
-			sb.append(i + ":\t");
-			sb.append(str[i] + "\n");
-			if(i+1 == problematicLine) {
-				int j=0;
-				sb.append("   \t");
-				for(; j< beginColumn-1; j++)
-					sb.append(" ");
-				for(; j<endColumn; j++)
-					sb.append("^");
-				sb.append("---------\n");
-			}
-		}
-		return sb.toString();
-	}
+    /**
+     * Parse a statement and return a query tree.  Implements the Parser
+     * interface
+     *
+     * @param statementSQLText Statement to parse
+     * @param paramDefaults    parameter defaults. Passed around as an array
+     *                         of objects, but is really an array of StorableDataValues
+     * @throws StandardException Thrown on error
+     * @return A QueryTree representing the parsed statement
+     */
+    public Visitable parseStatement(String statementSQLText, Object[] paramDefaults)
+            throws StandardException {
 
-	/**
-	 * Parse a statement and return a query tree.  Implements the Parser
-	 * interface
-	 *
-	 * @param statementSQLText	Statement to parse
-	 * @param paramDefaults	parameter defaults. Passed around as an array
-	 *                      of objects, but is really an array of StorableDataValues
-	 * @return	A QueryTree representing the parsed statement
-	 *
-	 * @exception StandardException	Thrown on error
-	 */
-	public Visitable parseStatement(String statementSQLText, Object[] paramDefaults)
-		throws StandardException
-	{
+        java.io.Reader sqlText = new java.io.StringReader(statementSQLText);
 
-		java.io.Reader sqlText = new java.io.StringReader(statementSQLText);
+        /* Get a char stream if we don't have one already */
+        if (charStream == null) {
+            charStream = new UCode_CharStream(sqlText, 1, 1, LARGE_TOKEN_SIZE);
+        } else {
+            charStream.ReInit(sqlText, 1, 1, LARGE_TOKEN_SIZE);
+        }
 
-		/* Get a char stream if we don't have one already */
-		if (charStream == null)
-		{
-			charStream = new UCode_CharStream(sqlText, 1, 1, LARGE_TOKEN_SIZE);
-		}
-		else
-		{
-			charStream.ReInit(sqlText, 1, 1, LARGE_TOKEN_SIZE);
-		}
+        /* remember the string that we're parsing */
+        SQLtext = statementSQLText;
 
-		/* remember the string that we're parsing */
-		SQLtext = statementSQLText;
+        /* Parse the statement, and return the QueryTree */
+        try {
+            return getParser().Statement(statementSQLText, paramDefaults);
+        } catch (ParseException e) {
+            String highlight = highlightProblematicSql(statementSQLText,
+                    e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endColumn);
+            throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, e.getMessage() + "\n" + highlight);
+        } catch (TokenMgrError e) {
+            // Derby - 2103.
+            // When the exception occurs cachedParser may live with
+            // some flags set inappropriately that may cause Exception
+            // in the subsequent compilation. This seems to be a javacc bug.
+            // Issue Javacc-152 has been raised.
+            // As a workaround, the cachedParser object is cleared to ensure
+            // that the exception does not have any side effect.
+            // TODO : Remove the following line if javacc-152 is fixed.
+            cachedParser = null;
+            // e.getMessage() ==
+            // Lexical error at line L, column C.
+            String highlight = "";
 
-		/* Parse the statement, and return the QueryTree */
-		try
-		{
-		    return getParser().Statement(statementSQLText, paramDefaults);
-		}
-		catch (ParseException e)
-		{
-			String highlight = highlightProblematicSql(statementSQLText,
-					e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endColumn);
-			throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, e.getMessage() + "\n" + highlight);
-		}
-		catch (TokenMgrError e)
-		{
-			// Derby - 2103.
-			// When the exception occurs cachedParser may live with
-			// some flags set inappropriately that may cause Exception
-			// in the subsequent compilation. This seems to be a javacc bug.
-			// Issue Javacc-152 has been raised.
-			// As a workaround, the cachedParser object is cleared to ensure
-			// that the exception does not have any side effect.
-			// TODO : Remove the following line if javacc-152 is fixed.
-			cachedParser = null;
-			// e.getMessage() ==
-			// Lexical error at line L, column C.
-			String highlight = "";
+            Pattern outputRowsP = Pattern.compile("Lexical error at line (\\d+), column (\\d+)");
+            Matcher m = outputRowsP.matcher(e.getMessage());
+            if (m.find()) {
+                int line = Integer.parseInt(m.group(1));
+                int col = Integer.parseInt(m.group(2));
+                highlight = "\n\n" + highlightProblematicSql(statementSQLText, line, col - 1, col);
+            }
 
-			Pattern outputRowsP = Pattern.compile("Lexical error at line (\\d+), column (\\d+)");
-			Matcher m = outputRowsP.matcher(e.getMessage());
-			if(m.find()) {
-				int line = Integer.parseInt(m.group(1));
-				int col  = Integer.parseInt(m.group(2));
-				highlight = "\n\n" + highlightProblematicSql(statementSQLText, line, col-1, col);
-			}
-
-			throw StandardException.newException(SQLState.LANG_LEXICAL_ERROR, e.getMessage() + highlight);
-		}
-	}
+            throw StandardException.newException(SQLState.LANG_LEXICAL_ERROR, e.getMessage() + highlight);
+        }
+    }
 
     /**
      * Parse a full SQL statement or a fragment that represents a
      * {@code <search condition>}.
      *
-     * @param sql the SQL statement or fragment to parse
+     * @param sql           the SQL statement or fragment to parse
      * @param paramDefaults parameter defaults to pass on to the parser
-     *   in the case where {@code sql} is a full SQL statement
-     * @param isStatement {@code true} if {@code sql} is a full SQL statement,
-     *   {@code false} if it is a fragment
+     *                      in the case where {@code sql} is a full SQL statement
+     * @param isStatement   {@code true} if {@code sql} is a full SQL statement,
+     *                      {@code false} if it is a fragment
      * @return parse tree for the SQL
      * @throws StandardException if an error happens during parsing
      */
@@ -238,57 +223,50 @@ public class ParserImpl implements Parser
     {
         StringReader sqlText = new StringReader(sql);
 
-	/* Get a char stream if we don't have one already */
-	if (charStream == null)
-	{
-		charStream = new UCode_CharStream(sqlText, 1, 1, LARGE_TOKEN_SIZE);
-	}
-	else
-	{
-		charStream.ReInit(sqlText, 1, 1, LARGE_TOKEN_SIZE);
-	}
+        /* Get a char stream if we don't have one already */
+        if (charStream == null) {
+            charStream = new UCode_CharStream(sqlText, 1, 1, LARGE_TOKEN_SIZE);
+        } else {
+            charStream.ReInit(sqlText, 1, 1, LARGE_TOKEN_SIZE);
+        }
 
-	/* remember the string that we're parsing */
+        /* remember the string that we're parsing */
         SQLtext = sql;
 
-	/* Parse the statement, and return the QueryTree */
-	try
-	{
+        /* Parse the statement, and return the QueryTree */
+        try {
             SQLParser p = getParser();
             return isStatement
                     ? p.Statement(sql, paramDefaults)
                     : p.SearchCondition(sql);
-		}
-		catch (ParseException e)
-		{
-		    throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, e.getMessage());
-		}
-		catch (TokenMgrError e)
-		{
-			// Derby - 2103.
-			// When the exception occurs cachedParser may live with
-			// some flags set inappropriately that may cause Exception
-			// in the subsequent compilation. This seems to be a javacc bug.
-			// Issue Javacc-152 has been raised.
-			// As a workaround, the cachedParser object is cleared to ensure
-			// that the exception does not have any side effect.
-			// TODO : Remove the following line if javacc-152 is fixed.
-			cachedParser = null;
-		    throw StandardException.newException(SQLState.LANG_LEXICAL_ERROR, e.getMessage());
-		}
-	}
+        } catch (ParseException e) {
+            throw StandardException.newException(SQLState.LANG_SYNTAX_ERROR, e.getMessage());
+        } catch (TokenMgrError e) {
+            // Derby - 2103.
+            // When the exception occurs cachedParser may live with
+            // some flags set inappropriately that may cause Exception
+            // in the subsequent compilation. This seems to be a javacc bug.
+            // Issue Javacc-152 has been raised.
+            // As a workaround, the cachedParser object is cleared to ensure
+            // that the exception does not have any side effect.
+            // TODO : Remove the following line if javacc-152 is fixed.
+            cachedParser = null;
+            throw StandardException.newException(SQLState.LANG_LEXICAL_ERROR, e.getMessage());
+        }
+    }
 
-	@Override
-	public Visitable parseSearchCondition(String sqlFragment)
-	    throws StandardException {
-		return parseStatementOrSearchCondition(sqlFragment, null, false);
-	}
-	/**
-	 * Returns the current SQL text string that is being parsed.
-	 *
-	 * @return	Current SQL text string.
-	 *
-	 */
-	public	String		getSQLtext()
-	{	return	SQLtext; }
+    @Override
+    public Visitable parseSearchCondition(String sqlFragment)
+            throws StandardException {
+        return parseStatementOrSearchCondition(sqlFragment, null, false);
+    }
+
+    /**
+     * Returns the current SQL text string that is being parsed.
+     *
+     * @return Current SQL text string.
+     */
+    public String getSQLtext() {
+        return SQLtext;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ParserImpl.java
@@ -37,11 +37,16 @@ import com.splicemachine.db.iapi.sql.compile.Visitable;
 
 import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.error.StandardException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.StringReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@SuppressFBWarnings(value={
+        "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", // SpotBugs can't see that currentToken.next is initialized
+},
+        justification = ".")
 public class ParserImpl implements Parser {
     /*
      ** We will use the following constant to pass in to

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Token.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/Token.java
@@ -31,6 +31,8 @@
 
 package com.splicemachine.db.impl.sql.compile;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Describes the input token stream.
  */
@@ -72,6 +74,7 @@ public class Token {
    * token.  Otherwise, see below for a description of the contents of
    * this field.
    */
+  @SuppressFBWarnings("UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD")
   public Token next;
 
   /**
@@ -86,6 +89,7 @@ public class Token {
    * immediately follow it (without an intervening regular token).  If there
    * is no such token, this field is null.
    */
+  @SuppressFBWarnings("UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD")
   public Token specialToken;
 
   /**

--- a/findbugs-exclude-filter.xml
+++ b/findbugs-exclude-filter.xml
@@ -74,6 +74,10 @@
     <Match>
         <Class name="~com\.splicemachine\.db\.impl\.tools\.ij\.TokenMgrError.*"/>
     </Match>
+    <Match>
+        <!-- generated code for parser -->
+        <Class name="~com\.splicemachine\.db\.impl\.sql\.misc.*"/>
+    </Match>
 
     <!-- SpliceConstants: our static fields in are intentionally not final -->
     <Match>

--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
@@ -440,4 +440,56 @@ public class SqlshellIT {
         Assert.assertEquals(Arrays.toString(ijCommands.parseVersion("3.2.0.1992")), "[3, 2, 0, 1992]");
         Assert.assertEquals(Arrays.toString(ijCommands.parseVersion("2.8.0.1973-SNAPSHOT")), "[2, 8, 0, 1973]");
     }
+
+    public void testSyntaxErrorMessage() {
+        execute("CREATE TABLE MY_TABLE (\n" +
+                "L_ORDERKEY BIGINT NOT NULL,\n" +
+                "L_PARTKEY INTEGER NOT DECIMAL,\n" +
+                "L_SUPPKEY INTEGER NOT NULL,\n" +
+                "L_LINENUMBER INTEGER NOT NULL,\n" +
+                "L_QUANTITY DECIMAL(15,2),\n" +
+                "L_EXTENDEDPRICE DECIMAL(15,2),\n" +
+                "L_DISCOUNT DECIMAL(15,2)\n" +
+                ");\n",
+
+                "ERROR 42X01: Syntax error: Encountered \"DECIMAL\" at line 3, column 23.\n" +
+                "Was expecting:\n" +
+                "    \"null\" ...\n" +
+                "    \n" +
+                "0:\tCREATE TABLE MY_TABLE (\n" +
+                "1:\tL_ORDERKEY BIGINT NOT NULL,\n" +
+                "2:\tL_PARTKEY INTEGER NOT DECIMAL,\n" +
+                "   \t                      ^^^^^^^---------\n" +
+                "3:\tL_SUPPKEY INTEGER NOT NULL,\n" +
+                "4:\tL_LINENUMBER INTEGER NOT NULL,\n" +
+                "5:\tL_QUANTITY DECIMAL(15,2),\n" +
+                ".\n" +
+                "Issue the 'help' command for general information on Splice command syntax.\n" +
+                "Any unrecognized commands are treated as potential SQL commands and executed directly.\n" +
+                "Consult your DBMS server reference documentation for details of the SQL syntax supported by your server.\n");
+    }
+
+    @Test
+    public void testLexerErrorMessage() {
+        execute("CREATE TABLE MY_TABLE (\n" +
+                "L_ORDERKEY BIGINT NOT NULL,\n" +
+                "L_PARTKEY # INTEGER NOT NULL,\n" +
+                "L_SUPPKEY INTEGER NOT NULL,\n" +
+                "L_LINENUMBER INTEGER NOT NULL,\n" +
+                "L_QUANTITY DECIMAL(15,2),\n" +
+                "L_EXTENDEDPRICE DECIMAL(15,2),\n" +
+                "L_DISCOUNT DECIMAL(15,2)\n" +
+                ");\n",
+
+                "ERROR 42X02: Lexical error at line 3, column 11.  Encountered: \"#\" (35), after : \"\"\n" +
+                "\n" +
+                "0:\tCREATE TABLE MY_TABLE (\n" +
+                "1:\tL_ORDERKEY BIGINT NOT NULL,\n" +
+                "2:\tL_PARTKEY # INTEGER NOT NULL,\n" +
+                "   \t         ^^---------\n" +
+                "3:\tL_SUPPKEY INTEGER NOT NULL,\n" +
+                "4:\tL_LINENUMBER INTEGER NOT NULL,\n" +
+                "5:\tL_QUANTITY DECIMAL(15,2),\n" +
+                ".\n");
+    }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropTableIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropTableIT.java
@@ -140,7 +140,8 @@ public class DropTableIT extends SpliceUnitTest {
         }
         catch (SQLException e) {
             Assert.assertEquals("Wrong Exception","42X01",e.getSQLState());
-            Assert.assertEquals("Wrong Warning Message", "Syntax error: Encountered \"EXISTS\" at line 1, column 12.", e.getMessage());
+            Assert.assertEquals("Wrong Warning Message",
+                    "Syntax error: Encountered \"EXISTS\" at line 1, column 12.", e.getMessage().split("\n")[0]);
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropViewIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/DropViewIT.java
@@ -141,7 +141,8 @@ public class DropViewIT {
         }
         catch (SQLException e) {
             Assert.assertEquals("Wrong Exception","42X01",e.getSQLState());
-            Assert.assertEquals("Wrong Warning Message", "Syntax error: Encountered \"EXISTS\" at line 1, column 11.", e.getMessage());
+            Assert.assertEquals("Wrong Warning Message",
+                    "Syntax error: Encountered \"EXISTS\" at line 1, column 11.", e.getMessage().split("\n")[0]);
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TruncateFunctionIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/TruncateFunctionIT.java
@@ -607,7 +607,7 @@ public class TruncateFunctionIT {
             fail("Expected exception.");
         } catch (Exception e) {
             Assert.assertEquals("Syntax error: Encountered \")\" at line 1, column 17.",
-                                e.getLocalizedMessage());
+                                e.getLocalizedMessage().split("\n")[0]);
         }
     }
 
@@ -620,7 +620,7 @@ public class TruncateFunctionIT {
             fail("Expected exception.");
         } catch (Exception e) {
             Assert.assertEquals("Syntax error: Encountered \"null\" at line 1, column 17.",
-                                e.getLocalizedMessage());
+                                e.getLocalizedMessage().split("\n")[0]);
         }
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/test/framework/SpliceUnitTest.java
@@ -594,7 +594,8 @@ public class SpliceUnitTest {
             fail(failMsg);
         }
         catch (Exception e) {
-            boolean found = expectedErrors.contains(e.getMessage());
+            String msg = e.getMessage().split("\n")[0];
+            boolean found = expectedErrors.contains(msg);
             if (!found)
                 fail(format("\n + Unexpected error message: %s + \n", e.getMessage()));
         }
@@ -609,7 +610,8 @@ public class SpliceUnitTest {
             fail(failMsg);
         }
         catch (Exception e) {
-            boolean found = expectedErrors.contains(e.getMessage());
+            String msg = e.getMessage().split("\n")[0];
+            boolean found = expectedErrors.contains(msg);
             if (!found)
                 fail(format("\n + Unexpected error message: %s + \n", e.getMessage()));
         }


### PR DESCRIPTION
## Short Description
improve error messages with more detailed description what's wrong with the SQL

## Example
SQL with errors:
```
CREATE TABLE MY_TABLE (
L_ORDERKEY BIGINT NOT NULL,
L_PARTKEY INTEGER NOT DECIMAL,
L_SUPPKEY INTEGER NOT NULL,
L_LINENUMBER INTEGER NOT NULL,
L_QUANTITY DECIMAL(15,2),
L_EXTENDEDPRICE DECIMAL(15,2),
L_DISCOUNT DECIMAL(15,2)
);
```

Error Message before

```
ERROR 42X01: Syntax error: Encountered "DECIMAL" at line 3, column 23.
```

New Error Message

```
ERROR 42X01: Syntax error: Encountered "DECIMAL" at line 3, column 23.
Was expecting:
    "null" ...
    
1: CREATE TABLE MY_TABLE (
2: L_ORDERKEY BIGINT NOT NULL,
3: L_PARTKEY INTEGER NOT DECIMAL,
                         ^^^^^^^---------
4: L_SUPPKEY INTEGER NOT NULL,
5: L_LINENUMBER INTEGER NOT NULL,
6:L_QUANTITY DECIMAL(15,2),
```
