### PR TITLE
DB-12225 Implement constant folding for numeric binary +-*/% 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -363,7 +363,7 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
     /** @see ValueNode#evaluateConstantExpressions */
     @Override
     ValueNode evaluateConstantExpressions() throws StandardException {
-        if (isConstantExpression()) {
+        if (getLeftOperand() instanceof ConstantNode && getRightOperand() instanceof ConstantNode) {
             ConstantNode lhs = (ConstantNode) getLeftOperand();
             ConstantNode rhs = (ConstantNode) getRightOperand();
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/BinaryArithmeticOperatorNode.java
@@ -37,11 +37,7 @@ import com.splicemachine.db.iapi.services.sanity.SanityManager;
 
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 
-import com.splicemachine.db.iapi.types.DataTypeUtilities;
-import com.splicemachine.db.iapi.types.DateTimeDataValue;
-import com.splicemachine.db.iapi.types.TypeId;
-
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
+import com.splicemachine.db.iapi.types.*;
 
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 
@@ -362,5 +358,57 @@ public final class BinaryArithmeticOperatorNode extends BinaryOperatorNode
             localCost *= FLOAT_OP_COST_FACTOR;
         }
         return localCost + super.getBaseOperationCost() + SIMPLE_OP_COST * FN_CALL_COST_FACTOR;
+    }
+
+    /** @see ValueNode#evaluateConstantExpressions */
+    @Override
+    ValueNode evaluateConstantExpressions() throws StandardException {
+        if (isConstantExpression()) {
+            ConstantNode lhs = (ConstantNode) getLeftOperand();
+            ConstantNode rhs = (ConstantNode) getRightOperand();
+
+            if (lhs.isNull()) {
+                return lhs;
+            }
+            if (rhs.isNull()) {
+                return rhs;
+            }
+            if (lhs instanceof NumericConstantNode && rhs instanceof NumericConstantNode) {
+                DataTypeDescriptor resultType = lhs.getTypeCompiler().resolveArithmeticOperation(
+                        lhs.getTypeServices(),
+                        rhs.getTypeServices(),
+                        operator
+                );
+                NumberDataValue result;
+                NumberDataValue leftValue = (NumberDataValue) lhs.getValue();
+                NumberDataValue rightValue = (NumberDataValue) rhs.getValue();
+                NumberDataValue receiver = leftIsReceiver() ? leftValue : rightValue;
+                switch (operator) {
+                    case TypeCompiler.TIMES_OP:
+                        result = receiver.times(leftValue, rightValue, null);
+                        break;
+                    case TypeCompiler.DIVIDE_OP:
+                        result = receiver.divide(leftValue, rightValue, null);
+                        break;
+                    case TypeCompiler.PLUS_OP:
+                        result = receiver.plus(leftValue, rightValue, null);
+                        break;
+                    case TypeCompiler.MINUS_OP:
+                        result = receiver.minus(leftValue, rightValue, null);
+                        break;
+                    case TypeCompiler.MOD_OP:
+                        result = receiver.mod(leftValue, rightValue, null);
+                        break;
+                    default:
+                        throw new IllegalStateException("Unexpected value: " + operator);
+                }
+                return new NumericConstantNode(
+                        getContextManager(),
+                        QueryTreeNode.getConstantNodeType(resultType),
+                        result,
+                        resultType);
+            }
+        }
+        return this;
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/QueryTreeNode.java
@@ -620,7 +620,7 @@ public abstract class QueryTreeNode implements Node, Visitable{
         return false;
     }
 
-    public int getConstantNodeType(DataTypeDescriptor type) throws StandardException {
+    public static int getConstantNodeType(DataTypeDescriptor type) throws StandardException {
         int constantNodeType;
         switch(type.getTypeId().getJDBCTypeId()){
             case Types.VARCHAR:

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ConstantFoldingIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/ConstantFoldingIT.java
@@ -180,6 +180,24 @@ public class ConstantFoldingIT extends SpliceUnitTest {
                 "1 = + (1)"
         ));
     }
+
+    @Test
+    public void testBinaryArithmetic() throws Exception {
+        checkFalsePredicates(Arrays.asList(
+                "1 = 2 + 4",
+                "1 = 2 - 4",
+                "1 = 2 * 4",
+                "1 = 2 / 4",
+                "1 = mod(2, 4)"
+        ));
+        checkTruePredicates(Arrays.asList(
+                "6 = 2 + 4",
+                "-2 = 2 - 4",
+                "8 = 2 * 4",
+                "0 = 2 / 4",
+                "2 = mod(2, 4)"
+        ));
+    }
 }
 
 

--- a/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateTransitiveClosureIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/db/impl/sql/compile/PredicateTransitiveClosureIT.java
@@ -85,7 +85,7 @@ public class PredicateTransitiveClosureIT extends SpliceUnitTest {
 
         ResultSet rs = methodWatcher.executeQuery("explain " + sqlText);
         String explainString = TestUtils.FormattedResult.ResultFactory.toStringUnsorted(rs);
-        Assert.assertTrue(sqlText + " expected to derive a2=1+2", explainString.contains("preds=[(A2[2:1] = (1 + 2))])"));
+        Assert.assertTrue(sqlText + " expected to derive a2=1+2", explainString.contains("preds=[(A2[2:1] = 3)])"));
         rs.close();
         rs = methodWatcher.executeQuery(sqlText);
         Assert.assertEquals("\n"+sqlText+"\n", expected, TestUtils.FormattedResult.ResultFactory.toString(rs));

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperatonIT.java
@@ -242,7 +242,7 @@ public class MultiProbeTableScanOperatonIT extends SpliceUnitTest {
     @Test
     public void testMultiProbeWithComputations() throws Exception {
         this.thirdRowContainsQuery("explain select * from a --splice-properties index=i\n" +
-                " where d in (10.0+10, 11.0+10)","keys=[(D[0:1] IN ((10.0 + 10),(11.0 + 10)))]",methodWatcher);
+                " where d in (10.0+10, 11.0+10)","keys=[(D[0:1] IN (20.0,21.0))]",methodWatcher);
     }
 
     // DB-1323

--- a/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
+++ b/splice_machine/src/test/java/com/splicemachine/subquery/Subquery_Flattening_InList_IT.java
@@ -158,8 +158,9 @@ public class Subquery_Flattening_InList_IT extends SpliceUnitTest {
     @Test
     public void testMultiColumnLikeNotFlattenOrNodeCorrelated() throws Exception {
         assertUnorderedResult(methodWatcher.getOrCreateConnection(),
-                "select * from C as O where 1+1=1 or (name, surname) in (select * from C as I --splice-properties joinStrategy=nestedloop\n where length(I.surname) = length(O.surname))", ONE_SUBQUERY_NODE, "" +
-                        "NAME  | SURNAME |\n" +
+                "select * from C as O where length('a')+1=1 or (name, surname) in (select * from C as I --splice-properties joinStrategy=nestedloop\n where length(I.surname) = length(O.surname))",
+                ONE_SUBQUERY_NODE,
+                "NAME  | SURNAME |\n" +
                         "------------------\n" +
                         "Eddard |  Stark  |\n" +
                         "  Jon  |  Arryn  |\n" +


### PR DESCRIPTION
## Description

Support plus, minus, times, divide, mod constant folding for numeric operands

## How to test

This can be tested via an explain on simple selects:

```
explain select * from sysibm.sysdummy1 where 1 = 1 + 1
```

will return a plan without a table scan because 1 = 1 + 1 is evaluated to be false at compile time
The same principle will apply to the other operators supported in that ticket.