### PR TITLE
DB-12057 Cost broadcast join for left outer join with no hash key

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1BroadcastJoinCostEstimation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/costing/V1BroadcastJoinCostEstimation.java
@@ -70,8 +70,9 @@ public class V1BroadcastJoinCostEstimation implements StrategyJoinCostEstimation
                 estimatedMemoryMB<regionThreshold &&
                         estimatedRowCount<rowCountThreshold &&
                         (!currentAccessPath.isMissingHashKeyOK() ||
-                                // allow full outer join without equality join condition
-                                outerCost.getJoinType() == JoinNode.FULLOUTERJOIN||
+                                // allow outer join without equality join condition
+                                outerCost.getJoinType() == JoinNode.FULLOUTERJOIN ||
+                                outerCost.getJoinType() == JoinNode.LEFTOUTERJOIN ||  // DB-11063
                                 // allow left or inner join with non-equality broadcast join only if using spark
                                 (innerTable instanceof FromBaseTable && optimizer.isForSpark()));
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/joins/BroadcastJoinIT.java
@@ -361,6 +361,30 @@ public class BroadcastJoinIT extends SpliceUnitTest {
         row(3, "ce")
         )).create();
 
+        new TableCreator(conn)
+                .withCreate("create table VT (STARTTS TIMESTAMP, ENDTS TIMESTAMP)")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table RTPS (\"FULLNAME\" VARCHAR(100) NOT NULL,\n" +
+                                    "           \"NAME\"     VARCHAR(100) NOT NULL,\n" +
+                                    "           \"TIME\"     TIMESTAMP    NOT NULL,\n" +
+                                    "           \"VALUE\"    DOUBLE,\n" +
+                                    "           \"QUALITY\"  INTEGER,\n" +
+                                    "           CONSTRAINT RTPS_PK PRIMARY KEY (\"FULLNAME\", \"TIME\"))")
+                .create();
+
+        new TableCreator(conn)
+                .withCreate("create table TF (\"FULLNAME\"   VARCHAR(100) NOT NULL,\n" +
+                                    "         \"TBR\"        INTEGER,\n" +
+                                    "         \"COUNT\"      INTEGER,\n" +
+                                    "         CONSTRAINT TF_PK PRIMARY KEY (\"FULLNAME\"))")
+                .create();
+
+        classWatcher.execute(format("CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'VT', 1000000, 100, 1)", schemaName));
+        classWatcher.execute(format("CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'RTPS', 29921286817, 100, 1)", schemaName));
+        classWatcher.execute(format("CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'TF', 10000, 100, 1)", schemaName));
+
         classWatcher.executeUpdate("insert into t11 values (2,2)");
         classWatcher.executeUpdate("insert into t11 values (3,3)");
         classWatcher.executeUpdate("insert into t11 values (4,4)");
@@ -1050,5 +1074,23 @@ public class BroadcastJoinIT extends SpliceUnitTest {
                             "where t11.a between 1 and 90 and t11.b = myTab.a";
             testQueryContains(explainQuery, "NestedLoopJoin", methodWatcher, true);
         }
+    }
+
+    @Test
+    public void testBroadcastLeftOuterJoinLowerCost() throws Exception {
+        String query = "explain select * from --splice-properties joinOrder=fixed\n" +
+                " (select 1 as JK, STARTTS, ENDTS from VT) T" +
+                " left outer join" +
+                " (select TIME from RTPS" +
+                "          where TIME between '2020-01-01 00:00:00' AND '2020-01-03 00:00:00'" +
+                "            and FULLNAME in ('1234', '5678')" +
+                "          group by TIME) TG" +
+                "   on T.STARTTS = TG.TIME" +
+                " left outer join" +
+                " (select * from TF" +
+                "          where FULLNAME in ('1234', '5678')) TX" +
+                "   on 1 = 1";
+
+        rowContainsQuery(new int[]{3,6}, query, methodWatcher, "BroadcastLeftOuterJoin", "MergeSortLeftOuterJoin");
     }
 }


### PR DESCRIPTION
## Short Description
This PR fixes two issues:
- broadcast join is feasible but not costed in case of left outer join + missing hash key
- hash join predicates are not pulled up properly when the predicate is under a hash join which is in turn nested inside a non-flattenable subquery

## Long Description

Broadcast join is not costed in some cases. When it’s not costed, its cost is set to `Double.MAX`, thus losing the comparison to other join strategies.

The current condition is the following:
```
boolean costIt = isHinted ||
                estimatedMemoryMB<regionThreshold &&
                        estimatedRowCount<rowCountThreshold &&
                        (!currentAccessPath.isMissingHashKeyOK() ||
                                // allow outer join without equality join condition
                                outerCost.getJoinType() == JoinNode.FULLOUTERJOIN ||
                                // allow left or inner join with non-equality broadcast join only if using spark
                                (innerTable instanceof FromBaseTable && optimizer.isForSpark()));
```
We can see that broadcast join is costed anyway when `isHinted` is true. That’s why when giving the hint, we see a broadcast join plan with lower cost.

For the query in this ticket, problem is that `isMissingHashKeyOK()` is true (thus false after negation), the join type is `JoinNode.LEFTOUTERJOIN`, and `innerTable` is a from subquery, thus not an instance of `FromBaseTable`. The whole condition in parentheses is then false, making `costIt` false.

In DB-11063 PR, `isMissingHashKeyOK` is set also in case of a left outer join:
```
if (hashKeyColumns == null && skipKeyCheck) {
            // For full outer join, broadcast join is the default join strategy that can be applied
            // to any kinds of join predicate, so make the eligibility check more general
            if ((outerCost.getJoinType() == JoinNode.FULLOUTERJOIN ||
                 outerCost.getJoinType() == JoinNode.LEFTOUTERJOIN) &&  // <-- added by DB-11063
                (innerTable.isMaterializable() ||
                 innerTable.supportsMultipleInstantiations())) {
                ap.setMissingHashKeyOK(true);
                return true;
            }
            ...
}
```
So it looks like the `costIt` condition is not updated. This PR add left outer join to the condition, too.

After this fix, the following test case in `Subquery_Flattening_SSQ_To_FromSubquery_IT` fails:
```
/* Q4: SSQ correlated to table more than one level up */
sql = "select d1 from t1 where a1 in (select (select d2 from t2 where a1+a3-1=a2 and a2<>2) as D from t3 where b1=b3) and d1=1";

expected = "D1 |\n" +
                "----\n" +
                " 1 |";
SubqueryITUtil.assertUnorderedResult(methodWatcher.getOrCreateConnection(), sql, SubqueryITUtil.ONE_SUBQUERY_NODE, expected);
```

Problem is that in the final plan, a broadcast join is between `T3` and `T2` under a subquery node. Predicate `a1 + a3 - 1 = a2` is wrongly pushed to `T2` side. Since it references `a3` from `T3`, there is no way to evaluate this predicate when preparing `T2` for the broadcast join.

In `JoinConditionVisitor`, we handle such cases by calling `pullUpPreds()` for `JoinNode` if it's a hash join or cross join. The condition of testing if a predicate should be pulled up or not is the following:
```
joinScoped = evalableAtNode(j);
shouldPull =
      Predicates.and(Predicates.or(Predicates.not(evalableAtNode(rsn)), isFullJoinPredicate), joinScoped);
```

In plain text, the condition is "(the predicate cannot be evaluated at current node (rsn) or it's a full join predicate) and the predicate can be evaluated at the join node (j)".

For the case above, however, both `evalableAtNode(rsn)` and `evalableAtNode(j)` are false. The way that `evalableAtNode(j)` runs is to check if the set of result set numbers referenced in a predicate is a subset of the set of all result set numbers from the subtree rooted from `j`. Since `a1 + a3 - 1 = a2` references `a1` from `T1`, it's not a subset of the result set number set of `j` because `j` subtree has only `T2` and `T3`.

But the predicate can indeed be evaluated at node `j` because it's under a subquery node. The execution model of the subquery node is like NLJ: each row from `T1` is passed in to the subquery node iteratively. This means the `evalableAtNode()` check is not sufficient because it doesn't know `T1` is accessible.

The fix introduces a new `accessibleResultSets` field in `JoinConditionVisitor`. When visiting a PRN node and the PRN node has subqueries, the child result set number of the PRN is added to `accessibleResultSets`. After visiting the restriction list of the PRN, the child reset set number is then removed. This process can be nested in multiple levels.

## How to test
Setup:
```
create table VT (STARTTS TIMESTAMP, ENDTS TIMESTAMP);
create table RTPS ("FULLNAME" VARCHAR(100) NOT NULL,
                                "NAME"     VARCHAR(100) NOT NULL,
                                "TIME"     TIMESTAMP    NOT NULL,
                                "VALUE"    DOUBLE,
                                "QUALITY"  INTEGER,
                                CONSTRAINT RTPS_PK PRIMARY KEY ("FULLNAME", "TIME"));
create table TF ("FULLNAME"   VARCHAR(100) NOT NULL,
                           "TBR"        INTEGER,
                           "COUNT"      INTEGER,
                            CONSTRAINT TF_PK PRIMARY KEY (\"FULLNAME\"));

CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'VT', 1000000, 100, 1);
CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'RTPS', 29921286817, 100, 1);
CALL SYSCS_UTIL.FAKE_TABLE_STATISTICS('%s', 'TF', 10000, 100, 1);
```
Query:
Find it in `testBroadcastLeftOuterJoinLowerCost` in `BroadcastJoinIT`.

Expected:
- before the fix, the query should give a plan with the second join being a nested loop join;
- after the fix, the query should give a plan with the second join being a broadcast join;
- at any time, `Subquery_Flattening_SSQ_To_FromSubquery_IT` and all other ITs should never fail.
