### PR TITLE
DB-12057 Cost broadcast join for left outer join with no hash key (3.0)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/ast/ISpliceVisitor.java
@@ -48,6 +48,12 @@ public interface ISpliceVisitor {
     boolean stopTraversal();
     boolean skipChildren(Visitable node);
 
+    /**
+     * Return the low-level Visitor instead of the wrapper class
+     * in case this is an ASTVisitor.
+     */
+    default ISpliceVisitor getVisitor() { return this; }
+
     Visitable defaultVisit(Visitable node) throws StandardException;
 
     // ResultSet nodes

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/Visitor.java
@@ -31,6 +31,7 @@
 
 package	com.splicemachine.db.iapi.sql.compile;
 
+import com.splicemachine.db.iapi.ast.ISpliceVisitor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.impl.sql.compile.QueryTreeNode;
 
@@ -116,4 +117,10 @@ public interface Visitor
 	 * @return true/false
 	 */
 	boolean skipChildren(Visitable node) throws StandardException;
+
+	/**
+	 * Return the low-level Visitor instead of the wrapper class
+	 * in case this is an ASTVisitor.
+	 */
+	default ISpliceVisitor getBaseVisitor() { return null; }
 }	

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/JoinConditionVisitor.java
@@ -78,6 +78,7 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
 
     private static Logger LOG = Logger.getLogger(JoinConditionVisitor.class);
     private LongLongHashMap joinChainMap;
+    private Set<Integer> accessibleResultSets = new HashSet<>(64);
 
     private void initializeMap(QueryTreeNode v)  throws StandardException {
         if (joinChainMap == null)
@@ -145,7 +146,7 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
                 RSUtils.nodesUntilBinaryNode(j.getRightResultSet()),
                 RSUtils.rsnHasPreds);
 
-        splice.com.google.common.base.Predicate<Predicate> joinScoped = evalableAtNode(j);
+        splice.com.google.common.base.Predicate<Predicate> joinScoped = evalableAtNode(j, accessibleResultSets);
         splice.com.google.common.base.Predicate<Predicate> isFullJoinPredicate = pred -> pred.isFullJoinPredicate();
 
         ResultSetNode parent = null;
@@ -154,7 +155,9 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
             // Encode whether to pull up predicate to join:
             //  when can't evaluate on node but can evaluate at join
             splice.com.google.common.base.Predicate<Predicate> shouldPull =
-                    Predicates.and(Predicates.or(Predicates.not(evalableAtNode(rsn)), isFullJoinPredicate), joinScoped);
+                    Predicates.and(Predicates.or(Predicates.not(evalableAtNode(rsn, accessibleResultSets)),
+                                                 isFullJoinPredicate),
+                                   joinScoped);
             if(rsn instanceof ProjectRestrictNode)
                 c = pullPredsFromPR((ProjectRestrictNode)rsn,shouldPull);
             else if(rsn instanceof FromBaseTable){
@@ -352,7 +355,7 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
                 RSUtils.nodesUntilIntersectOrExcept(j.getRightResultSet()),
                 RSUtils.rsnHasPreds);
 
-        splice.com.google.common.base.Predicate<Predicate> joinScoped = evalableAtNode(j);
+        splice.com.google.common.base.Predicate<Predicate> joinScoped = evalableAtNode(j, accessibleResultSets);
 
     	if (LOG.isDebugEnabled())
     		LOG.debug(String.format("joinScoped joinScoped=%s",joinScoped));
@@ -363,7 +366,7 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
         	// Encode whether to pull up predicate to join:
             //  when can't evaluate on node but can evaluate at join
             splice.com.google.common.base.Predicate<Predicate> predOfInterest =
-                    Predicates.and(Predicates.not(evalableAtNode(rsn)), joinScoped);
+                    Predicates.and(Predicates.not(evalableAtNode(rsn, accessibleResultSets)), joinScoped);
             joinPreds.addAll(Collections2
                      .filter(RSUtils.collectExpressionNodes(rsn, Predicate.class),
                              predOfInterest));
@@ -398,9 +401,10 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
     /**
      * Returns a fn that returns true if a Predicate can be evaluated at the node rsn
      */
-    public static splice.com.google.common.base.Predicate<Predicate> evalableAtNode(final ResultSetNode rsn)
+    public static splice.com.google.common.base.Predicate<Predicate> evalableAtNode(final ResultSetNode rsn, final Set<Integer> accessibleRSNs)
             throws StandardException {
-        final Set<Integer> rsns = Sets.newHashSet(Lists.transform(RSUtils.getSelfAndDescendants(rsn), RSUtils.rsNum));
+        Set<Integer> rsns = Sets.newHashSet(Lists.transform(RSUtils.getSelfAndDescendants(rsn), RSUtils.rsNum));
+        rsns.addAll(accessibleRSNs);
         return new splice.com.google.common.base.Predicate<Predicate>() {
             @Override
             public boolean apply(Predicate p) {
@@ -666,5 +670,13 @@ public class JoinConditionVisitor extends AbstractSpliceVisitor {
     public boolean isPostOrder() {
         // Default to PostOrder traversal, i.e. bottom-up
         return false;
+    }
+
+    public void addResultSetNumbers(int rsn) {
+        accessibleResultSets.add(rsn);
+    }
+
+    public void removeResultSetNumbers(int rsn) {
+        accessibleResultSets.remove(rsn);
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/ast/SpliceDerbyVisitorAdapter.java
@@ -136,4 +136,7 @@ public class SpliceDerbyVisitorAdapter implements ASTVisitor {
     public boolean skipChildren(Visitable node) throws StandardException {
         return v.skipChildren(node);
     }
+
+    @Override
+    public ISpliceVisitor getBaseVisitor() { return v.getVisitor(); }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/ProjectRestrictNode.java
@@ -32,6 +32,7 @@
 package com.splicemachine.db.impl.sql.compile;
 
 import com.splicemachine.db.catalog.types.ReferencedColumnsDescriptorImpl;
+import com.splicemachine.db.iapi.ast.ISpliceVisitor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.reference.ClassName;
 import com.splicemachine.db.iapi.services.classfile.VMOpcode;
@@ -46,8 +47,10 @@ import com.splicemachine.db.iapi.sql.dictionary.IndexRowGenerator;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.util.JBitSet;
+import com.splicemachine.db.impl.ast.JoinConditionVisitor;
 import com.splicemachine.db.impl.ast.PredicateUtils;
 import com.splicemachine.db.impl.ast.RSUtils;
+import com.splicemachine.db.impl.ast.SpliceDerbyVisitorAdapter;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import splice.com.google.common.base.Joiner;
 import splice.com.google.common.collect.Lists;
@@ -1944,11 +1947,29 @@ public class ProjectRestrictNode extends SingleChildResultSetNode{
     @Override
     public void acceptChildren(Visitor v) throws StandardException{
         super.acceptChildren(v);
+
+        JoinConditionVisitor jcv = null;
+        if (v instanceof JoinConditionVisitor) {
+            jcv = (JoinConditionVisitor) v;
+        } else if (v instanceof SpliceDerbyVisitorAdapter && v.getBaseVisitor() instanceof JoinConditionVisitor) {
+            jcv = (JoinConditionVisitor) v.getBaseVisitor();
+        }
+
+        if (jcv != null && hasSubqueries()) {
+            // if this PRN has subqueries, correlated predicates in those subqueries can
+            // access childResult
+            jcv.addResultSetNumbers(childResult.getResultSetNumber());
+        }
+
         if(restriction!=null){
             restriction=(ValueNode)restriction.accept(v, this);
         }
         if(restrictionList!=null){
             restrictionList=(PredicateList)restrictionList.accept(v, this);
+        }
+
+        if (jcv != null && hasSubqueries()) {
+            jcv.removeResultSetNumbers(childResult.getResultSetNumber());
         }
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/BroadcastJoinStrategy.java
@@ -132,7 +132,8 @@ public class BroadcastJoinStrategy extends HashableJoinStrategy {
                 estimatedRowCount<rowCountThreshold &&
                 (!currentAccessPath.isMissingHashKeyOK() ||
                  // allow full outer join without equality join condition
-                 outerCost.getJoinType() == JoinNode.FULLOUTERJOIN||
+                 outerCost.getJoinType() == JoinNode.FULLOUTERJOIN ||
+                 outerCost.getJoinType() == JoinNode.LEFTOUTERJOIN || // DB-11063
                  // allow left or inner join with non-equality broadcast join only if using spark
                  (innerTable instanceof FromBaseTable && optimizer.isForSpark()));
 


### PR DESCRIPTION
See https://github.com/splicemachine/spliceengine/pull/5610.

There is a second commit in this PR only for 3.0 branch. It introduces some visitor utility methods that are in master and 3.1 but not 3.0.