### PR TITLE
DB-12280 Stop key for Index Prefix Iteration should not override stopSearchOperator

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -649,7 +649,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     stopSearchOperator,
                     sameStartStopPosition,
                     rowIdKey,
-                    null, // qualifiersField
+                    qualifiersField,
                     tableName,
                     userSuppliedOptimizerOverrides,
                     indexName,

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DerbyScanInformation.java
@@ -64,6 +64,7 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
     private String scanQualifiersFieldName;
     private Field  qualifiersField;
     protected boolean sameStartStopPosition;
+    protected boolean skipScanQualifiers = false;
     private long conglomId;
     protected int startSearchOperator;
     protected int stopSearchOperator;
@@ -459,7 +460,7 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
     protected Qualifier[][] populateQualifiers() throws StandardException {
 
         Qualifier[][] scanQualifiers = null;
-        if (scanQualifiersFieldName != null) {
+        if (scanQualifiersFieldName != null && !skipScanQualifiers) {
             try {
                 if (qualifiersField == null)
                     qualifiersField = activation.getClass().getField(scanQualifiersFieldName);
@@ -526,5 +527,9 @@ public class DerbyScanInformation implements ScanInformation<ExecRow>, Externali
     // No-Op.  ProbeValue is used only by MultiProbeScan.
     public void setProbeValue(DataValueDescriptor dvd) {
 
+    }
+
+    public void skipQualifiers(boolean skip) {
+        skipScanQualifiers = skip;
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexPrefixIteratorOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexPrefixIteratorOperation.java
@@ -233,7 +233,7 @@ public class IndexPrefixIteratorOperation extends TableScanOperation{
                     firstRow = tableScannerIterator.next();
                 closeFirstTableScanner(tableScannerIterator);
                 if (firstRow == null)
-                    return controlDSP.getEmpty();
+                    return dsp.getEmpty();
 
                 int firstMappedIndexColumnNumber = baseColumnMap[firstIndexColumnNumber-1]+1;
                 ExecRow keyRow = new ValueRow(1);
@@ -272,7 +272,7 @@ public class IndexPrefixIteratorOperation extends TableScanOperation{
 
         DataSet<ExecRow> finalDS;
         if (keys.size() == 0)
-            finalDS = controlDSP.getEmpty();
+            finalDS = dsp.getEmpty();
         else if (isMemPlatform) {
             ((BaseActivation) sourceResultSet.getActivation()).setSameStartStopScanKeyPrefix(true);
             // Instead of using MultiRowRangeFilter, on mem we create a separate scanner for each
@@ -324,7 +324,9 @@ public class IndexPrefixIteratorOperation extends TableScanOperation{
             controlDSP =
             EngineDriver.driver().processorFactory().
                                                     localProcessor(getOperation().getActivation(), this);
+        scanInformation.skipQualifiers(true);
         DataScan dataScan = getNonSIScan();
+        scanInformation.skipQualifiers(false);
 
         // No need for a large cache since we're
         // going after a single row on each read.

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/iapi/ScanInformation.java
@@ -88,4 +88,7 @@ public interface ScanInformation<T> {
     FormatableBitSet getDefaultValueMap() throws StandardException;
 
     boolean getSameStartStopPosition();
+
+    // Setting to true skips evaluation of the scan qualifiers.
+    void skipQualifiers(boolean skip);
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/utils/Scans.java
@@ -398,9 +398,9 @@ public class Scans extends SpliceUtils {
                 startKeyDVDs[0] = keyPrefixRow.getColumn(1);
                 stopKeyDVDs[0]  = keyPrefixRow.getColumn(1);
                  startStopKeys =
-                  buildStartAndStopKeys(startKeyDVDs, ScanController.GE,
+                  buildStartAndStopKeys(startKeyDVDs, startSearchOperator,
                                         stopKeyDVDs, null,
-                                        GT,
+                                        stopSearchOperator,
                                         sortOrder,
                                         scannedRow, //template row
                                         keyTablePositionMap, //the location in the ENTIRE row of the key columns


### PR DESCRIPTION
## Short Description
Avoid incorrect results on queries flagged as IndexPrefixIteratorMode in the EXPLAIN with predicates of the form _2nd_index_column_ < _constant_.

## Long Description
Scans.attachScanKeys was updated by [SPLICE-2399](https://github.com/splicemachine/spliceengine/pull/5013) to combine a list of key values on the first index column (firstIndexColumnKeys) with key values on the remaining index columns from predicates.  However this path always passed the stopSearchOperator parameter of buildStartAndStopKeys as hard-coded GT, which causes the stop key to be appended with an extra byte of value 1, causing the stop key to be inclusive, even if we are using a less than operator in the predicate.  The range was made wider in an attempt to never exclude necessary values with the assumption that the scan qualifier could filter out any unqualified values.  This works fine on control, but on spark, since the IndexPrefixIteratorOperation and associated TableScanOperation have the same result set number, spark SerDe ends up sharing the same DerbyScanInformation between the two operations (see SparkLeanOperationContext.readExternal):

> op=(Op)ah.getOperationsMap().get(in.readInt());

... and we pick up the qualifier of the IndexPrefixIteratorOperation, which has been set to null, since it is not desirable for the initial scanner to have a predicate (it may read to the end of the table in control mode before finding the first row!).  

The solution is:
1.  Use the passed-in startSearchOperator and stopSearchOperator parameters for building the scan keys instead of hard-coded arguments.
2. Build the IndexPrefixIteratorOperation with the same qualifier as the main table scan so the TableScanPredicateFunction of the TableScanOperation can see it and use it.  However, for performing the IndexPrefixIteratorOperation itself, temporarily set the qualifier to null when building that operation's scan to avoid applying an undesirable qualifier.

## How to test
create table t1 (a int, b timestamp, primary key(a,b));
insert into t1 values (1,timestamp('2021-06-24 18:00:00'));
insert into t1 values (2,timestamp('2021-06-24 17:00:00'));
/- the following should return 1 row:
select distinct(b) from t1 where b >= timestamp('2021-06-24 17:00:00') and b < timestamp('2021-06-24 18:00:00');
B
/-
2021-06-24 17:00:00.0



