### PR TITLE
DB-12210 NSDSv2 Continuous Topic Deletion

### DIFF
--- a/splice_spark2/pom.xml
+++ b/splice_spark2/pom.xml
@@ -317,10 +317,6 @@
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.fasterxml</pattern>
-                                    <shadedPattern>splice.com.fasterxml</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>org.codehaus.jackson</pattern>
                                     <shadedPattern>splice.org.codehaus.jackson</shadedPattern>
                                 </relocation>

--- a/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
@@ -43,9 +43,7 @@ class KafkaTopics(
   private def deleteTopics(): Unit = {
     val toDelete = collection.mutable.Set.empty[String]
     unneeded.drainTo(toDelete.asJava)
-    println(s"Deleting topics $toDelete")  // todo remove println
-    admin.deleteTopics(toDelete, 60*1000)  // todo will admin.deleteTopics accept an empty toDelete when there are no topics?
-    println(s"Delete done")  // todo remove println
+    admin.deleteTopics(toDelete, 60*1000)
   }
   
   if(continuousCleanup) {
@@ -53,7 +51,7 @@ class KafkaTopics(
       override def run {
         while (processing.get) {
           deleteTopics
-          Thread.sleep(60 * 1000)
+          Thread.sleep(60*1000)
         }
         deleteTopics
       }

--- a/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ * Copyright (c) 2012 - 2021 Splice Machine, Inc.
  *
  * This file is part of Splice Machine.
  * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
@@ -17,16 +17,49 @@ package com.splicemachine.nsds.kafka
 
 import com.splicemachine.primitives.Bytes
 import java.security.SecureRandom
+import java.util.concurrent.LinkedTransferQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.collection.JavaConverters._
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 @SerialVersionUID(20200518241L)
 @SuppressFBWarnings(value = Array("NP_ALWAYS_NULL"), justification = "Field 'unused' initialization is not null")
-class KafkaTopics(kafkaServers: String, defaultNumPartitions: Int = 1, defaultRepFactor: Short = 1) extends Serializable {
-  val admin = new KafkaAdmin(kafkaServers)
-  val unneeded = collection.mutable.HashSet[String]()
+class KafkaTopics(
+    kafkaServers: String, 
+    defaultNumPartitions: Int = 1, 
+    defaultRepFactor: Short = 1,
+    continuousCleanup: Boolean = true
+  ) extends Serializable
+{
+  private val admin = new KafkaAdmin(kafkaServers)
 
-  val unused = collection.mutable.Queue.fill(5)(createTopic())
+  private val unneeded = new LinkedTransferQueue[String]()
+  private val processing = new AtomicBoolean(true)
+
+  private val unused = collection.mutable.Queue.fill(5)(createTopic())
+
+  private def deleteTopics(): Unit = {
+    val toDelete = collection.mutable.Set.empty[String]
+    unneeded.drainTo(toDelete.asJava)
+    println(s"Deleting topics $toDelete")  // todo remove println
+    admin.deleteTopics(toDelete, 60*1000)  // todo will admin.deleteTopics accept an empty toDelete when there are no topics?
+    println(s"Delete done")  // todo remove println
+  }
   
+  if(continuousCleanup) {
+    new Thread {
+      override def run {
+        while (processing.get) {
+          deleteTopics
+          Thread.sleep(60 * 1000)
+        }
+        deleteTopics
+      }
+    }.start
+  }
+
   def create(): String = {
     unused.enqueue(createTopic())
     unused.dequeue
@@ -45,7 +78,10 @@ class KafkaTopics(kafkaServers: String, defaultNumPartitions: Int = 1, defaultRe
     topicName
   }
 
-  def delete(topicName: String): Unit = unneeded += topicName
+  def delete(topicName: String): Unit = unneeded.put(topicName)
 
-  def cleanup(timeoutMs: Long = 0): Unit = admin.deleteTopics(unneeded, timeoutMs)
+  def shutdown(): Unit = {
+    processing.compareAndSet(true, false)
+    if(!continuousCleanup) deleteTopics
+  }
 }

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -183,12 +183,13 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
       try {
         connectionManager.shutdown
       } catch {
-        case e: Throwable => ;
+        case e: Throwable => println(s"Problem closing JDBC connection.\n$e")
       }
       try {
         kafkaTopics.shutdown
       } catch {
-        case e: Throwable => ;  // no-op, undeleted topics should be handled by separate cleanup process
+        case e: Throwable => println(s"Problem cleaning up topics in Kafka.\n$e")
+        // undeleted topics should be handled by separate cleanup process
       }
     }
   })

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -186,7 +186,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
         case e: Throwable => ;
       }
       try {
-        kafkaTopics.cleanup(60*1000)
+        kafkaTopics.shutdown
       } catch {
         case e: Throwable => ;  // no-op, undeleted topics should be handled by separate cleanup process
       }

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -179,7 +179,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
 
   SparkSession.builder.getOrCreate.sparkContext.addSparkListener(new SparkListener {
     override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
-      println(s"Cleaning up SplicemachineContext.")
+      println(s"Cleaning up SplicemachineContext resources before shutdown.")
       try {
         connectionManager.shutdown
       } catch {
@@ -190,7 +190,6 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
       } catch {
         case e: Throwable => ;  // no-op, undeleted topics should be handled by separate cleanup process
       }
-      println(s"Clean up of SplicemachineContext Completed.")
     }
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
NSDS now deletes used topics during processing instead of at shutdown.

## Long Description
NSDS v2 (eNSDS) uses a new Kafka topic for each transaction, for both transactions to and from the DB.  After the call to the DB returns (which should mean the transaction is completed), NSDS puts the used topic name on a queue to be deleted.  A separate thread now checks the deletion queue and sends the topic names to Kafka to delete the topics.  The thread sleeps for a minute between checks of the deletion queue.

The code was previously queueing the used topic names after each transaction and sending them for deletion when NSDS shut down.  For a long running process like streaming, a large number of topics accumulate and fill disk and memory in Kafka.  Now NSDS performs continual cleanup.

## How to test
Use NSDS v2 (eNSDS) normally.  It's set to do topic deletion by default.  Watch the Kafka controller.log for messages containing the phrase `Deletion of topic`.
