### PR TITLE
DB-12222 Track all active sessions

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/db/InternalDatabase.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/db/InternalDatabase.java
@@ -156,4 +156,6 @@ public interface InternalDatabase extends com.splicemachine.db.database.Database
     long replaceJar(final InputStream is, JarUtil util) throws StandardException;
 
 	AccessFactory getAccessFactory();
+
+	default void unregisterSession(long sessionId) {};
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/jdbc/EmbedConnection.java
@@ -870,10 +870,11 @@ public abstract class EmbedConnection implements EngineConnection
      */
     private void checkUserIsNotARole() throws SQLException {
         TransactionResourceImpl tr = getTR();
+        LanguageConnectionContext lcc = null;
 
         try {
             tr.startTransaction();
-            LanguageConnectionContext lcc = tr.getLcc();
+            lcc = tr.getLcc();
             String username = lcc.getSessionUserId();
 
             DataDictionary dd = lcc.getDataDictionary();
@@ -895,6 +896,13 @@ public abstract class EmbedConnection implements EngineConnection
             }
 
             throw handleException(e);
+        } finally {
+            if (lcc != null) {
+                try {
+                    lcc.resetFromPool();
+                } catch (StandardException ignored) {
+                }
+            }
         }
 
     }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -1041,6 +1041,8 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
     /*Reset the connection before it is returned (indirectly) by a PooledConnection object. See EmbeddedConnection. */
     @Override
     public void resetFromPool() throws StandardException {
+        getSpliceInstance().unregisterSession(instanceNumber);
+
         interruptedException = null;
 
         // Reset IDENTITY_VAL_LOCAL

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/AdapterPipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/AdapterPipelineEnvironment.java
@@ -40,11 +40,11 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.rollforward.RollForward;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.data.hbase.coprocessor.AdapterSIEnvironment;
-import com.splicemachine.si.data.hbase.coprocessor.HOldestActiveTransactionTaskFactory;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.driver.SIEnvironment;
 import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
@@ -66,7 +66,6 @@ public class AdapterPipelineEnvironment implements PipelineEnvironment{
 
     private final SIEnvironment delegate;
     private final PipelineExceptionFactory pipelineExceptionFactory;
-    private final OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
     private final ContextFactoryDriver contextFactoryLoader;
     private final SConfiguration pipelineConfiguration;
     private final PipelineCompressor compressor;
@@ -95,7 +94,6 @@ public class AdapterPipelineEnvironment implements PipelineEnvironment{
                                        PipelineExceptionFactory pef){
         this.delegate = env;
         this.pipelineExceptionFactory = pef;
-        this.oldestActiveTransactionTaskFactory = new HOldestActiveTransactionTaskFactory();
         this.contextFactoryLoader = ctxFactoryLoader;
         this.pipelineConfiguration = env.configuration();
         this.pipelineFactory = new AvailablePipelineFactory();
@@ -124,7 +122,17 @@ public class AdapterPipelineEnvironment implements PipelineEnvironment{
 
     @Override
     public OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory(){
-        return oldestActiveTransactionTaskFactory;
+        return delegate.oldestActiveTransactionTaskFactory();
+    }
+
+    @Override
+    public ActiveSessionsTaskFactory allActiveSessionsTaskFactory(){
+        return delegate.allActiveSessionsTaskFactory();
+    }
+
+    @Override
+    public SessionsWatcher sessionsWatcher() {
+        return delegate.sessionsWatcher();
     }
 
     @Override public TxnStore txnStore(){ return delegate.txnStore(); }

--- a/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
+++ b/hbase_pipeline/src/main/java/com/splicemachine/derby/hbase/HBasePipelineEnvironment.java
@@ -42,11 +42,11 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.rollforward.RollForward;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
 import com.splicemachine.si.data.hbase.coprocessor.HBaseSIEnvironment;
-import com.splicemachine.si.data.hbase.coprocessor.HOldestActiveTransactionTaskFactory;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.driver.SIEnvironment;
 import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
@@ -64,7 +64,6 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
 
     private final SIEnvironment delegate;
     private final PipelineExceptionFactory pipelineExceptionFactory;
-    private final OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
     private final ContextFactoryDriver contextFactoryLoader;
     private final SConfiguration pipelineConfiguration;
     private final PipelineCompressor compressor;
@@ -93,7 +92,6 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
                                      PipelineExceptionFactory pef){
         this.delegate = env;
         this.pipelineExceptionFactory = pef;
-        this.oldestActiveTransactionTaskFactory = new HOldestActiveTransactionTaskFactory();
         this.contextFactoryLoader = ctxFactoryLoader;
         this.pipelineConfiguration = env.configuration();
         this.pipelineFactory = new AvailablePipelineFactory();
@@ -122,7 +120,17 @@ public class HBasePipelineEnvironment implements PipelineEnvironment{
 
     @Override
     public OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory(){
-        return oldestActiveTransactionTaskFactory;
+        return delegate.oldestActiveTransactionTaskFactory();
+    }
+
+    @Override
+    public ActiveSessionsTaskFactory allActiveSessionsTaskFactory(){
+        return delegate.allActiveSessionsTaskFactory();
+    }
+
+    @Override
+    public SessionsWatcher sessionsWatcher() {
+        return delegate.sessionsWatcher();
     }
 
     @Override public TxnStore txnStore(){ return delegate.txnStore(); }

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/SessionsWatcherImpl.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/SessionsWatcherImpl.java
@@ -31,7 +31,7 @@ public class SessionsWatcherImpl implements com.splicemachine.si.api.session.Ses
     private static final Logger LOG = Logger.getLogger(SessionsWatcherImpl.class);
     private final Set<Long> activeSessions = new ConcurrentHashSet<>();
 
-    public static SessionsWatcherImpl INSTANCE = new SessionsWatcherImpl();
+    public static final SessionsWatcherImpl INSTANCE = new SessionsWatcherImpl();
 
     private SessionsWatcherImpl(){}
 

--- a/hbase_storage/src/main/java/com/splicemachine/hbase/SessionsWatcherImpl.java
+++ b/hbase_storage/src/main/java/com/splicemachine/hbase/SessionsWatcherImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.hbase;
+
+import com.splicemachine.access.api.GetActiveSessionsTask;
+import com.splicemachine.access.api.PartitionAdmin;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.storage.PartitionServer;
+import com.splicemachine.utils.SpliceLogUtils;
+import org.apache.log4j.Logger;
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import splice.com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class SessionsWatcherImpl implements com.splicemachine.si.api.session.SessionsWatcher {
+    private static final Logger LOG = Logger.getLogger(SessionsWatcherImpl.class);
+    private final Set<Long> activeSessions = new ConcurrentHashSet<>();
+
+    public static SessionsWatcherImpl INSTANCE = new SessionsWatcherImpl();
+
+    private SessionsWatcherImpl(){}
+
+    @Override
+    public Set<Long> getLocalActiveSessions() {
+        return new HashSet<>(activeSessions);
+    }
+
+    @Override
+    public List<Long> getAllActiveSessions() {
+        Set<Long> idSet = new HashSet<>(activeSessions);
+        try {
+            if (LOG.isDebugEnabled())
+                SpliceLogUtils.debug(LOG, "fetch all active sessions");
+
+            PartitionAdmin pa = SIDriver.driver().getTableFactory().getAdmin();
+            ExecutorService executorService = SIDriver.driver().getExecutorService();
+            Collection<PartitionServer> servers = pa.allServers();
+
+            List<Future<Set<Long>>> futures = Lists.newArrayList();
+            for (PartitionServer server : servers) {
+                GetActiveSessionsTask task = SIDriver.driver().getAllActiveSessionsTaskFactory().get(
+                        server.getHostname(), server.getPort(), server.getStartupTimestamp());
+                futures.add(executorService.submit(task));
+            }
+
+            for (Future<Set<Long>> future : futures) {
+                Set<Long> localActiveSessions = future.get();
+                idSet.addAll(localActiveSessions);
+            }
+        } catch (IOException | ExecutionException | InterruptedException e) {
+            SpliceLogUtils.error(LOG, "Unable to fetch all active sessions. " +
+                    "Leaving local active session ID list untouched. Error cause by: %s", e);
+        }
+        List<Long> result = new ArrayList<>(idSet);
+        Collections.sort(result);
+        return result;
+    }
+
+    @Override
+    public void registerSession(long sessionId) {
+        activeSessions.add(sessionId);
+    }
+
+    @Override
+    public void unregisterSession(long sessionId) {
+        activeSessions.remove(sessionId);
+    }
+
+}

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HActiveSessionsTaskFactory.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HActiveSessionsTaskFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.si.data.hbase.coprocessor;
+
+import com.splicemachine.access.api.ActiveSessionsTaskFactory;
+import com.splicemachine.access.api.GetActiveSessionsTask;
+import org.apache.hadoop.hbase.ServerName;
+
+import java.io.IOException;
+
+public class HActiveSessionsTaskFactory implements ActiveSessionsTaskFactory {
+
+    @Override
+    public GetActiveSessionsTask get(String hostName, int port, long startupTimestamp) throws IOException {
+        ServerName serverName = ServerName.valueOf(hostName, port, startupTimestamp);
+        return new HGetActiveSessionsTask(serverName);
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HBaseSIEnvironment.java
@@ -23,8 +23,10 @@ import com.splicemachine.access.hbase.HBaseConnectionFactory;
 import com.splicemachine.access.hbase.HFilesystemAdmin;
 import com.splicemachine.access.hbase.HSnowflakeFactory;
 import com.splicemachine.access.util.ByteComparisons;
+import com.splicemachine.hbase.SessionsWatcherImpl;
 import com.splicemachine.hbase.ZkUtils;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.data.hbase.rollforward.HBaseRollForward;
 import com.splicemachine.si.impl.store.IgnoreTxnSupplier;
 import com.splicemachine.si.impl.store.IgnoreTxnSupplierImpl;
@@ -72,6 +74,8 @@ public class HBaseSIEnvironment implements SIEnvironment{
     private final TimestampSource timestampSource;
     private final PartitionFactory<TableName> partitionFactory;
     private final OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
+    private final ActiveSessionsTaskFactory activeSessionsTaskFactory;
+    private final SessionsWatcher sessionsWatcher;
     private final TxnStore txnStore;
     private final TxnSupplier txnSupplier;
     private final IgnoreTxnSupplier ignoreTxnSupplier;
@@ -113,6 +117,8 @@ public class HBaseSIEnvironment implements SIEnvironment{
         this.partitionCache = PartitionCacheService.loadPartitionCache(config);
         this.partitionFactory = TableFactoryService.loadTableFactory(clock,this.config,partitionCache);
         this.oldestActiveTransactionTaskFactory = new HOldestActiveTransactionTaskFactory();
+        this.activeSessionsTaskFactory = new HActiveSessionsTaskFactory();
+        this.sessionsWatcher = SessionsWatcherImpl.INSTANCE;
         TxnNetworkLayerFactory txnNetworkLayerFactory= TableFactoryService.loadTxnNetworkLayer(this.config);
         this.opFactory = HOperationFactory.INSTANCE;
         this.txnOpFactory = new SimpleTxnOperationFactory(exceptionFactory(),opFactory);
@@ -146,6 +152,8 @@ public class HBaseSIEnvironment implements SIEnvironment{
         this.partitionCache = PartitionCacheService.loadPartitionCache(config);
         this.partitionFactory = TableFactoryService.loadTableFactory(clock, this.config,partitionCache);
         this.oldestActiveTransactionTaskFactory = new HOldestActiveTransactionTaskFactory();
+        this.activeSessionsTaskFactory = new HActiveSessionsTaskFactory();
+        this.sessionsWatcher = SessionsWatcherImpl.INSTANCE;
         TxnNetworkLayerFactory txnNetworkLayerFactory= TableFactoryService.loadTxnNetworkLayer(this.config);
         this.opFactory = HOperationFactory.INSTANCE;
         this.txnOpFactory = new SimpleTxnOperationFactory(exceptionFactory(),opFactory);
@@ -181,6 +189,16 @@ public class HBaseSIEnvironment implements SIEnvironment{
     @Override
     public OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory(){
         return oldestActiveTransactionTaskFactory;
+    }
+
+    @Override
+    public ActiveSessionsTaskFactory allActiveSessionsTaskFactory(){
+        return activeSessionsTaskFactory;
+    }
+
+    @Override
+    public SessionsWatcher sessionsWatcher() {
+        return sessionsWatcher;
     }
 
     @Override

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HGetActiveSessionsTask.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/HGetActiveSessionsTask.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.si.data.hbase.coprocessor;
+
+import com.splicemachine.access.HConfiguration;
+import com.splicemachine.access.api.GetActiveSessionsTask;
+import com.splicemachine.access.api.SConfiguration;
+import com.splicemachine.access.hbase.HBaseConnectionFactory;
+import com.splicemachine.coprocessor.SpliceMessage;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class HGetActiveSessionsTask implements GetActiveSessionsTask {
+    ServerName serverName;
+    public HGetActiveSessionsTask(ServerName serverName){
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Set<Long> call() throws Exception{
+        SConfiguration configuration = HConfiguration.getConfiguration();
+        Connection conn = HBaseConnectionFactory.getInstance(configuration).getConnection();
+        Admin admin = conn.getAdmin();
+        CoprocessorRpcChannel channel = admin.coprocessorService(serverName);
+        SpliceRSRpcServices.BlockingInterface service = SpliceRSRpcServices.newBlockingStub(channel);
+        SpliceMessage.SpliceActiveSessionsRequest request = SpliceMessage.SpliceActiveSessionsRequest.getDefaultInstance();
+        SpliceMessage.SpliceActiveSessionsResponse response = service.getActiveSessions(null, request);
+        return new HashSet<>(response.getActiveSessionIdsList());
+    }
+}

--- a/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SpliceRSRpcServices.java
+++ b/hbase_storage/src/main/java/com/splicemachine/si/data/hbase/coprocessor/SpliceRSRpcServices.java
@@ -158,4 +158,20 @@ public class SpliceRSRpcServices extends SpliceMessage.SpliceRSRpcServices imple
         writeResponse.setOldestActiveTransaction(oldestActiveTransaction);
         callback.run(writeResponse.build());
     }
+
+    @Override
+    public void getActiveSessions(RpcController controller,
+                                  SpliceMessage.SpliceActiveSessionsRequest request,
+                                  RpcCallback<SpliceMessage.SpliceActiveSessionsResponse> callback) {
+        if (LOG.isDebugEnabled())
+            SpliceLogUtils.debug(LOG, "getActiveSessions");
+        SpliceMessage.SpliceActiveSessionsResponse.Builder writeResponse =
+                SpliceMessage.SpliceActiveSessionsResponse.newBuilder();
+
+        // Client sent SpliceActiveSessionsRequest to all RSs. For this RS, return our
+        // local active sessions. The client aggregates all local active sessions.
+        Set<Long> activeSessionIds = SIDriver.driver().getSessionsWatcher().getLocalActiveSessions();
+        writeResponse.addAllActiveSessionIds(activeSessionIds);
+        callback.run(writeResponse.build());
+    }
 }

--- a/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
+++ b/mem_pipeline/src/main/java/com/splicemachine/pipeline/MPipelineEnv.java
@@ -33,6 +33,7 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.rollforward.RollForward;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -54,7 +55,6 @@ public class MPipelineEnv  implements PipelineEnvironment{
     private SIEnvironment siEnv;
     private BulkWriterFactory writerFactory;
     private ContextFactoryDriver ctxFactoryDriver;
-    private OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
     private final WritePipelineFactory pipelineFactory= new MappedPipelineFactory();
 
     public MPipelineEnv(SIEnvironment siEnv) throws IOException{
@@ -64,12 +64,6 @@ public class MPipelineEnv  implements PipelineEnvironment{
                 new AtomicSpliceWriteControl(Integer.MAX_VALUE,Integer.MAX_VALUE,Integer.MAX_VALUE,Integer.MAX_VALUE),
                 pipelineExceptionFactory(),pipelineMeter());
         this.ctxFactoryDriver = ContextFactoryDriverService.loadDriver();
-        this.oldestActiveTransactionTaskFactory = new OldestActiveTransactionTaskFactory() {
-            @Override
-            public GetOldestActiveTransactionTask get(String hostName, int port, long startupTimestamp) throws IOException {
-                throw new UnsupportedOperationException("Operation not supported in Mem profile");
-            }
-        };
     }
 
     @Override
@@ -89,7 +83,17 @@ public class MPipelineEnv  implements PipelineEnvironment{
 
     @Override
     public OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory(){
-        return oldestActiveTransactionTaskFactory;
+        return siEnv.oldestActiveTransactionTaskFactory();
+    }
+
+    @Override
+    public ActiveSessionsTaskFactory allActiveSessionsTaskFactory(){
+        return siEnv.allActiveSessionsTaskFactory();
+    }
+
+    @Override
+    public SessionsWatcher sessionsWatcher() {
+        return siEnv.sessionsWatcher();
     }
 
     @Override

--- a/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
+++ b/mem_storage/src/main/java/com/splicemachine/si/MemSIEnvironment.java
@@ -30,6 +30,7 @@ import com.splicemachine.si.api.data.TxnOperationFactory;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.rollforward.RollForward;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -56,6 +57,8 @@ public class MemSIEnvironment implements SIEnvironment{
     private final TxnStore txnStore;
     private final PartitionFactory tableFactory;
     private final OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
+    private final ActiveSessionsTaskFactory activeSessionsTaskFactory;
+    private final SessionsWatcher sessionsWatcher = MSessionsWatcherImpl.INSTANCE;
     private final DataFilterFactory filterFactory = MFilterFactory.INSTANCE;
     private final SnowflakeFactory snowflakeFactory = MSnowflakeFactory.INSTANCE;
     private final OperationStatusFactory operationStatusFactory =MOpStatusFactory.INSTANCE;
@@ -80,6 +83,12 @@ public class MemSIEnvironment implements SIEnvironment{
         this.oldestActiveTransactionTaskFactory = new OldestActiveTransactionTaskFactory() {
             @Override
             public GetOldestActiveTransactionTask get(String hostName, int port, long startupTimestamp) throws IOException {
+                throw new UnsupportedOperationException("Operation not supported in Mem profile");
+            }
+        };
+        this.activeSessionsTaskFactory = new ActiveSessionsTaskFactory() {
+            @Override
+            public GetActiveSessionsTask get(String hostName, int port, long startupTimestamp) throws IOException {
                 throw new UnsupportedOperationException("Operation not supported in Mem profile");
             }
         };
@@ -138,6 +147,16 @@ public class MemSIEnvironment implements SIEnvironment{
     @Override
     public OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory(){
         return oldestActiveTransactionTaskFactory;
+    }
+
+    @Override
+    public ActiveSessionsTaskFactory allActiveSessionsTaskFactory(){
+        return activeSessionsTaskFactory;
+    }
+
+    @Override
+    public SessionsWatcher sessionsWatcher() {
+        return sessionsWatcher;
     }
 
     @Override

--- a/mem_storage/src/main/java/com/splicemachine/storage/MSessionsWatcherImpl.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MSessionsWatcherImpl.java
@@ -24,7 +24,7 @@ public class MSessionsWatcherImpl implements SessionsWatcher {
     private static final Logger LOG = Logger.getLogger(MSessionsWatcherImpl.class);
     private final Set<Long> activeSessions = ConcurrentHashMap.newKeySet();
 
-    public static MSessionsWatcherImpl INSTANCE = new MSessionsWatcherImpl();
+    public static final MSessionsWatcherImpl INSTANCE = new MSessionsWatcherImpl();
 
     private MSessionsWatcherImpl(){}
 

--- a/mem_storage/src/main/java/com/splicemachine/storage/MSessionsWatcherImpl.java
+++ b/mem_storage/src/main/java/com/splicemachine/storage/MSessionsWatcherImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.storage;
+
+import com.splicemachine.si.api.session.SessionsWatcher;
+import org.apache.log4j.Logger;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class MSessionsWatcherImpl implements SessionsWatcher {
+    private static final Logger LOG = Logger.getLogger(MSessionsWatcherImpl.class);
+    private final Set<Long> activeSessions = ConcurrentHashMap.newKeySet();
+
+    public static MSessionsWatcherImpl INSTANCE = new MSessionsWatcherImpl();
+
+    private MSessionsWatcherImpl(){}
+
+    @Override
+    public Set<Long> getLocalActiveSessions() {
+        return new HashSet<>(activeSessions);
+    }
+
+    @Override
+    public List<Long> getAllActiveSessions() {
+        List<Long> result = new ArrayList<>(activeSessions);
+        Collections.sort(result);
+        return result;
+    }
+
+    @Override
+    public void registerSession(long sessionId) {
+        activeSessions.add(sessionId);
+    }
+
+    @Override
+    public void unregisterSession(long sessionId) {
+        activeSessions.remove(sessionId);
+    }
+
+}

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/ActiveSessionsTaskFactory.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/ActiveSessionsTaskFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.access.api;
+
+import java.io.IOException;
+
+public interface ActiveSessionsTaskFactory {
+    GetActiveSessionsTask get(String hostName, int port, long startupTimestamp) throws IOException;
+}

--- a/splice_access_api/src/main/java/com/splicemachine/access/api/GetActiveSessionsTask.java
+++ b/splice_access_api/src/main/java/com/splicemachine/access/api/GetActiveSessionsTask.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.access.api;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+public interface GetActiveSessionsTask extends Callable<Set<Long>> {
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/db/SpliceDatabase.java
@@ -181,6 +181,8 @@ public class SpliceDatabase extends BasicDatabase{
                 drdaID, dbname, rdbIntTkn, dspt, sparkExecutionType, skipStats, defaultSelectivityFactor, ipAddress, defaultSchema, sessionProperties);
 
         setupASTVisitors(lctx);
+
+        SIDriver.driver().getSessionsWatcher().registerSession(lctx.getInstanceNumber());
         return lctx;
     }
 
@@ -562,5 +564,10 @@ public class SpliceDatabase extends BasicDatabase{
     protected AuthenticationService bootAuthenticationService(boolean create, Properties props) throws StandardException {
         return (AuthenticationService)
                 Monitor.bootServiceModule(create, this, AuthenticationService.MODULE, props);
+    }
+
+    @Override
+    public void unregisterSession(long sessionId) {
+        SIDriver.driver().getSessionsWatcher().unregisterSession(sessionId);
     }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -324,6 +324,16 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
         procedures.add(getActiveTxn);
 
         /*
+         * Procedure to get all active session id
+         */
+        Procedure getActiveSessions = Procedure.newBuilder().name("SYSCS_GET_ACTIVE_SESSIONS")
+                .numOutputParams(0)
+                .numResultSets(1)
+                .ownerClass(spliceAdminClass)
+                .build();
+        procedures.add(getActiveSessions);
+
+        /*
          * Procedure to list a directory
          */
         Procedure ANALYZE_EXTERNAL_TABLE = Procedure.newBuilder().name("ANALYZE_EXTERNAL_TABLE")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/compile/SpliceLevel2OptimizerImpl.java
@@ -17,6 +17,7 @@ package com.splicemachine.derby.impl.sql.compile;
 import java.util.List;
 
 import com.splicemachine.db.iapi.sql.compile.costing.CostModel;
+import com.splicemachine.si.impl.driver.SIDriver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;

--- a/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
@@ -1709,6 +1709,17 @@ public class SpliceAdmin extends BaseAdminProcedures {
         resultSet[0] = res.getResultSet();
     }
 
+    public static void SYSCS_GET_ACTIVE_SESSIONS(ResultSet[] resultSet) throws SQLException {
+        ResultHelper res = new ResultHelper();
+        ResultHelper.BigintColumn col = res.addBigint("sessionId", 6);
+        List<Long> result = SIDriver.driver().getSessionsWatcher().getAllActiveSessions();
+        for (long sessionId : result) {
+            res.newRow();
+            col.set(sessionId);
+        }
+        resultSet[0] = res.getResultSet();
+    }
+
     public static String getCurrentUserId() throws SQLException {
         EmbedConnection conn = (EmbedConnection)getDefaultConn();
         Activation lastActivation = conn.getLanguageConnection().getLastActivation();

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/ProcedureUnitTest.java
@@ -208,8 +208,8 @@ public class ProcedureUnitTest {
         // note: this value changes if you add new system procedures
         // this is here to help in refactoring methods, move them around
         // and be sure that there's still the same procedures afterwards
-        Assert.assertEquals(161, proc.stream().count());
-        Assert.assertEquals(-462861185, proc.stream().map( procedure -> procedure.getName() ).sorted()
+        Assert.assertEquals(162, proc.stream().count());
+        Assert.assertEquals(-1550098486, proc.stream().map( procedure -> procedure.getName() ).sorted()
                 .map( s -> s.hashCode()).reduce(0, (subtotal, element) -> subtotal + element).longValue() );
     }
 

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_GetActiveSessionsIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceAdmin_GetActiveSessionsIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.utils;
+
+import com.splicemachine.derby.test.framework.SpliceSchemaWatcher;
+import com.splicemachine.derby.test.framework.SpliceUnitTest;
+import com.splicemachine.derby.test.framework.SpliceWatcher;
+import com.splicemachine.derby.test.framework.TestConnection;
+import com.splicemachine.test.SerialTest;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(value = {SerialTest.class})
+public class SpliceAdmin_GetActiveSessionsIT extends SpliceUnitTest {
+    final protected static SpliceWatcher spliceClassWatcher = new SpliceWatcher();
+    public static final String CLASS_NAME = SpliceAdminIT.class.getSimpleName().toUpperCase();
+    final protected static SpliceSchemaWatcher spliceSchemaWatcher = new SpliceSchemaWatcher(CLASS_NAME);
+
+    @ClassRule
+    public static TestRule chain =
+            RuleChain.outerRule(spliceClassWatcher)
+                    .around(spliceSchemaWatcher);
+
+    @Rule
+    public SpliceWatcher methodWatcher = new SpliceWatcher();
+
+    @Ignore("DB-12283")
+    @Test
+    public void testGetActiveSessions() throws Exception {
+        try (TestConnection rs1Conn = methodWatcher.createConnection()) {
+            Set<Integer> rs1Result = new HashSet<>();
+            try (Statement s = rs1Conn.createStatement()) {
+                try (ResultSet rs = s.executeQuery("call syscs_util.syscs_get_active_sessions()")) {
+                    while (rs.next()) {
+                        rs1Result.add(rs.getInt(1));
+                    }
+                }
+            }
+
+            Set<Integer> rs2Result = new HashSet<>();
+            if (isMemPlatform(spliceClassWatcher)) {
+                try (TestConnection secondConn = methodWatcher.createConnection()) {
+                    try (Statement s = secondConn.createStatement()) {
+                        try (ResultSet rs = s.executeQuery("call syscs_util.syscs_get_active_sessions()")) {
+                            while (rs.next()) {
+                                rs2Result.add(rs.getInt(1));
+                            }
+                            Assert.assertEquals(rs1Result.size() + 2, rs2Result.size());
+                            Assert.assertTrue(rs2Result.containsAll(rs1Result));
+                        }
+                    }
+                }
+            } else {
+                try (TestConnection rs2Conn = spliceClassWatcher.connectionBuilder().user("splice").password("admin").port(1528).create(true).build()) {
+                    try (Statement s = rs2Conn.createStatement()) {
+                        try (ResultSet rs = s.executeQuery("call syscs_util.syscs_get_active_sessions()")) {
+                            while (rs.next()) {
+                                rs2Result.add(rs.getInt(1));
+                            }
+                            Assert.assertEquals(rs1Result.size() + 1, rs2Result.size());
+                            Assert.assertTrue(rs2Result.containsAll(rs1Result));
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/splice_protocol/src/main/protobuf/Splice.proto
+++ b/splice_protocol/src/main/protobuf/Splice.proto
@@ -228,6 +228,14 @@ message SpliceOldestActiveTransactionResponse {
     required int64 oldestActiveTransaction = 1;
 }
 
+message SpliceActiveSessionsRequest {
+
+}
+
+message SpliceActiveSessionsResponse {
+    repeated int64 activeSessionIds = 1;
+}
+
 message TestResponse {
     optional uint64 count = 1;
 }
@@ -249,6 +257,9 @@ service SpliceRSRpcServices {
 
     rpc getOldestActiveTransaction(SpliceOldestActiveTransactionRequest)
         returns (SpliceOldestActiveTransactionResponse);
+
+    rpc getActiveSessions(SpliceActiveSessionsRequest)
+        returns (SpliceActiveSessionsResponse);
 
 }
 

--- a/splice_si_api/src/main/java/com/splicemachine/si/api/session/SessionsWatcher.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/api/session/SessionsWatcher.java
@@ -1,0 +1,14 @@
+package com.splicemachine.si.api.session;
+
+import java.util.List;
+import java.util.Set;
+
+public interface SessionsWatcher {
+    Set<Long> getLocalActiveSessions();
+
+    List<Long> getAllActiveSessions();
+
+    void registerSession(long sessionId);
+
+    void unregisterSession(long sessionId);
+}

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIDriver.java
@@ -14,13 +14,9 @@
 
 package com.splicemachine.si.impl.driver;
 
+import com.splicemachine.access.api.*;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import splice.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.splicemachine.access.api.DistributedFileSystem;
-import com.splicemachine.access.api.FilesystemAdmin;
-import com.splicemachine.access.api.PartitionFactory;
-import com.splicemachine.access.api.OldestActiveTransactionTaskFactory;
-import com.splicemachine.access.api.SConfiguration;
-import com.splicemachine.access.api.SnowflakeFactory;
 import com.splicemachine.concurrent.Clock;
 import com.splicemachine.si.api.data.ExceptionFactory;
 import com.splicemachine.si.api.data.OperationFactory;
@@ -87,6 +83,8 @@ public class SIDriver {
     private final PartitionFactory tableFactory;
     private final ExceptionFactory exceptionFactory;
     private final OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory;
+    private final ActiveSessionsTaskFactory activeSessionsTaskFactory;
+    private final SessionsWatcher sessionsWatcher;
     private final SConfiguration config;
     private final TxnStore txnStore;
     private final OperationStatusFactory operationStatusFactory;
@@ -114,6 +112,8 @@ public class SIDriver {
         this.tableFactory = env.tableFactory();
         this.exceptionFactory = env.exceptionFactory();
         this.oldestActiveTransactionTaskFactory = env.oldestActiveTransactionTaskFactory();
+        this.activeSessionsTaskFactory = env.allActiveSessionsTaskFactory();
+        this.sessionsWatcher = env.sessionsWatcher();
         this.config = env.configuration();
         this.txnStore = env.txnStore();
         this.operationStatusFactory = env.statusFactory();
@@ -170,6 +170,14 @@ public class SIDriver {
 
     public OldestActiveTransactionTaskFactory getOldestActiveTransactionTaskFactory() {
         return oldestActiveTransactionTaskFactory;
+    }
+
+    public ActiveSessionsTaskFactory getAllActiveSessionsTaskFactory() {
+        return activeSessionsTaskFactory;
+    }
+
+    public SessionsWatcher getSessionsWatcher() {
+        return sessionsWatcher;
     }
 
     public SnowflakeFactory getSnowflakeFactory() {

--- a/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
+++ b/splice_si_api/src/main/java/com/splicemachine/si/impl/driver/SIEnvironment.java
@@ -20,6 +20,7 @@ import com.splicemachine.si.api.data.*;
 import com.splicemachine.si.api.readresolve.KeyedReadResolver;
 import com.splicemachine.si.api.rollforward.RollForward;
 import com.splicemachine.si.api.server.ClusterHealth;
+import com.splicemachine.si.api.session.SessionsWatcher;
 import com.splicemachine.si.api.txn.KeepAliveScheduler;
 import com.splicemachine.si.api.txn.TxnStore;
 import com.splicemachine.si.api.txn.TxnSupplier;
@@ -88,4 +89,8 @@ public interface SIEnvironment{
     FilesystemAdmin filesystemAdmin();
 
     OldestActiveTransactionTaskFactory oldestActiveTransactionTaskFactory();
+
+    ActiveSessionsTaskFactory allActiveSessionsTaskFactory();
+
+    SessionsWatcher sessionsWatcher();
 }


### PR DESCRIPTION
## Short Description
This PR implements a new admin system procedure `syscs_util.syscs_get_active_sessions()`, which lists all active sessions on all region servers.

## Long Description
This is the first step of cleaning up obsolete local temporary tables.

Each region server has a singleton instance of `SessionsWatcherImpl`. Internally, it maintains a concurrent hash set recording active sessions on this region server. Each session registers itself in setting up the connection and unregisters itself when disconnected from the region server.

When calling `syscs_util.syscs_get_active_sessions()` on a region server, `SessionWatcherImpl.getAllActiveSessions()` sends a request via protobuf to all region servers and merge returned active sessions from all region servers into a single list.

On mem platform, there is no region server communication and session IDs are tracked using a single instance of `MSessionsWatcherImpl`.

The IT is currently marked as ignored because currently, we do not have a dedicate session ID field in a connection. At the moment we always use `lcc.getInstanceNumber()`, which is unique only to a region server. For this reason, multiple connections on different region servers could have the same session ID, making the test sporadic. This issue is tracked in DB-12283.

## How to test
Run `syscs_util.syscs_get_active_sessions()` from a connection with admin privileges returns a list of all active session IDs. This list should contain all connections on all region servers, despite of from which session on which region server this statement is executed.
