### PR TITLE
DB-10594 Add a system procedure to clean up obsolete temp tables

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/conn/GenericLanguageConnectionContext.java
@@ -1185,7 +1185,7 @@ public class GenericLanguageConnectionContext extends ContextImpl implements Lan
      * Note: I'm assuming, because this class extends BaseActivation, it will properly serialize and
      * work across region servers.
      */
-    private static class DropTableActivation extends BaseActivation {
+    public static class DropTableActivation extends BaseActivation {
 
         public DropTableActivation(LanguageConnectionContext lcc, TableDescriptor td) throws StandardException {
             // Just pass the only pertinent info to BaseActivation

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceSystemProcedures.java
@@ -334,6 +334,17 @@ public class SpliceSystemProcedures extends DefaultSystemProcedureGenerator {
         procedures.add(getActiveSessions);
 
         /*
+         * Procedure to drop obsolete local temporary tables
+         */
+        Procedure dropObsoleteTempTables = Procedure.newBuilder().name("SYSCS_DROP_OBSOLETE_TEMPORARY_TABLES")
+                .numOutputParams(0)
+                .varchar("schema", 32672)
+                .numResultSets(1)
+                .ownerClass(spliceAdminClass)
+                .build();
+        procedures.add(dropObsoleteTempTables);
+
+        /*
          * Procedure to list a directory
          */
         Procedure ANALYZE_EXTERNAL_TABLE = Procedure.newBuilder().name("ANALYZE_EXTERNAL_TABLE")

--- a/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
@@ -31,12 +31,14 @@ import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.property.PropertyUtil;
 import com.splicemachine.db.iapi.sql.Activation;
 import com.splicemachine.db.iapi.sql.ResultColumnDescriptor;
+import com.splicemachine.db.iapi.sql.StatementType;
 import com.splicemachine.db.iapi.sql.conn.Authorizer;
 import com.splicemachine.db.iapi.sql.conn.ConnectionUtil;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.*;
+import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.sql.execute.ExecPreparedStatement;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.store.access.TransactionController;
@@ -49,6 +51,9 @@ import com.splicemachine.db.impl.sql.GenericActivationHolder;
 import com.splicemachine.db.impl.sql.GenericColumnDescriptor;
 import com.splicemachine.db.impl.sql.GenericPreparedStatement;
 import com.splicemachine.db.impl.sql.catalog.*;
+import com.splicemachine.db.impl.sql.conn.GenericLanguageConnectionContext;
+import com.splicemachine.db.impl.sql.execute.GenericConstantActionFactory;
+import com.splicemachine.db.impl.sql.execute.GenericExecutionFactory;
 import com.splicemachine.db.impl.sql.execute.IteratorNoPutResultSet;
 import com.splicemachine.db.impl.sql.execute.ValueRow;
 import com.splicemachine.ddl.DDLMessage;
@@ -98,6 +103,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.splicemachine.db.shared.common.reference.SQLState.*;
+import static com.splicemachine.derby.utils.EngineUtils.getSchemaDescriptor;
 
 /**
  * @author Jeff Cunningham
@@ -1707,7 +1713,7 @@ public class SpliceAdmin extends BaseAdminProcedures {
         resultSet[0] = res.getResultSet();
     }
 
-    public static void SYSCS_GET_ACTIVE_SESSIONS(ResultSet[] resultSet) throws SQLException {
+    public static void SYSCS_GET_ACTIVE_SESSIONS(final ResultSet[] resultSet) throws SQLException {
         ResultHelper res = new ResultHelper();
         ResultHelper.VarcharColumn col = res.addVarchar("sessionId", 48);
         List<String> result = SIDriver.driver().getSessionsWatcher().getAllActiveSessions();
@@ -1716,6 +1722,72 @@ public class SpliceAdmin extends BaseAdminProcedures {
             col.set(sessionId);
         }
         resultSet[0] = res.getResultSet();
+    }
+
+    public static void SYSCS_DROP_OBSOLETE_TEMPORARY_TABLES(String schemaName, final ResultSet[] resultSet) throws SQLException {
+        ResultHelper res = new ResultHelper();
+        ResultHelper.VarcharColumn tblNameCol = res.addVarchar("tableName", 128);
+        try (EmbedConnection conn = (EmbedConnection) getDefaultConn()) {
+            try {
+                if (schemaName == null) {
+                    throw StandardException.newException(LANG_INVALID_FUNCTION_ARGUMENT, "null", "SYSCS_DROP_OBSOLETE_TEMPORARY_TABLES");
+                }
+
+                schemaName = EngineUtils.validateSchema(schemaName);
+
+                LanguageConnectionContext lcc = conn.getLanguageConnection();
+                DataDictionary dd = lcc.getDataDictionary();
+                dd.startWriting(lcc);
+
+                // Get table descriptor list first, never change order!
+                SchemaDescriptor sd = getSchemaDescriptor(schemaName, lcc, dd);
+                List<TableDescriptor> tds = StatisticsProcedures.getAllTableDescriptors(sd, conn);
+                if (tds.isEmpty()) {
+                    return;
+                }
+
+                // Then get active session list.
+                List<String> activeSessionIDs = SIDriver.driver().getSessionsWatcher().getAllActiveSessions();
+                Set<UUID> sessionIDSet = activeSessionIDs.stream().map(UUID::fromString).collect(Collectors.toSet());
+
+                for (TableDescriptor td : tds) {
+                    if (td.getTableType() == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE) {
+                        String tableName = td.getName();
+                        try {
+                            java.util.UUID creatingSessionID = lcc.getLocalTempTableSessionID(td);
+                            if (!sessionIDSet.contains(creatingSessionID)) {
+                                dropTempTable(lcc, td);
+                                res.newRow();
+                                tblNameCol.set(tableName);
+                            }
+                        } catch (StandardException se) {
+                            if (se.getSQLState().equals(SQLState.LANG_INVALID_INTERNAL_TEMP_TABLE_NAME)) {
+                                // for temporary tables created using instance numbers
+                                dropTempTable(lcc, td);
+                                res.newRow();
+                                tblNameCol.set(tableName);
+                            }
+                        }
+                    }
+                }
+                resultSet[0] = res.getResultSet();
+            } catch (StandardException se) {
+                throw PublicAPI.wrapStandardException(se);
+            }
+        }
+    }
+
+    private static void dropTempTable(LanguageConnectionContext lcc, TableDescriptor td) throws StandardException {
+        // Drop the temp table via normal drop table action
+        GenericExecutionFactory execFactory = (GenericExecutionFactory) lcc.getLanguageConnectionFactory().getExecutionFactory();
+        GenericConstantActionFactory constantActionFactory = execFactory.getConstantActionFactory();
+        ConstantAction action = constantActionFactory.getDropTableConstantAction(td.getQualifiedName(),
+                                                                                 td.getName(),
+                                                                                 td.getSchemaDescriptor(),
+                                                                                 td.getHeapConglomerateId(),
+                                                                                 td.getUUID(), StatementType.DROP_CASCADE);
+
+        action.executeConstantAction(new GenericLanguageConnectionContext.DropTableActivation(lcc, td));
     }
 
     public static String getCurrentUserId() throws SQLException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/procedures/SpliceAdmin.java
@@ -1748,13 +1748,13 @@ public class SpliceAdmin extends BaseAdminProcedures {
 
                 // Then get active session list.
                 List<String> activeSessionIDs = SIDriver.driver().getSessionsWatcher().getAllActiveSessions();
-                Set<UUID> sessionIDSet = activeSessionIDs.stream().map(UUID::fromString).collect(Collectors.toSet());
+                Set<String> sessionIDSet = new HashSet<>(activeSessionIDs);
 
                 for (TableDescriptor td : tds) {
                     if (td.getTableType() == TableDescriptor.LOCAL_TEMPORARY_TABLE_TYPE) {
                         String tableName = td.getName();
                         try {
-                            java.util.UUID creatingSessionID = lcc.getLocalTempTableSessionID(td);
+                            String creatingSessionID = lcc.getLocalTempTableSessionID(td);
                             if (!sessionIDSet.contains(creatingSessionID)) {
                                 dropTempTable(lcc, td);
                                 res.newRow();


### PR DESCRIPTION
## Short Description
This change adds a new administrative system procedure which cleans up obsolete temporary tables.

## Long Description
Currently, local temporary tables are not dropped properly when region servers crash because the happy path in disconnecting a session is not executed.

Once the cluster is up again, there is no way to remove the obsolete local temporary tables because they were created by previous sessions, thus not visible to new sessions. Over time, there could be more and more obsolete temporary tables in system, wasting space and causing troubles in fixing inconsistency issues when they occur.

The new system procedure `SYSCS_DROP_OBSOLETE_TEMPORARY_TABLES(schemaName)` cleans up all obsolete temporary tables in schema `schemaName`. It works in the following steps:
1. get a copy of table descriptors in the give schema
2. get a list of active session IDs
3. for each local temporary table that is not created by any of the active sessions, drop it cascade

The workflow above handles all of the following cases:
a. A new session appears after step 1 and create a local temporary table. This is fine because the new temp table is not in the list of step 1. thus not processed.
b. A new session appears after step 2 and create a local temporary table. This is also fine because it's completely unknown to the procedure, thus not processed.
c. An existing session is closed after step 1 and its local temporary tables are dropped. This is fine because dropping a non-existing table is a no-op.
d. An existing session is closed after step 2 and its local temporary tables are dropped. This is fine because the table is already dropped. It's OK that we skip it.

However, if we reverse step 1 and 2, case a) would be wrong.

## How to test
This is currently a question. Since making an obsolete local temporary table requires killing the cluster, an automated test is not possible in current platform it.

Manual testing:
- create a local temporary table `T`
- create an index `T_IDX` on `T`
- verify that the index exists by looking up `sys.sysconglomerates`
- kill the cluster
- restart without build, i.e., `-b`
- verify that the index still exists
- call the new system procedure
- the index `T_IDX` should be gone because `T` is dropped cascade
