### PR TITLE
DB-12291: close consumer when reading from Kafka fails(3.1)

### DIFF
--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/KafkaReadFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/spark/KafkaReadFunction.java
@@ -127,6 +127,7 @@ public class KafkaReadFunction extends SpliceFlatMapFunction<ExportKafkaOperatio
                     if( !prevMessage.last() ) {
                         String msg = "KRF.call Didn't get full batch after " + retries + " retries, got " + totalCount + " records";
                         LOG.error(id+" "+msg);
+                        consumer.close();
                         throw new RuntimeException(msg+" from topic-partition "+topicName+"-"+partition);
                     }
                     return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
(e.g. short description of the PR)

## Long Description
(e.g. why in detail, how, potential further work)

## How to test
(e.g. if bugfix: how to reproduce bug / impact)
(if feature: a easy example of how to check the feature)
(if feature is a configuration: an example to see different behavior with different configuration)
