### PR TITLE
DB-12305 Fix DB-9898 regression after using storage cols in ColRefs 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromList.java
@@ -1227,7 +1227,7 @@ public class FromList extends QueryTreeNodeVector<QueryTreeNode> implements Opti
                 continue;
             }
 
-            int numColumns=fbt.getTableDescriptor().getNumberOfColumns();
+            int numColumns=fbt.getTableDescriptor().getNumberOfStorageColumns();
             boolean[] eqOuterCols=new boolean[numColumns+1];
             int tableNumber=fbt.getTableNumber();
             boolean resultColTable=false;


### PR DESCRIPTION
## Short description

Fix regression introduced by DB-9898 after switching `ColumnReference.columnNumber` from logical column number to storage number.

## Long description

DB-9898 started using storage columns in `ColumnReference`.
`FromList.returnsAtMostSingleRow` creates a column map to be passed to `recordColumnReferences`. This column map should be initialized with the `getNumberOfStorageColumns` (i.e. the max id of a storage column) instead of `getNumberOfColumns`

## How to test

```
drop table ADVANCED_TEST001_S.employees;
CREATE TABLE ADVANCED_TEST001_S.employees (emplid INTEGER NOT NULL, firstname VARCHAR(25) NOT NULL, reportsto INTEGER);

insert into ADVANCED_TEST001_S.employees values (7725070,'Kottapalli',8852090);

insert into ADVANCED_TEST001_S.employees values (6825081,'Anderson',8852090);

insert into ADVANCED_TEST001_S.employees values (8852090,'Messavussu',18520);

insert into ADVANCED_TEST001_S.employees values (18520,'Medina',10520);

alter table ADVANCED_TEST001_S.employees drop column firstname;



select reportsto,count(emplid) total_employees from ADVANCED_TEST001_S.employees a where emplid in (select emplid from ADVANCED_TEST001_S.employees b where a.emplid = b.emplid and a.reportsto = b.reportsto) group by a.reportsto order by a.reportsto;
``` 
Should return

```
REPORTSTO  |TOTAL_EMPLOYEES
--------------------------------
10520      |1
18520      |1
8852090    |2
```
instead of throwing an `ArrayIndexOutOfBoundException`

## All DB-12305 PRs

[spliceengine master](https://github.com/splicemachine/spliceengine/pull/5648)
[spliceengine branch-3.1](https://github.com/splicemachine/spliceengine/pull/5649)
