### PR TITLE
DB-12324 NSDS v2 Changes for Streaming Resampling (3.1)

### DIFF
--- a/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/nsds/kafka/KafkaTopics.scala
@@ -21,7 +21,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 
 @SerialVersionUID(20200518241L)
 @SuppressFBWarnings(value = Array("NP_ALWAYS_NULL"), justification = "Field 'unused' initialization is not null")
-class KafkaTopics(kafkaServers: String, defaultNumPartitions: Int = 1, defaultRepFactor: Short = 1) extends Serializable {
+class KafkaTopics(
+    kafkaServers: String, 
+    defaultNumPartitions: Int = 1, 
+    defaultRepFactor: Short = 1,
+    continuousCleanup: Boolean = false
+  ) extends Serializable
+{
   val admin = new KafkaAdmin(kafkaServers)
   val unneeded = collection.mutable.HashSet[String]()
 

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -590,13 +590,13 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
       val sqlText = insertSql(topicInfo)
       debug(s"SMC.inss sql $sqlText")
       
-      trace( s"SMC.inss topicCount preex ${KafkaUtils.messageCount(kafkaServers, topicName)}")
+      //trace( s"SMC.inss topicCount preex ${KafkaUtils.messageCount(kafkaServers, topicName)}")
 
       debug("SMC.inss executeUpdate")
       executeUpdate(sqlText)
       debug("SMC.inss done")
 
-      debug( s"SMC.inss topicCount postex ${KafkaUtils.messageCount(kafkaServers, topicName)}")
+      //debug( s"SMC.inss topicCount postex ${KafkaUtils.messageCount(kafkaServers, topicName)}")
     } catch {
       case e: java.sql.SQLNonTransientConnectionException => 
         if( retries < 2 ) {
@@ -668,10 +668,11 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
     rdd.rdd.mapPartitionsWithIndex(
       (partition, itrRow) => {
         val id = topicName.substring(0,5)+":"+partition.toString
-        trace(s"$id SMC.sendData p== $partition ${itrRow.nonEmpty}")
+        val nonEmpty = itrRow.nonEmpty
+        trace(s"$id SMC.sendData p== $partition ${nonEmpty}")
 
         var msgCount = 0
-        if( itrRow.nonEmpty ) {
+        if( nonEmpty ) {
           val taskContext = TaskContext.get
           val itr = if (taskContext != null && taskContext.attemptNumber > 0) {
             // Recover from previous task failure
@@ -759,7 +760,7 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
 
           insAccum.add(msgCount)
 
-          debug(s"$id SMC.sendData t $topicName p $partition records $msgCount")
+          info(s"$id SMC.sendData t $topicName p $partition records $msgCount")
 
           producer.flush
           producer.close

--- a/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
+++ b/splice_spark2/src/main/scala/com/splicemachine/spark2/splicemachine/SplicemachineContext.scala
@@ -568,11 +568,12 @@ class SplicemachineContext(options: Map[String, String]) extends Serializable {
   var insertSql: String => String = _
   
   /* Sets up insertSql to be used by insert_streaming */
-  def setTable(schemaTableName: String, schema: StructType): Unit = {
+  def setTable(schemaTableName: String, schema: StructType, upsert: Boolean = false): Unit = {
     val colList = columnList(schema) + fmColList
     val schStr = schemaStringWithoutNullable(schema, url)
+    val upsertProp = if(upsert) { "--splice-properties insertMode=UPSERT" } else { "" }
     // Line break at the end of the first line and before select is required, other line breaks aren't required
-    insertSql = (topicName: String) => s"""insert into $schemaTableName ($colList)
+    insertSql = (topicName: String) => s"""insert into $schemaTableName ($colList) $upsertProp
                                        select $colList from 
       new com.splicemachine.derby.vti.KafkaVTI('$topicName') 
       as SpliceDatasetVTI ($schStr$fmSchemaStr)"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Some changes made during work on streaming resampling.

## Long Description
1. Continuous topic cleanup default value set to false to reduce traffic on Kafka.
2. Support for upsert added in the setTable method so that streaming code can do upsert.
3. Some logging updates.

## How to test
1. Run eNSDS and note that topics are not automatically cleaned up in Kafka when transactions are completed.
2. Run streaming in upsert mode and note upsert behavior with the incoming records.
3. Note sendData log as an info instead of debug.  Note insert topicCount logs are gone.