### PR TITLE
DB-12158 Automatic view refreshing for alter table add/drop column

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/compile/CompilerContext.java
@@ -202,6 +202,7 @@ public interface CompilerContext extends Context
     boolean DEFAULT_DISABLE_SUBQUERY_FLATTENING = false;
     boolean DEFAULT_DISABLE_UNIONED_INDEX_SCANS = false;
     boolean DEFAULT_FAVOR_UNIONED_INDEX_SCANS = false;
+    boolean DEFAULT_SPLICE_ALTER_TABLE_AUTO_VIEW_REFRESHING = false;
     boolean DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE = false;
 
     boolean DEFAULT_PRESERVE_LINE_ENDINGS = false;
@@ -802,6 +803,10 @@ public interface CompilerContext extends Context
     void setFavorUnionedIndexScans(boolean newValue);
 
     boolean getFavorUnionedIndexScans();
+
+    void setAlterTableAutoViewRefreshing(boolean newValue);
+
+    boolean getAlterTableAutoViewRefreshing();
 
     void setVarcharDB2CompatibilityMode(boolean newValue);
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/DependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/depend/DependencyManager.java
@@ -41,6 +41,7 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
     Dependency Manager Interface
@@ -558,4 +559,14 @@ public interface DependencyManager {
             TransactionController tc)
             throws StandardException;
 
+    /**
+     * Returns an enumeration of all dependencies that this
+     * provider is supporting for any dependent at all (even
+     * invalid ones). Includes all dependency types.
+     *
+     * @param p the provider
+     * @return A list of dependents (possibly empty).
+     * @throws StandardException if something goes wrong
+     */
+    List<Dependency> getDependents (Provider p) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ViewDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/ViewDescriptor.java
@@ -454,7 +454,7 @@ public final class ViewDescriptor extends TupleDescriptor
      * @param action action
      * @throws StandardException standard error policy
      */
-    private void drop(
+    public void drop(
             LanguageConnectionContext lcc,
             SchemaDescriptor sd,
             TableDescriptor td,

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/GenericStatement.java
@@ -499,6 +499,7 @@ public class GenericStatement implements Statement{
         }
 
         setSSQFlatteningForUpdateDisabled(lcc, cc);
+        setAlterTableAutoViewRefreshing(lcc, cc);
         setVarcharDB2CompatibilityMode(lcc, cc);
         return cc;
     }
@@ -525,6 +526,15 @@ public class GenericStatement implements Statement{
             // just use the default setting.
         }
         cc.setVarcharDB2CompatibilityMode(varcharDB2CompatibilityMode);
+    }
+
+    private void setAlterTableAutoViewRefreshing(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {
+        String valueStr = PropertyUtil.getCached(lcc, GlobalDBProperties.SPLICE_ALTER_TABLE_AUTO_VIEW_REFRESHING);
+        boolean value = CompilerContext.DEFAULT_SPLICE_ALTER_TABLE_AUTO_VIEW_REFRESHING;
+        if (valueStr != null) {
+            value = Boolean.parseBoolean(valueStr);
+        }
+        cc.setAlterTableAutoViewRefreshing(value);
     }
 
     private void setSSQFlatteningForUpdateDisabled(LanguageConnectionContext lcc, CompilerContext cc) throws StandardException {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CompilerContextImpl.java
@@ -335,6 +335,14 @@ public class CompilerContextImpl extends ContextImpl
 
     public boolean getFavorUnionedIndexScans() { return favorUnionedIndexScans; }
 
+    public void setAlterTableAutoViewRefreshing(boolean newValue) {
+        alterTableAutoViewRefreshing = newValue;
+    }
+
+    public boolean getAlterTableAutoViewRefreshing() {
+        return alterTableAutoViewRefreshing;
+    }
+
     public void setVarcharDB2CompatibilityMode(boolean newValue) {
         varcharDB2CompatibilityMode = newValue;
     }
@@ -1293,6 +1301,7 @@ public class CompilerContextImpl extends ContextImpl
     private       boolean                             disableSubqueryFlattening                    = DEFAULT_DISABLE_SUBQUERY_FLATTENING;
     private       boolean                             disableUnionedIndexScans                     = DEFAULT_DISABLE_UNIONED_INDEX_SCANS;
     private       boolean                             favorUnionedIndexScans                       = DEFAULT_FAVOR_UNIONED_INDEX_SCANS;
+    private       boolean                             alterTableAutoViewRefreshing                 = DEFAULT_SPLICE_ALTER_TABLE_AUTO_VIEW_REFRESHING;
     private       boolean                             varcharDB2CompatibilityMode                  = DEFAULT_SPLICE_DB2_VARCHAR_COMPATIBLE;
     /**
      * Saved execution time default schema, if we need to change it

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/CreateViewNode.java
@@ -547,7 +547,7 @@ public class CreateViewNode extends DDLStatementNode
       *
       *    @return    the parsed query expression.
       */
-    ResultSetNode    getParsedQueryExpression() { return queryExpression; }
+    public ResultSetNode getParsedQueryExpression() { return queryExpression; }
 
 
     /*

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -33,6 +33,7 @@ package com.splicemachine.db.impl.sql.compile;
 
 
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.reference.SQLState;
 import com.splicemachine.db.iapi.services.context.ContextManager;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
@@ -44,6 +45,7 @@ import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.ast.ColumnCollectingVisitor;
+import com.splicemachine.db.impl.sql.misc.SQLCommentStripper;
 import splice.com.google.common.base.Predicates;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -310,14 +312,26 @@ public class FromSubquery extends FromTable
          * the table since the view was created.
          */
         subqueryRCL = subquery.getResultColumns();
-        if (resultColumns != null && resultColumns.getCountMismatchAllowed() &&
-            resultColumns.size() < subqueryRCL.size())
-        {
-            for (int index = subqueryRCL.size() - 1;
-                 index >= resultColumns.size();
-                 index--)
-            {
-                subqueryRCL.removeElementAt(index);
+        if (resultColumns != null && resultColumns.getCountMismatchAllowed()) {
+            if (resultColumns.size() < subqueryRCL.size()) {
+                // columns added to underlying table
+                for (int index = subqueryRCL.size() - 1;
+                     index >= resultColumns.size();
+                     index--) {
+                    subqueryRCL.removeElementAt(index);
+                }
+            } else if (resultColumns.size() > subqueryRCL.size()) {
+                // columns dropped from underlying table
+                throw StandardException.newException(SQLState.LANG_DERIVED_COLUMN_LIST_MISMATCH, correlationName);
+            } else {
+                // number of columns is OK, check column names
+                for (int i = 0; i < resultColumns.size(); ++i) {
+                    ResultColumn thisRC = resultColumns.elementAt(i);
+                    ResultColumn subqRC = subqueryRCL.elementAt(i);
+                    if (thisRC.getName() != null && !thisRC.getName().equals(subqRC.getName())) {
+                        throw StandardException.newException(SQLState.LANG_DERIVED_COLUMN_NAME_USE, thisRC.getName());
+                    }
+                }
             }
         }
 

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -1034,15 +1034,9 @@ public class BasicDependencyManager implements DependencyManager {
     }
 
     /**
-     * Returns an enumeration of all dependencies that this
-     * provider is supporting for any dependent at all (even
-     * invalid ones). Includes all dependency types.
-     *
-     * @param p the provider
-     * @return A list of dependents (possibly empty).
-     * @throws StandardException if something goes wrong
+     * @see DependencyManager#getDependents
      */
-    private List<Dependency> getDependents (Provider p) throws StandardException {
+    public List<Dependency> getDependents (Provider p) throws StandardException {
         List<Dependency> deps = new ArrayList<>();
         synchronized (this) {
             List<Dependency> memDeps = providers.get(p.getObjectID());

--- a/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
+++ b/db-shared/src/main/java/com/splicemachine/db/iapi/reference/GlobalDBProperties.java
@@ -119,6 +119,11 @@ public class GlobalDBProperties {
                     "if true, ignore trailing spaces in varchar comparisons",
                     Validator::parseBoolean);
 
+    public static PropertyType SPLICE_ALTER_TABLE_AUTO_VIEW_REFRESHING =
+            new PropertyType("splice.execution.alterTable.autoViewRefreshing",
+                             "if true, automatically refresh dependent views after adding or dropping a column",
+                             Validator::parseBoolean);
+
     /**
      * If enabled, disable calculation of join costs as cost per parallel task
      * and revert to using the old units: cost per partition (cost per region).

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -47,7 +47,6 @@ import com.splicemachine.db.impl.sql.execute.ColumnInfo;
 import com.splicemachine.pipeline.ErrorState;
 import org.apache.log4j.Logger;
 
-import javax.swing.text.View;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -28,7 +28,9 @@ import com.splicemachine.db.iapi.sql.compile.CompilerContext;
 import com.splicemachine.db.iapi.sql.compile.Parser;
 import com.splicemachine.db.iapi.sql.compile.Visitable;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.depend.Dependency;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
+import com.splicemachine.db.iapi.sql.depend.Dependent;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ConstantAction;
 import com.splicemachine.db.iapi.store.access.RowUtil;
@@ -38,12 +40,14 @@ import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 import com.splicemachine.db.iapi.util.IdUtil;
 import com.splicemachine.db.iapi.util.StringUtil;
-import com.splicemachine.db.impl.sql.compile.ColumnDefinitionNode;
-import com.splicemachine.db.impl.sql.compile.StatementNode;
+import com.splicemachine.db.impl.sql.GenericStatement;
+import com.splicemachine.db.impl.sql.GenericStorablePreparedStatement;
+import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.ColumnInfo;
 import com.splicemachine.pipeline.ErrorState;
 import org.apache.log4j.Logger;
 
+import javax.swing.text.View;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -279,6 +283,13 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
         // granted on that new column.
         //
         dd.updateSYSCOLPERMSforAddColumnToUserTable(tableDescriptor.getUUID(), tc);
+
+        CompilerContext cc = lcc.pushCompilerContext();
+        boolean refreshViews = cc.getAlterTableAutoViewRefreshing();
+        lcc.popCompilerContext(cc);
+        if (refreshViews) {
+            refreshDependentViews(activation, tableDescriptor);
+        }
 
         // refresh the activation's TableDescriptor now that we've modified it
         activation.setDDLTableDescriptor(tableDescriptor);
@@ -901,6 +912,13 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                 }
             }
         }
+
+        CompilerContext cc = lcc.pushCompilerContext();
+        boolean refreshViews = cc.getAlterTableAutoViewRefreshing();
+        lcc.popCompilerContext(cc);
+        if (refreshViews) {
+            refreshDependentViews(activation, tableDescriptor);
+        }
     }
 
     private void checkColumnUsage(String columnName, TableDescriptor td) throws StandardException{
@@ -1423,6 +1441,62 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                         ixCongNums[j] = newCongNum;
                 }
             }
+        }
+    }
+
+    private void refreshDependentViews(Activation activation, TableDescriptor tableDescriptor) throws StandardException {
+        LanguageConnectionContext lcc = activation.getLanguageConnectionContext();
+        DataDictionary dd = lcc.getDataDictionary();
+        DependencyManager dm = dd.getDependencyManager();
+
+        List<Dependency> deps = dm.getDependents(tableDescriptor);
+        List<ViewDescriptor> views = new ArrayList<>(deps.size());
+        for (Dependency dep : deps) {
+            Dependent d = dep.getDependent();
+            if (d instanceof ViewDescriptor) {
+                views.add((ViewDescriptor) d);
+            }
+        }
+
+        for (ViewDescriptor vd : views) {
+            TableDescriptor viewTd = dd.getTableDescriptor(vd.getUUID());
+
+            if (viewTd == null) {
+                // already dropped via another dependency
+                continue;
+            }
+
+            String viewDef = vd.getViewText();
+            CreateViewNode cvn;
+            CompilerContext newCC = lcc.pushCompilerContext();
+            try {
+                Parser p = newCC.getParser();
+                cvn = (CreateViewNode) p.parseStatement(viewDef);
+                if (cvn == null) {
+                    continue;
+                }
+                // Only refresh views defined with top-level "select *". View definitions could be
+                // arbitrarily complex, having "select *" in a subquery. However, as long as the
+                // top-level select items are explicitly fixed (i.e., "select a, b, ..."), newly
+                // added column will not be selected even if we refresh the view. If one of the
+                // explicitly selected column is dropped, the view definition becomes invalid even
+                // if we refresh the view. As a result, in both cases, there is no need to refresh
+                // the view if its top-level select columns are explicit.
+                ResultSetNode rsn = cvn.getParsedQueryExpression();
+                if (!rsn.getResultColumns().containsAllResultColumn()) {
+                    continue;
+                }
+
+                GenericStatement gs = new GenericStatement(viewTd.getSchemaDescriptor(), viewDef, false, lcc);
+                GenericStorablePreparedStatement gsps = new GenericStorablePreparedStatement(gs);
+                newCC.setCurrentDependent(gsps);
+                cvn.bindStatement();
+            } finally {
+                lcc.popCompilerContext(newCC);
+            }
+
+            vd.drop(lcc, viewTd.getSchemaDescriptor(), viewTd, DependencyManager.ALTER_TABLE);
+            cvn.makeConstantAction().executeConstantAction(activation);
         }
     }
 


### PR DESCRIPTION
## Short Description
This change introduces a new automatic view refreshing mode for alter table add/drop column.

3.1 PR: https://github.com/splicemachine/spliceengine/pull/5660.
3.0 PR: https://github.com/splicemachine/spliceengine/pull/5662.

## Long Description

This change introduces a new automatic view refreshing mode for alter table add/drop column.

When this mode is turned on, an `ALTER TABLE T ADD/DROP COLUMN ...` statement automatically refreshes all views defined both directly and indirectly on `T` whose top-level select list is a `SELECT *`. Other views are not refreshed.

This mode is off by default. To turn it on, run the following:
```
call syscs_util.syscs_set_global_database_property('splice.execution.alterTable.autoViewRefreshing', true)
```

To turn it off, run the following:
```
call syscs_util.syscs_set_global_database_property('splice.execution.alterTable.autoViewRefreshing', null)
```

### Detailed behavior description

- A view `V` defined using a top-level explicit select column list, i.e., `select a, b, ...` on top of `T`
	- this kind of views are not refreshed no matter view refreshing mode is on or off, even if it has subqueries that has `select *` (see explanation 1)
	- add column: the new column is not shown in `select * from v`
	- drop a column that is added after the `V` is defined: no effect
	- drop a column that exists when `V` is defined: throw (previous behavior: assertion failure if column number mismatch or wrong column names if column numbers match but it's a different set of columns)
- A view `V` defined using a top-level `select *` on top of `T`
	- when view refreshing mode is off, it has the same behavior as the explicit select column case
	- when view refreshing mode is on
		- add column: new column is shown in `select * from v`
		- drop column: dropped column is removed from `select * from v`
- A view `VV` defined using a top-level `select *` on another view `V` on top of `T`
	- when auto view refreshing mode is on, `VV` gets refreshed when a column is added to or dropped from `T`
	- if `V` is not a `select *` view, refreshing `VV` has no effect

### Explanation 1

We only need to refresh views defined with top-level "select *". View definitions could be arbitrarily complex, having "select *" in a subquery. However, as long as the top-level select items are explicitly fixed (i.e., "select a, b, ..."), newly added column will not be selected even if we refresh the view. Also, if one of the explicitly selected column is dropped, the view definition becomes invalid even if we refresh the view. As a result, in both cases, there is no need to refresh the view if its top-level select columns are explicit.

## How to test
It would be too long to copy all test cases here. For references, please check the following ITs in `DropAddColumnIT`:
- testAutomaticViewRefreshingOn_SelectStarView
- testAutomaticViewRefreshingOn_SecondLevelSelectStarView
- testAutomaticViewRefreshingOn_SelectExplicitColumnsView
- testAutomaticViewRefreshingOff
