### PR TITLE
DB-12323 Fix upgrade regression introduced by DB-9898 

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
@@ -72,6 +72,12 @@ public interface IndexDescriptor
     int[] baseColumnPositions();
 
     int[] baseColumnStoragePositions();
+
+    /**
+     * @return true if this index descriptor is invalid as a result of an upgrade from a pre 2023 version
+     */
+    boolean isInvalidIndexDescriptor();
+
     /**
      * Returns the postion of a column.
      * <p>
@@ -131,8 +137,15 @@ public interface IndexDescriptor
      * set the baseColumnPositions field of the index descriptor.  This
      * is for updating the field in operations such as "alter table drop
      * column" where baseColumnPositions is changed.
+     * @param baseColumnStoragePositions
      */
-    void     setBaseColumnPositions(int[] baseColumnPositions);
+    void setBaseColumnStoragePositions(int[] baseColumnStoragePositions);
+
+    void setBaseColumnPositions(int[] baseColumnsPositions);
+
+    int[] getBaseColumnStoragePositions();
+
+    int[] getBaseColumnPositions();
 
     /**
      * set the isAscending field of the index descriptor.  This

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/IndexDescriptor.java
@@ -74,9 +74,10 @@ public interface IndexDescriptor
     int[] baseColumnStoragePositions();
 
     /**
-     * @return true if this index descriptor is invalid as a result of an upgrade from a pre 2023 version
+     * Returns true if this index descriptor is invalid as a result of an upgrade from a pre 2023 version
+     * See DB-12323 for more information
      */
-    boolean isInvalidIndexDescriptor();
+    boolean isInvalidIndexDescriptorAfter2022Upgrade();
 
     /**
      * Returns the postion of a column.
@@ -137,7 +138,6 @@ public interface IndexDescriptor
      * set the baseColumnPositions field of the index descriptor.  This
      * is for updating the field in operations such as "alter table drop
      * column" where baseColumnPositions is changed.
-     * @param baseColumnStoragePositions
      */
     void setBaseColumnStoragePositions(int[] baseColumnStoragePositions);
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -274,13 +274,11 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
     /** @see IndexDescriptor#baseColumnPositions */
     public int[] baseColumnPositions()
     {
-        if (isInvalidIndexDescriptor()) {
-            throw new UnsupportedOperationException();
-        }
+        assert !isInvalidIndexDescriptorAfter2022Upgrade();
         return baseColumnPositions;
     }
 
-    public boolean isInvalidIndexDescriptor() {
+    public boolean isInvalidIndexDescriptorAfter2022Upgrade() {
         return baseColumnPositions.length != baseColumnStoragePositions.length;
     }
 

--- a/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/catalog/types/IndexDescriptorImpl.java
@@ -42,16 +42,13 @@ import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
 import com.splicemachine.db.iapi.types.ProtobufUtils;
 import com.splicemachine.db.iapi.util.ByteArray;
-import com.splicemachine.db.impl.ast.CollectingVisitor;
 import com.splicemachine.db.impl.sql.CatalogMessage;
 import com.splicemachine.db.impl.sql.compile.*;
 import com.splicemachine.db.impl.sql.execute.BaseExecutableIndexExpression;
-import splice.com.google.common.base.Predicates;
 
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -218,6 +215,7 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
         for (int i = 0; i < baseColumnStoragePositions.length; ++i) {
             baseColumnStoragePositions[i] = indexDescriptorImpl.getBaseColumnPositions(i);
         }
+        count = indexDescriptorImpl.getBaseColumnLogicalPositionsCount();
         baseColumnPositions = new int[count];
         for (int i = 0; i < baseColumnPositions.length; ++i) {
             baseColumnPositions[i] = indexDescriptorImpl.getBaseColumnLogicalPositions(i);
@@ -276,7 +274,14 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
     /** @see IndexDescriptor#baseColumnPositions */
     public int[] baseColumnPositions()
     {
+        if (isInvalidIndexDescriptor()) {
+            throw new UnsupportedOperationException();
+        }
         return baseColumnPositions;
+    }
+
+    public boolean isInvalidIndexDescriptor() {
+        return baseColumnPositions.length != baseColumnStoragePositions.length;
     }
 
     /**
@@ -346,10 +351,28 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
         return isAscending;
     }
 
-    /** @see IndexDescriptor#setBaseColumnPositions */
-    public void        setBaseColumnPositions(int[] baseColumnPositions)
+    /** @see IndexDescriptor#setBaseColumnStoragePositions
+     * @param baseColumnStoragePositions */
+    @Override
+    public void setBaseColumnStoragePositions(int[] baseColumnStoragePositions)
     {
-        this.baseColumnStoragePositions = baseColumnPositions;
+        this.baseColumnStoragePositions = baseColumnStoragePositions;
+    }
+
+    @Override
+    public void setBaseColumnPositions(int[] baseColumnPositions)
+    {
+        this.baseColumnPositions = baseColumnPositions;
+    }
+
+    @Override
+    public int[] getBaseColumnStoragePositions() {
+        return baseColumnStoragePositions;
+    }
+
+    @Override
+    public int[] getBaseColumnPositions() {
+        return baseColumnPositions;
     }
 
     /** @see IndexDescriptor#setIsAscending */
@@ -516,12 +539,16 @@ public class IndexDescriptorImpl implements IndexDescriptor, Formatable {
             builder.addIsAscending(asc);
         }
 
-        for (int pos : baseColumnStoragePositions) {
-            builder.addBaseColumnPositions(pos);
+        if (baseColumnStoragePositions != null) {
+            for (int pos : baseColumnStoragePositions) {
+                builder.addBaseColumnPositions(pos);
+            }
         }
 
-        for (int pos : baseColumnPositions) {
-            builder.addBaseColumnLogicalPositions(pos);
+        if (baseColumnPositions != null) {
+            for (int pos : baseColumnPositions) {
+                builder.addBaseColumnLogicalPositions(pos);
+            }
         }
 
         assert generatedClassNames.length == exprBytecode.length;

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -438,8 +438,8 @@ public class IndexRowGenerator implements IndexDescriptor, Formatable
     }
 
     @Override
-    public boolean isInvalidIndexDescriptor() {
-        return id.isInvalidIndexDescriptor();
+    public boolean isInvalidIndexDescriptorAfter2022Upgrade() {
+        return id.isInvalidIndexDescriptorAfter2022Upgrade();
     }
 
     /** @see IndexDescriptor#getKeyColumnPosition */

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/IndexRowGenerator.java
@@ -64,602 +64,624 @@ import java.io.ObjectOutput;
  */
 public class IndexRowGenerator implements IndexDescriptor, Formatable
 {
-	private IndexDescriptor  id;
-	private ExecutionFactory ef;
-
-	/**
-	 * Constructor for an IndexRowGeneratorImpl
-	 *
-	 * @param indexType		The type of index
-	 * @param isUnique		True means the index is unique
-	 * @param isUniqueWithDuplicateNulls means the index is almost unique
-	 *                              i.e. unique only for non null keys
-	 * @param baseColumnPositions	An array of column positions in the base
-	 * 								table.  Each index column corresponds to a
-	 * 								column position in the base table.
-	 * @param isAscending	An array of booleans telling asc/desc on each
-	 * 						column.
-	 * @param numberOfOrderedColumns	In the future, it will be possible
-	 * 									to store non-ordered columns in an
-	 * 									index.  These will be useful for
-	 * 									covered queries.
-	 */
-	public IndexRowGenerator(String indexType,
-							 boolean isUnique,
-							 boolean isUniqueWithDuplicateNulls,
-							 int[] baseColumnStoragePositions,
-							 int[] baseColumnPositions,
-							 boolean[] isAscending,
-							 int numberOfOrderedColumns,
-							 boolean excludeNulls,
-							 boolean excludeDefaults)
-	{
-		id = new IndexDescriptorImpl(indexType,
-				isUnique,
-				isUniqueWithDuplicateNulls,
-				baseColumnStoragePositions,
-				baseColumnPositions,
-				isAscending,
-				numberOfOrderedColumns,
-				excludeNulls,
-				excludeDefaults);
-
-		if (SanityManager.DEBUG)
-		{
-			SanityManager.ASSERT(baseColumnPositions != null,
-					"baseColumnPositions are null");
-		}
-	}
-
-	public IndexRowGenerator(String indexType,
-							 boolean isUnique,
-							 boolean isUniqueWithDuplicateNulls,
-							 int[] baseColumnPositions,
-							 int[] baseColumnLogicalPositions,
-							 DataTypeDescriptor[] indexColumnTypes,
-							 boolean[] isAscending,
-							 int numberOfOrderedColumns,
-							 boolean excludeNulls,
-							 boolean excludeDefaults,
-							 String[] exprTexts,
-							 ByteArray[] exprBytecode,
-							 String[] generatedClassNames)
-	{
-		id = new IndexDescriptorImpl(indexType,
-				isUnique,
-				isUniqueWithDuplicateNulls,
-				baseColumnPositions,
-				baseColumnLogicalPositions,
-				indexColumnTypes,
-				isAscending,
-				numberOfOrderedColumns,
-				excludeNulls,
-				excludeDefaults,
-				exprTexts,
-				exprBytecode,
-				generatedClassNames);
-
-		if (SanityManager.DEBUG)
-		{
-			SanityManager.ASSERT(baseColumnPositions != null,
-					"baseColumnPositions are null");
-		}
-	}
-
-	/**
-	 * Constructor for an IndexRowGeneratorImpl
-	 *
-	 * @param indexDescriptor		An IndexDescriptor to delegate calls to
-	 */
-	public IndexRowGenerator(IndexDescriptor indexDescriptor)
-	{
-		id = indexDescriptor;
-	}
-
-	public IndexRowGenerator(CatalogMessage.IndexRowGenerator indexRowGenerator) throws IOException {
-		init(indexRowGenerator);
-	}
-
-	private void init(CatalogMessage.IndexRowGenerator indexRowGenerator) throws IOException{
-		id = ProtobufUtils.fromProtobuf(indexRowGenerator.getId());
-	}
-	/**
-	 * Get a template for the index row, to be used with getIndexRow.
-	 *
-	 * @return  A row template for the index row.
-	 */
-	public ExecIndexRow getIndexRowTemplate()
-	{
-		return getExecutionFactory().getIndexableRow(
-				id.isAscending().length + 1);
-	}
-
-	/**
-	 * Get a template for the index row key, to be used with getIndexRowKey.
-	 *
-	 * @return  A row template for the index row.
-	 */
-	public ExecIndexRow getIndexRowKeyTemplate(boolean alwaysIncludeLocation)
-	{
-		if (!alwaysIncludeLocation && id.isUnique()) {
-			return getExecutionFactory().getIndexableRow(id.isAscending().length);
-		} else {
-			return getIndexRowTemplate();
-		}
-	}
-
-	/**
-	 * Get a NULL Index Row for this index. This is useful to create objects
-	 * that need to be passed to ScanController.
-	 *
-	 * @param columnList ColumnDescriptors describing the base table.
-	 * @param rowLocation   empty row location.
-	 *
-	 * @exception StandardException thrown on error.
-	 */
-	public ExecIndexRow getNullIndexRow(ColumnDescriptorList columnList,
-										RowLocation rowLocation)
-			throws StandardException
-	{
-		ExecIndexRow indexRow = getIndexRowTemplate();
-		DataTypeDescriptor[] columnTypes = getIndexColumnTypes();
-
-		if (columnTypes.length == 0) {
-			// Index is not built on expressions, use base column types.
-			int[] baseColumnPositions = id.baseColumnPositions();
-			for (int i = 0; i < baseColumnPositions.length; i++) {
-				DataTypeDescriptor dtd =
-						columnList.elementAt(baseColumnPositions[i] - 1).getType();
-				indexRow.setColumn(i + 1, dtd.getNull());
-			}
-			indexRow.setColumn(baseColumnPositions.length + 1, rowLocation);
-		} else {
-			// Index is built on expressions, use their result types.
-			for (int i = 0; i < columnTypes.length; i++) {
-				indexRow.setColumn(i + 1, columnTypes[i].getNull());
-			}
-			indexRow.setColumn(columnTypes.length + 1, rowLocation);
-		}
-		return indexRow;
-	}
-
-	/**
-	 * Get an index row for this index given a row from the base table
-	 * and the RowLocation of the base row.  This method can be used
-	 * to get the new index row for inserts, and the old and new index
-	 * rows for deletes and updates.  For updates, the result row has
-	 * all the old column values followed by all of the new column values,
-	 * so you must form a row using the new column values to pass to
-	 * this method to get the new index row.
-	 *
-	 * @param baseRow   A row in the base table
-	 * @param rowLocation   The RowLocation of the row in the base table
-	 * @param indexRow  A template for the index row.  It must have the
-	 *                  correct number of columns.
-	 * @param bitSet    If non-null, then baseRow is a partial row and the
-	 *                  set bits in bitSet represents the column mapping for
-	 *                  the partial row to the complete base row. <B> WARNING:
-	 *                  </B> ONE based!!!
-	 *
-	 * @exception StandardException     Thrown on error
-	 */
-	public void getIndexRow(ExecRow baseRow,
-							RowLocation rowLocation,
-							ExecIndexRow indexRow,
-							FormatableBitSet bitSet)
-			throws StandardException
-	{
-		getIndexRowHelper(baseRow, rowLocation, indexRow, bitSet, true);
-	}
-
-	/**
-	 * Get an index row key for this index given a row from the base table
-	 * and the RowLocation of the base row.  This method can be used
-	 * to get the new index row for inserts, and the old and new index
-	 * rows for deletes and updates.  For updates, the result row has
-	 * all the old column values followed by all of the new column values,
-	 * so you must form a row using the new column values to pass to
-	 * this method to get the new index row. For unique indices the row
-	 * location is not included in the row key.
-	 *
-	 * @param baseRow       A row in the base table
-	 * @param rowLocation   The RowLocation of the row in the base table
-	 * @param indexRow      A template for the index row.  It must have the
-	 *                      correct number of columns.
-	 * @param bitSet        If non-null, then baseRow is a partial row and the
-	 *                       set bits in bitSet represents the column mapping for
-	 *                       the partial row to the complete base row. <B> WARNING:
-	 *                       </B> ONE based!!!
-	 *
-	 * @exception StandardException        Thrown on error
-	 */
-	public void getIndexRowKey(ExecRow baseRow,
-							   RowLocation rowLocation,
-							   ExecIndexRow indexRow,
-							   FormatableBitSet bitSet)
-			throws StandardException
-	{
-		getIndexRowHelper(baseRow, rowLocation, indexRow, bitSet, false);
-	}
-
-	private void getIndexRowHelper(ExecRow baseRow,
-								   RowLocation rowLocation,
-								   ExecIndexRow indexRow,
-								   FormatableBitSet bitSet,
-								   boolean alwaysIncludeLocation)
-			throws StandardException
-	{
-		int colCount;
-		if (isOnExpression()) {
-			colCount = isAscending().length;
-			ExecRow expandedRow;
-
-			if (bitSet == null) {
-				expandedRow = baseRow;
-			} else {
-				// expand partial row
-				int maxNumCols = getMaxBaseColumnPosition();
-				expandedRow = new ValueRow(maxNumCols);
-				for (int expandedRowIndex = 1, baseRowIndex = 1; expandedRowIndex <= maxNumCols; expandedRowIndex++) {
-					if (bitSet.get(expandedRowIndex)) {
-						expandedRow.setColumn(expandedRowIndex, baseRow.getColumn(baseRowIndex));
-						baseRowIndex++;
-					}
-				}
-			}
-			for (int i = 0; i < colCount; i++) {
-				BaseExecutableIndexExpression execExpr = getExecutableIndexExpression(i);
-				if (execExpr == null) {
-					throw StandardException.newException(SQLState.LANG_UNABLE_TO_LOAD_GENERATE_CODE, getExprTexts()[i]);
-				}
-				execExpr.runExpression(expandedRow, indexRow);
-			}
-		} else {
-			/*
-			 ** Set the columns in the index row that are based on columns in
-			 ** the base row.
-			 */
-			int[] baseColumnPositions = id.baseColumnStoragePositions();
-			colCount = baseColumnPositions.length;
-
-			if (bitSet == null) {
-				/*
-				 ** Set the columns in the index row that are based on columns in
-				 ** the base row.
-				 */
-				for (int i = 0; i < colCount; i++) {
-					indexRow.setColumn(i + 1,
-							baseRow.getColumn(baseColumnPositions[i]));
-				}
-			} else {
-				if (SanityManager.DEBUG) {
-					SanityManager.ASSERT(!bitSet.get(0), "element zero of the bitSet passed into getIndexRow() is not false, bitSet should be 1 based");
-				}
-
-				/*
-				 ** Set the columns in the index row that are based on columns in
-				 ** the base row.
-				 */
-				for (int i = 0; i < colCount; i++) {
-					int fullColumnNumber = baseColumnPositions[i];
-					int partialColumnNumber = 0;
-					for (int index = 1; index <= fullColumnNumber; index++) {
-						if (bitSet.get(index)) {
-							partialColumnNumber++;
-						}
-					}
-					indexRow.setColumn(i + 1,
-							baseRow.getColumn(partialColumnNumber));
-				}
-			}
-		}
-
-		if (alwaysIncludeLocation || !id.isUnique()) {
-			/* Set the row location in the last column of the index row */
-			indexRow.setColumn(colCount + 1, rowLocation);
-		}
-	}
-
-	/**
-	 * Return an array of collation ids for this table.
-	 * <p>
-	 * Return an array of collation ids, one for each column in the
-	 * columnDescriptorList.  This is useful for passing collation id info
-	 * down to store, for instance in createConglomerate() to create
-	 * the index.
-	 *
-	 * This is only expected to get called during ddl, so object allocation
-	 * is ok.
-	 *
-	 * @param columnList ColumnDescriptors describing the base table.
-	 *
-	 * @exception  StandardException  Standard exception policy.
-	 **/
-	public int[] getColumnCollationIds(ColumnDescriptorList columnList)
-			throws StandardException
-	{
-		int[] collation_ids = new int[isAscending().length + 1];
-		DataTypeDescriptor[] indexColumnTypes = getIndexColumnTypes();
-
-		if (indexColumnTypes.length <= 0) {
-			int[] base_cols = id.baseColumnStoragePositions();
-			for (int i = 0; i < base_cols.length; i++) {
-				collation_ids[i] =
-						columnList.getColumnDescriptorByStoragePosition(base_cols[i]).getType().getCollationType();
-			}
-		} else {
-			for (int i = 0; i < indexColumnTypes.length; i++) {
-				collation_ids[i] = indexColumnTypes[i].getCollationType();
-			}
-		}
-
-		// row location column at end is always basic collation type.
-		collation_ids[collation_ids.length - 1] =
-				StringDataValue.COLLATION_TYPE_UCS_BASIC;
-
-		return(collation_ids);
-	}
-
-
-	/**
-	 * Get the IndexDescriptor that this IndexRowGenerator is based on.
-	 */
-	public IndexDescriptor getIndexDescriptor()
-	{
-		return id;
-	}
-
-	/** Zero-argument constructor for Formatable interface */
-	public IndexRowGenerator()
-	{
-	}
-
-	/**
-	 * @see IndexDescriptor#isUniqueWithDuplicateNulls
-	 */
-	public boolean isUniqueWithDuplicateNulls()
-	{
-		return id.isUniqueWithDuplicateNulls();
-	}
-	/** @see IndexDescriptor#isUnique */
-	public boolean isUnique()
-	{
-		return id.isUnique();
-	}
-
-	/** @see IndexDescriptor#baseColumnPositions */
-	public int[] baseColumnPositions() {
-		return id.baseColumnPositions();
-	}
-
-	@Override
-	public int[] baseColumnStoragePositions() {
-		return id.baseColumnStoragePositions();
-	}
-
-	/** @see IndexDescriptor#getKeyColumnPosition */
-	public int getKeyColumnPosition(int columnStoragePosition) throws StandardException
-	{
-		return id.getKeyColumnPosition(columnStoragePosition);
-	}
-
-	/** @see IndexDescriptor#numberOfOrderedColumns */
-	public int numberOfOrderedColumns()
-	{
-		return id.numberOfOrderedColumns();
-	}
-
-	/** @see IndexDescriptor#indexType */
-	public String indexType()
-	{
-		return id==null?null:id.indexType();
-	}
-
-	public String toString()
-	{
-		return id.toString();
-	}
-
-	/** @see IndexDescriptor#getIndexColumnTypes */
-	public DataTypeDescriptor[] getIndexColumnTypes() { return id.getIndexColumnTypes(); }
-
-	/** @see IndexDescriptor#isAscending */
-	public boolean			isAscending(Integer keyColumnPosition)
-	{
-		return id.isAscending(keyColumnPosition);
-	}
-
-	/** @see IndexDescriptor#isDescending */
-	public boolean			isDescending(Integer keyColumnPosition)
-	{
-		return id.isDescending(keyColumnPosition);
-	}
-
-	@Override public boolean excludeNulls() {return id.excludeNulls();}
-
-	@Override public boolean excludeDefaults() {return id.excludeDefaults();}
-
-	/** @see IndexDescriptor#isAscending */
-	public boolean[]		isAscending()
-	{
-		return id.isAscending();
-	}
-
-	/** @see IndexDescriptor#setBaseColumnPositions */
-	public void		setBaseColumnPositions(int[] baseColumnPositions)
-	{
-		id.setBaseColumnPositions(baseColumnPositions);
-	}
-
-	/** @see IndexDescriptor#setIsAscending */
-	public void		setIsAscending(boolean[] isAscending)
-	{
-		id.setIsAscending(isAscending);
-	}
-
-	/** @see IndexDescriptor#setNumberOfOrderedColumns */
-	public void		setNumberOfOrderedColumns(int numberOfOrderedColumns)
-	{
-		id.setNumberOfOrderedColumns(numberOfOrderedColumns);
-	}
-
-	/**
-	 * Test for value equality
-	 *
-	 * @param other		The other indexrowgenerator to compare this one with
-	 *
-	 * @return	true if this indexrowgenerator has the same value as other
-	 */
-	@Override
-	public boolean equals(Object other) {
-		if (this == other) return true;
-		if (other == null || getClass() != other.getClass()) return false;
-
-		IndexRowGenerator that = (IndexRowGenerator) other;
-
-		return id != null ? id.equals(that.id) : that.id == null;
-
-	}
-
-	@Override
-	public int hashCode() {
-		return id != null ? id.hashCode() : 0;
-	}
-
-	private ExecutionFactory getExecutionFactory()
-	{
-		if (ef == null)
-		{
-			ExecutionContext	ec;
-
-			ec = (ExecutionContext)
-					ContextService.getContext(ExecutionContext.CONTEXT_ID);
-			ef = ec.getExecutionFactory();
-		}
-		return ef;
-	}
-
-	////////////////////////////////////////////////////////////////////////////
-	//
-	// EXTERNALIZABLE
-	//
-	////////////////////////////////////////////////////////////////////////////
-
-	/**
-	 * @see java.io.Externalizable#readExternal
-	 *
-	 * @exception IOException	Thrown on read error
-	 * @exception ClassNotFoundException	Thrown on read error
-	 */
-	@Override
-	public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-		if (DataInputUtil.shouldReadOldFormat()) {
-			readExternalOld(in);
-		}
-		else {
-			readExternalNew(in);
-		}
-	}
-
-	protected void readExternalNew(ObjectInput in) throws IOException {
-		byte[] bs = ArrayUtil.readByteArray(in);
-		CatalogMessage.IndexRowGenerator irg = CatalogMessage.IndexRowGenerator.parseFrom(bs);
-		init(irg);
-	}
-
-	protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
-		id = (IndexDescriptor)in.readObject();
-	}
-
-	/**
-	 *
-	 * @exception IOException	Thrown on write error
-	 */
-	@Override
-	public void writeExternal( ObjectOutput out ) throws IOException {
-		if (DataInputUtil.shouldWriteOldFormat()) {
-			writeExternalOld(out);
-		}
-		else {
-			writeExternalNew(out);
-		}
-	}
-
-	protected void writeExternalOld(ObjectOutput out) throws IOException {
-		out.writeObject(id);
-	}
-
-	protected void writeExternalNew(ObjectOutput out) throws IOException {
-		CatalogMessage.IndexRowGenerator indexRowGenerator = toProtobuf();
-		ArrayUtil.writeByteArray(out, indexRowGenerator.toByteArray());
-	}
-
-	public CatalogMessage.IndexRowGenerator toProtobuf() {
-		CatalogMessage.IndexDescriptorImpl indexDescriptor = ((IndexDescriptorImpl)id).toProtobuf();
-		CatalogMessage.IndexRowGenerator indexRowGenerator = CatalogMessage.IndexRowGenerator.newBuilder()
-				.setId(indexDescriptor)
-				.build();
-		return indexRowGenerator;
-	}
-
-	/* TypedFormat interface */
-	public int getTypeFormatId()
-	{
-		return StoredFormatIds.INDEX_ROW_GENERATOR_V01_ID;
-	}
-
-	/**
-	 * Is the IndexRowGenerator a Primary Key?
-	 *
-	 * @return
-	 */
-	@Override
-	public boolean isPrimaryKey() {
-		return indexType() != null && indexType().contains("PRIMARY");
-	}
-
-	/** @see IndexDescriptor#getExprTexts */
-	@Override
-	public String[] getExprTexts() { return id.getExprTexts(); }
-
-	/** @see IndexDescriptor#getExprTexts */
-	@Override
-	public String getExprText(Integer keyColumnPosition) { return id.getExprText(keyColumnPosition); }
-
-	/** @see IndexDescriptor#getExprBytecode */
-	@Override
-	public ByteArray[] getExprBytecode() { return id.getExprBytecode(); }
-
-	/** @see IndexDescriptor#getGeneratedClassNames */
-	@Override
-	public String[] getGeneratedClassNames() { return id.getGeneratedClassNames(); }
-
-	/** @see IndexDescriptor#isOnExpression */
-	@Override
-	public boolean isOnExpression() { return id != null && id.isOnExpression(); }
-
-	/** @see IndexDescriptor#getExecutableIndexExpression */
-	@Override
-	public BaseExecutableIndexExpression getExecutableIndexExpression(int indexColumnPosition)
-			throws StandardException
-	{
-		return id.getExecutableIndexExpression(indexColumnPosition);
-	}
-
-	/** @see IndexDescriptor#getParsedIndexExpressions */
-	@Override
-	public ValueNode[] getParsedIndexExpressions(LanguageConnectionContext context, Optimizable optTable)
-			throws StandardException
-	{
-		return id.getParsedIndexExpressions(context, optTable);
-	}
-
-	private int getMaxBaseColumnPosition() {
-		int maxPosition = 1;  // base column positions are 1-based
-		for (int bcp : id.baseColumnStoragePositions()) {
-			if (bcp > maxPosition)
-				maxPosition = bcp;
-		}
-		return maxPosition;
-	}
+    private IndexDescriptor  id;
+    private ExecutionFactory ef;
+
+    /**
+     * Constructor for an IndexRowGeneratorImpl
+     *
+     * @param indexType        The type of index
+     * @param isUnique        True means the index is unique
+     * @param isUniqueWithDuplicateNulls means the index is almost unique
+     *                              i.e. unique only for non null keys
+     * @param baseColumnPositions    An array of column positions in the base
+     *                                 table.  Each index column corresponds to a
+     *                                 column position in the base table.
+     * @param isAscending    An array of booleans telling asc/desc on each
+     *                         column.
+     * @param numberOfOrderedColumns    In the future, it will be possible
+     *                                     to store non-ordered columns in an
+     *                                     index.  These will be useful for
+     *                                     covered queries.
+     */
+    public IndexRowGenerator(String indexType,
+                             boolean isUnique,
+                             boolean isUniqueWithDuplicateNulls,
+                             int[] baseColumnStoragePositions,
+                             int[] baseColumnPositions,
+                             boolean[] isAscending,
+                             int numberOfOrderedColumns,
+                             boolean excludeNulls,
+                             boolean excludeDefaults)
+    {
+        id = new IndexDescriptorImpl(indexType,
+                isUnique,
+                isUniqueWithDuplicateNulls,
+                baseColumnStoragePositions,
+                baseColumnPositions,
+                isAscending,
+                numberOfOrderedColumns,
+                excludeNulls,
+                excludeDefaults);
+
+        if (SanityManager.DEBUG)
+        {
+            SanityManager.ASSERT(baseColumnPositions != null,
+                    "baseColumnPositions are null");
+        }
+    }
+
+    public IndexRowGenerator(String indexType,
+                             boolean isUnique,
+                             boolean isUniqueWithDuplicateNulls,
+                             int[] baseColumnPositions,
+                             int[] baseColumnLogicalPositions,
+                             DataTypeDescriptor[] indexColumnTypes,
+                             boolean[] isAscending,
+                             int numberOfOrderedColumns,
+                             boolean excludeNulls,
+                             boolean excludeDefaults,
+                             String[] exprTexts,
+                             ByteArray[] exprBytecode,
+                             String[] generatedClassNames)
+    {
+        id = new IndexDescriptorImpl(indexType,
+                isUnique,
+                isUniqueWithDuplicateNulls,
+                baseColumnPositions,
+                baseColumnLogicalPositions,
+                indexColumnTypes,
+                isAscending,
+                numberOfOrderedColumns,
+                excludeNulls,
+                excludeDefaults,
+                exprTexts,
+                exprBytecode,
+                generatedClassNames);
+
+        if (SanityManager.DEBUG)
+        {
+            SanityManager.ASSERT(baseColumnPositions != null,
+                    "baseColumnPositions are null");
+        }
+    }
+
+    /**
+     * Constructor for an IndexRowGeneratorImpl
+     *
+     * @param indexDescriptor        An IndexDescriptor to delegate calls to
+     */
+    public IndexRowGenerator(IndexDescriptor indexDescriptor)
+    {
+        id = indexDescriptor;
+    }
+
+    public IndexRowGenerator(CatalogMessage.IndexRowGenerator indexRowGenerator) throws IOException {
+        init(indexRowGenerator);
+    }
+
+    private void init(CatalogMessage.IndexRowGenerator indexRowGenerator) throws IOException{
+        id = ProtobufUtils.fromProtobuf(indexRowGenerator.getId());
+    }
+    /**
+     * Get a template for the index row, to be used with getIndexRow.
+     *
+     * @return  A row template for the index row.
+     */
+    public ExecIndexRow getIndexRowTemplate()
+    {
+        return getExecutionFactory().getIndexableRow(
+                id.isAscending().length + 1);
+    }
+
+    /**
+     * Get a template for the index row key, to be used with getIndexRowKey.
+     *
+     * @return  A row template for the index row.
+     */
+    public ExecIndexRow getIndexRowKeyTemplate(boolean alwaysIncludeLocation)
+    {
+        if (!alwaysIncludeLocation && id.isUnique()) {
+            return getExecutionFactory().getIndexableRow(id.isAscending().length);
+        } else {
+            return getIndexRowTemplate();
+        }
+    }
+
+    /**
+     * Get a NULL Index Row for this index. This is useful to create objects
+     * that need to be passed to ScanController.
+     *
+     * @param columnList ColumnDescriptors describing the base table.
+     * @param rowLocation   empty row location.
+     *
+     * @exception StandardException thrown on error.
+     */
+    public ExecIndexRow getNullIndexRow(ColumnDescriptorList columnList,
+                                        RowLocation rowLocation)
+            throws StandardException
+    {
+        ExecIndexRow indexRow = getIndexRowTemplate();
+        DataTypeDescriptor[] columnTypes = getIndexColumnTypes();
+
+        if (columnTypes.length == 0) {
+            // Index is not built on expressions, use base column types.
+            int[] baseColumnPositions = id.baseColumnPositions();
+            for (int i = 0; i < baseColumnPositions.length; i++) {
+                DataTypeDescriptor dtd =
+                        columnList.elementAt(baseColumnPositions[i] - 1).getType();
+                indexRow.setColumn(i + 1, dtd.getNull());
+            }
+            indexRow.setColumn(baseColumnPositions.length + 1, rowLocation);
+        } else {
+            // Index is built on expressions, use their result types.
+            for (int i = 0; i < columnTypes.length; i++) {
+                indexRow.setColumn(i + 1, columnTypes[i].getNull());
+            }
+            indexRow.setColumn(columnTypes.length + 1, rowLocation);
+        }
+        return indexRow;
+    }
+
+    /**
+     * Get an index row for this index given a row from the base table
+     * and the RowLocation of the base row.  This method can be used
+     * to get the new index row for inserts, and the old and new index
+     * rows for deletes and updates.  For updates, the result row has
+     * all the old column values followed by all of the new column values,
+     * so you must form a row using the new column values to pass to
+     * this method to get the new index row.
+     *
+     * @param baseRow   A row in the base table
+     * @param rowLocation   The RowLocation of the row in the base table
+     * @param indexRow  A template for the index row.  It must have the
+     *                  correct number of columns.
+     * @param bitSet    If non-null, then baseRow is a partial row and the
+     *                  set bits in bitSet represents the column mapping for
+     *                  the partial row to the complete base row. <B> WARNING:
+     *                  </B> ONE based!!!
+     *
+     * @exception StandardException     Thrown on error
+     */
+    public void getIndexRow(ExecRow baseRow,
+                            RowLocation rowLocation,
+                            ExecIndexRow indexRow,
+                            FormatableBitSet bitSet)
+            throws StandardException
+    {
+        getIndexRowHelper(baseRow, rowLocation, indexRow, bitSet, true);
+    }
+
+    /**
+     * Get an index row key for this index given a row from the base table
+     * and the RowLocation of the base row.  This method can be used
+     * to get the new index row for inserts, and the old and new index
+     * rows for deletes and updates.  For updates, the result row has
+     * all the old column values followed by all of the new column values,
+     * so you must form a row using the new column values to pass to
+     * this method to get the new index row. For unique indices the row
+     * location is not included in the row key.
+     *
+     * @param baseRow       A row in the base table
+     * @param rowLocation   The RowLocation of the row in the base table
+     * @param indexRow      A template for the index row.  It must have the
+     *                      correct number of columns.
+     * @param bitSet        If non-null, then baseRow is a partial row and the
+     *                       set bits in bitSet represents the column mapping for
+     *                       the partial row to the complete base row. <B> WARNING:
+     *                       </B> ONE based!!!
+     *
+     * @exception StandardException        Thrown on error
+     */
+    public void getIndexRowKey(ExecRow baseRow,
+                               RowLocation rowLocation,
+                               ExecIndexRow indexRow,
+                               FormatableBitSet bitSet)
+            throws StandardException
+    {
+        getIndexRowHelper(baseRow, rowLocation, indexRow, bitSet, false);
+    }
+
+    private void getIndexRowHelper(ExecRow baseRow,
+                                   RowLocation rowLocation,
+                                   ExecIndexRow indexRow,
+                                   FormatableBitSet bitSet,
+                                   boolean alwaysIncludeLocation)
+            throws StandardException
+    {
+        int colCount;
+        if (isOnExpression()) {
+            colCount = isAscending().length;
+            ExecRow expandedRow;
+
+            if (bitSet == null) {
+                expandedRow = baseRow;
+            } else {
+                // expand partial row
+                int maxNumCols = getMaxBaseColumnPosition();
+                expandedRow = new ValueRow(maxNumCols);
+                for (int expandedRowIndex = 1, baseRowIndex = 1; expandedRowIndex <= maxNumCols; expandedRowIndex++) {
+                    if (bitSet.get(expandedRowIndex)) {
+                        expandedRow.setColumn(expandedRowIndex, baseRow.getColumn(baseRowIndex));
+                        baseRowIndex++;
+                    }
+                }
+            }
+            for (int i = 0; i < colCount; i++) {
+                BaseExecutableIndexExpression execExpr = getExecutableIndexExpression(i);
+                if (execExpr == null) {
+                    throw StandardException.newException(SQLState.LANG_UNABLE_TO_LOAD_GENERATE_CODE, getExprTexts()[i]);
+                }
+                execExpr.runExpression(expandedRow, indexRow);
+            }
+        } else {
+            /*
+             ** Set the columns in the index row that are based on columns in
+             ** the base row.
+             */
+            int[] baseColumnPositions = id.baseColumnStoragePositions();
+            colCount = baseColumnPositions.length;
+
+            if (bitSet == null) {
+                /*
+                 ** Set the columns in the index row that are based on columns in
+                 ** the base row.
+                 */
+                for (int i = 0; i < colCount; i++) {
+                    indexRow.setColumn(i + 1,
+                            baseRow.getColumn(baseColumnPositions[i]));
+                }
+            } else {
+                if (SanityManager.DEBUG) {
+                    SanityManager.ASSERT(!bitSet.get(0), "element zero of the bitSet passed into getIndexRow() is not false, bitSet should be 1 based");
+                }
+
+                /*
+                 ** Set the columns in the index row that are based on columns in
+                 ** the base row.
+                 */
+                for (int i = 0; i < colCount; i++) {
+                    int fullColumnNumber = baseColumnPositions[i];
+                    int partialColumnNumber = 0;
+                    for (int index = 1; index <= fullColumnNumber; index++) {
+                        if (bitSet.get(index)) {
+                            partialColumnNumber++;
+                        }
+                    }
+                    indexRow.setColumn(i + 1,
+                            baseRow.getColumn(partialColumnNumber));
+                }
+            }
+        }
+
+        if (alwaysIncludeLocation || !id.isUnique()) {
+            /* Set the row location in the last column of the index row */
+            indexRow.setColumn(colCount + 1, rowLocation);
+        }
+    }
+
+    /**
+     * Return an array of collation ids for this table.
+     * <p>
+     * Return an array of collation ids, one for each column in the
+     * columnDescriptorList.  This is useful for passing collation id info
+     * down to store, for instance in createConglomerate() to create
+     * the index.
+     *
+     * This is only expected to get called during ddl, so object allocation
+     * is ok.
+     *
+     * @param columnList ColumnDescriptors describing the base table.
+     *
+     * @exception  StandardException  Standard exception policy.
+     **/
+    public int[] getColumnCollationIds(ColumnDescriptorList columnList)
+            throws StandardException
+    {
+        int[] collation_ids = new int[isAscending().length + 1];
+        DataTypeDescriptor[] indexColumnTypes = getIndexColumnTypes();
+
+        if (indexColumnTypes.length <= 0) {
+            int[] base_cols = id.baseColumnStoragePositions();
+            for (int i = 0; i < base_cols.length; i++) {
+                collation_ids[i] =
+                        columnList.getColumnDescriptorByStoragePosition(base_cols[i]).getType().getCollationType();
+            }
+        } else {
+            for (int i = 0; i < indexColumnTypes.length; i++) {
+                collation_ids[i] = indexColumnTypes[i].getCollationType();
+            }
+        }
+
+        // row location column at end is always basic collation type.
+        collation_ids[collation_ids.length - 1] =
+                StringDataValue.COLLATION_TYPE_UCS_BASIC;
+
+        return(collation_ids);
+    }
+
+
+    /**
+     * Get the IndexDescriptor that this IndexRowGenerator is based on.
+     */
+    public IndexDescriptor getIndexDescriptor()
+    {
+        return id;
+    }
+
+    /** Zero-argument constructor for Formatable interface */
+    public IndexRowGenerator()
+    {
+    }
+
+    /**
+     * @see IndexDescriptor#isUniqueWithDuplicateNulls
+     */
+    public boolean isUniqueWithDuplicateNulls()
+    {
+        return id.isUniqueWithDuplicateNulls();
+    }
+    /** @see IndexDescriptor#isUnique */
+    public boolean isUnique()
+    {
+        return id.isUnique();
+    }
+
+    /** @see IndexDescriptor#baseColumnPositions */
+    public int[] baseColumnPositions() {
+        return id.baseColumnPositions();
+    }
+
+    @Override
+    public int[] baseColumnStoragePositions() {
+        return id.baseColumnStoragePositions();
+    }
+
+    @Override
+    public boolean isInvalidIndexDescriptor() {
+        return id.isInvalidIndexDescriptor();
+    }
+
+    /** @see IndexDescriptor#getKeyColumnPosition */
+    public int getKeyColumnPosition(int columnStoragePosition) throws StandardException
+    {
+        return id.getKeyColumnPosition(columnStoragePosition);
+    }
+
+    /** @see IndexDescriptor#numberOfOrderedColumns */
+    public int numberOfOrderedColumns()
+    {
+        return id.numberOfOrderedColumns();
+    }
+
+    /** @see IndexDescriptor#indexType */
+    public String indexType()
+    {
+        return id==null?null:id.indexType();
+    }
+
+    public String toString()
+    {
+        return id.toString();
+    }
+
+    /** @see IndexDescriptor#getIndexColumnTypes */
+    public DataTypeDescriptor[] getIndexColumnTypes() { return id.getIndexColumnTypes(); }
+
+    /** @see IndexDescriptor#isAscending */
+    public boolean            isAscending(Integer keyColumnPosition)
+    {
+        return id.isAscending(keyColumnPosition);
+    }
+
+    /** @see IndexDescriptor#isDescending */
+    public boolean            isDescending(Integer keyColumnPosition)
+    {
+        return id.isDescending(keyColumnPosition);
+    }
+
+    @Override public boolean excludeNulls() {return id.excludeNulls();}
+
+    @Override public boolean excludeDefaults() {return id.excludeDefaults();}
+
+    /** @see IndexDescriptor#isAscending */
+    public boolean[]        isAscending()
+    {
+        return id.isAscending();
+    }
+
+    /** @see IndexDescriptor#setBaseColumnStoragePositions
+     * @param baseColumnStoragePositions */
+    @Override
+    public void setBaseColumnStoragePositions(int[] baseColumnStoragePositions)
+    {
+        id.setBaseColumnStoragePositions(baseColumnStoragePositions);
+    }
+    @Override
+    public void setBaseColumnPositions(int[] baseColumnPositions)
+    {
+        id.setBaseColumnPositions(baseColumnPositions);
+    }
+
+    @Override
+    public int[] getBaseColumnStoragePositions() {
+        return id.getBaseColumnStoragePositions();
+    }
+
+    @Override
+    public int[] getBaseColumnPositions() {
+        return id.getBaseColumnPositions();
+    }
+
+    /** @see IndexDescriptor#setIsAscending */
+    public void        setIsAscending(boolean[] isAscending)
+    {
+        id.setIsAscending(isAscending);
+    }
+
+    /** @see IndexDescriptor#setNumberOfOrderedColumns */
+    public void        setNumberOfOrderedColumns(int numberOfOrderedColumns)
+    {
+        id.setNumberOfOrderedColumns(numberOfOrderedColumns);
+    }
+
+    /**
+     * Test for value equality
+     *
+     * @param other        The other indexrowgenerator to compare this one with
+     *
+     * @return    true if this indexrowgenerator has the same value as other
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+
+        IndexRowGenerator that = (IndexRowGenerator) other;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    private ExecutionFactory getExecutionFactory()
+    {
+        if (ef == null)
+        {
+            ExecutionContext    ec;
+
+            ec = (ExecutionContext)
+                    ContextService.getContext(ExecutionContext.CONTEXT_ID);
+            ef = ec.getExecutionFactory();
+        }
+        return ef;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // EXTERNALIZABLE
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * @see java.io.Externalizable#readExternal
+     *
+     * @exception IOException    Thrown on read error
+     * @exception ClassNotFoundException    Thrown on read error
+     */
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        if (DataInputUtil.shouldReadOldFormat()) {
+            readExternalOld(in);
+        }
+        else {
+            readExternalNew(in);
+        }
+    }
+
+    protected void readExternalNew(ObjectInput in) throws IOException {
+        byte[] bs = ArrayUtil.readByteArray(in);
+        CatalogMessage.IndexRowGenerator irg = CatalogMessage.IndexRowGenerator.parseFrom(bs);
+        init(irg);
+    }
+
+    protected void readExternalOld(ObjectInput in) throws IOException, ClassNotFoundException {
+        id = (IndexDescriptor)in.readObject();
+    }
+
+    /**
+     *
+     * @exception IOException    Thrown on write error
+     */
+    @Override
+    public void writeExternal( ObjectOutput out ) throws IOException {
+        if (DataInputUtil.shouldWriteOldFormat()) {
+            writeExternalOld(out);
+        }
+        else {
+            writeExternalNew(out);
+        }
+    }
+
+    protected void writeExternalOld(ObjectOutput out) throws IOException {
+        out.writeObject(id);
+    }
+
+    protected void writeExternalNew(ObjectOutput out) throws IOException {
+        CatalogMessage.IndexRowGenerator indexRowGenerator = toProtobuf();
+        ArrayUtil.writeByteArray(out, indexRowGenerator.toByteArray());
+    }
+
+    public CatalogMessage.IndexRowGenerator toProtobuf() {
+        CatalogMessage.IndexDescriptorImpl indexDescriptor = ((IndexDescriptorImpl)id).toProtobuf();
+        CatalogMessage.IndexRowGenerator indexRowGenerator = CatalogMessage.IndexRowGenerator.newBuilder()
+                .setId(indexDescriptor)
+                .build();
+        return indexRowGenerator;
+    }
+
+    /* TypedFormat interface */
+    public int getTypeFormatId()
+    {
+        return StoredFormatIds.INDEX_ROW_GENERATOR_V01_ID;
+    }
+
+    /**
+     * Is the IndexRowGenerator a Primary Key?
+     *
+     * @return
+     */
+    @Override
+    public boolean isPrimaryKey() {
+        return indexType() != null && indexType().contains("PRIMARY");
+    }
+
+    /** @see IndexDescriptor#getExprTexts */
+    @Override
+    public String[] getExprTexts() { return id.getExprTexts(); }
+
+    /** @see IndexDescriptor#getExprTexts */
+    @Override
+    public String getExprText(Integer keyColumnPosition) { return id.getExprText(keyColumnPosition); }
+
+    /** @see IndexDescriptor#getExprBytecode */
+    @Override
+    public ByteArray[] getExprBytecode() { return id.getExprBytecode(); }
+
+    /** @see IndexDescriptor#getGeneratedClassNames */
+    @Override
+    public String[] getGeneratedClassNames() { return id.getGeneratedClassNames(); }
+
+    /** @see IndexDescriptor#isOnExpression */
+    @Override
+    public boolean isOnExpression() { return id != null && id.isOnExpression(); }
+
+    /** @see IndexDescriptor#getExecutableIndexExpression */
+    @Override
+    public BaseExecutableIndexExpression getExecutableIndexExpression(int indexColumnPosition)
+            throws StandardException
+    {
+        return id.getExecutableIndexExpression(indexColumnPosition);
+    }
+
+    /** @see IndexDescriptor#getParsedIndexExpressions */
+    @Override
+    public ValueNode[] getParsedIndexExpressions(LanguageConnectionContext context, Optimizable optTable)
+            throws StandardException
+    {
+        return id.getParsedIndexExpressions(context, optTable);
+    }
+
+    private int getMaxBaseColumnPosition() {
+        int maxPosition = 1;  // base column positions are 1-based
+        for (int bcp : id.baseColumnStoragePositions()) {
+            if (bcp > maxPosition)
+                maxPosition = bcp;
+        }
+        return maxPosition;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -4255,6 +4255,17 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         return list;
     }
 
+    public List<TableDescriptor> getAllTableDescriptors() throws StandardException {
+        TabInfoImpl ti=coreInfo[SYSTABLES_CORE_NUM];
+        List<TableDescriptor> list = new ArrayList<>();
+        getDescriptorViaHeap(null, null, ti, null, list);
+        for (int i = 0; i < list.size(); i++) {
+            list.set(i, finishTableDescriptor(list.get(i), null));
+        }
+
+        return list;
+    }
+
     /**
      * Comparator that can be used for sorting lists of column references
      * on the position they have in the SQL query string.

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -109,7 +109,7 @@ public class SpliceCatalogUpgradeScripts{
         addUpgradeScript(baseVersion4, 1989, new UpgradeScriptToAddIndexColUseViewInSYSCAT(sdd, tc));
         addUpgradeScript(baseVersion4, 1992, new UpgradeScriptForTablePriorities(sdd, tc));
         addUpgradeScript(baseVersion4, BaseDataDictionary.SERDE_UPGRADE_SPRINT, new UpgradeStoredObjects(sdd, tc));
-        addUpgradeScript(baseVersion4, 2022, new UpgradeFixIndexDescriptors(sdd, tc));
+        addUpgradeScript(baseVersion4, 2023, new UpgradeFixIndexDescriptors(sdd, tc));
         // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -109,6 +109,7 @@ public class SpliceCatalogUpgradeScripts{
         addUpgradeScript(baseVersion4, 1989, new UpgradeScriptToAddIndexColUseViewInSYSCAT(sdd, tc));
         addUpgradeScript(baseVersion4, 1992, new UpgradeScriptForTablePriorities(sdd, tc));
         addUpgradeScript(baseVersion4, BaseDataDictionary.SERDE_UPGRADE_SPRINT, new UpgradeStoredObjects(sdd, tc));
+        addUpgradeScript(baseVersion4, 2022, new UpgradeFixIndexDescriptors(sdd, tc));
         // remember to add your script to SpliceCatalogUpgradeScriptsTest too, otherwise test fails
     }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeFixIndexDescriptors.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeFixIndexDescriptors.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012 - 2020 Splice Machine, Inc.
+ *
+ * This file is part of Splice Machine.
+ * Splice Machine is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3, or (at your option) any later version.
+ * Splice Machine is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with Splice Machine.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.splicemachine.derby.impl.sql.catalog.upgrade;
+
+import com.splicemachine.access.api.PartitionAdmin;
+import com.splicemachine.access.configuration.HBaseConfiguration;
+import com.splicemachine.db.catalog.IndexDescriptor;
+import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
+import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
+import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
+import com.splicemachine.db.iapi.store.access.TransactionController;
+import com.splicemachine.db.impl.sql.catalog.BaseDataDictionary;
+import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
+import com.splicemachine.derby.impl.sql.catalog.Splice_DD_Version;
+import com.splicemachine.derby.impl.sql.execute.operations.ScanOperation;
+import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
+import com.splicemachine.derby.impl.store.access.base.SpliceConglomerate;
+import com.splicemachine.derby.utils.ConglomerateUtils;
+import com.splicemachine.si.api.txn.Txn;
+import com.splicemachine.si.impl.driver.SIDriver;
+import com.splicemachine.utils.SpliceLogUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class UpgradeFixIndexDescriptors extends UpgradeScriptBase {
+    public UpgradeFixIndexDescriptors(SpliceDataDictionary sdd, TransactionController tc) {
+        super(sdd, tc);
+    }
+
+    @Override
+    protected void upgradeSystemTables() throws StandardException {
+        for (TableDescriptor td: sdd.getAllTableDescriptors()) {
+            SchemaDescriptor sd = td.getSchemaDescriptor();
+            for (ConglomerateDescriptor cd: td.getConglomerateDescriptors()) {
+                if (cd.isIndex()) {
+                    fixIndexDescriptorColumns(td, sd, cd);
+                }
+                addKeyFormatIdsToConglomerate(cd);
+            }
+        }
+    }
+
+    private void fixIndexDescriptorColumns(TableDescriptor td, SchemaDescriptor sd, ConglomerateDescriptor cd) throws StandardException {
+        IndexDescriptor id = cd.getIndexDescriptor();
+        if (id.isInvalidIndexDescriptor()) {
+            sdd.dropConglomerateDescriptor(cd, tc);
+            /* At this point, baseStorageColumnDescription mistakenly contains the LOGICAL column ids, and
+             * baseColumnDescription contains nothing.
+             * We want to recreate the index descriptor and baseStorageColumnDescription should contain the STORAGE
+             * columns ids, whereas baseColumnDescription should contain the LOGICAL ids
+             */
+            id.setBaseColumnPositions(id.getBaseColumnStoragePositions());
+            id.setBaseColumnStoragePositions(
+                    Arrays.stream(id.getBaseColumnPositions())
+                            .map(colPos -> td.getColumnDescriptor(colPos).getStoragePosition())
+                            .toArray()
+            );
+            sdd.addDescriptor(cd, sd, DataDictionary.SYSCONGLOMERATES_CATALOG_NUM, false, tc, false);
+        }
+    }
+
+    private void addKeyFormatIdsToConglomerate(ConglomerateDescriptor cd) throws StandardException {
+        SpliceConglomerate conglomerate = (SpliceConglomerate)
+                ((SpliceTransactionManager) tc).findConglomerate(cd.getConglomerateNumber());
+        int[] keyFormatIds = ScanOperation.getKeyFormatIds(conglomerate.getColumnOrdering(), conglomerate.getFormat_ids());
+        conglomerate.setKeyFormatIds(keyFormatIds);
+        ConglomerateUtils.updateConglomerate(conglomerate, (Txn) ((SpliceTransactionManager) tc).getActiveStateTxn());
+    }
+}

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeFixIndexDescriptors.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeFixIndexDescriptors.java
@@ -14,8 +14,6 @@
 
 package com.splicemachine.derby.impl.sql.catalog.upgrade;
 
-import com.splicemachine.access.api.PartitionAdmin;
-import com.splicemachine.access.configuration.HBaseConfiguration;
 import com.splicemachine.db.catalog.IndexDescriptor;
 import com.splicemachine.db.iapi.error.StandardException;
 import com.splicemachine.db.iapi.sql.dictionary.ConglomerateDescriptor;
@@ -23,19 +21,13 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.sql.dictionary.SchemaDescriptor;
 import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.store.access.TransactionController;
-import com.splicemachine.db.impl.sql.catalog.BaseDataDictionary;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
-import com.splicemachine.derby.impl.sql.catalog.Splice_DD_Version;
 import com.splicemachine.derby.impl.sql.execute.operations.ScanOperation;
 import com.splicemachine.derby.impl.store.access.SpliceTransactionManager;
 import com.splicemachine.derby.impl.store.access.base.SpliceConglomerate;
 import com.splicemachine.derby.utils.ConglomerateUtils;
 import com.splicemachine.si.api.txn.Txn;
-import com.splicemachine.si.impl.driver.SIDriver;
-import com.splicemachine.utils.SpliceLogUtils;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.io.IOException;
 import java.util.Arrays;
 
 public class UpgradeFixIndexDescriptors extends UpgradeScriptBase {
@@ -58,11 +50,11 @@ public class UpgradeFixIndexDescriptors extends UpgradeScriptBase {
 
     private void fixIndexDescriptorColumns(TableDescriptor td, SchemaDescriptor sd, ConglomerateDescriptor cd) throws StandardException {
         IndexDescriptor id = cd.getIndexDescriptor();
-        if (id.isInvalidIndexDescriptor()) {
+        if (id.isInvalidIndexDescriptorAfter2022Upgrade()) {
             sdd.dropConglomerateDescriptor(cd, tc);
             /* At this point, baseStorageColumnDescription mistakenly contains the LOGICAL column ids, and
              * baseColumnDescription contains nothing.
-             * We want to recreate the index descriptor and baseStorageColumnDescription should contain the STORAGE
+             * We want to recreate the index descriptor and baseStorageColumnPositions should contain the STORAGE
              * columns ids, whereas baseColumnDescription should contain the LOGICAL ids
              */
             id.setBaseColumnPositions(id.getBaseColumnStoragePositions());

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/base/SpliceConglomerate.java
@@ -320,6 +320,10 @@ public abstract class SpliceConglomerate extends GenericConglomerate implements 
         return keyFormatIds;
     }
 
+    public void setKeyFormatIds(int[] keyFormatIds) {
+        this.keyFormatIds = keyFormatIds;
+    }
+
     @Override
     public void dropColumn(TransactionManager xact_manager,int storagePosition, int position) throws StandardException{
         boolean dropColumnOrdering = false;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/btree/IndexConglomerate.java
@@ -473,15 +473,16 @@ public class IndexConglomerate extends SpliceConglomerate{
     @Override
     public TypeMessage.DataValueDescriptor toProtobuf() throws IOException {
 
-        TypeMessage.HBaseConglomerate hbaseConglomerate = TypeMessage.HBaseConglomerate.newBuilder()
+        TypeMessage.HBaseConglomerate.Builder hbaseConglomerate = TypeMessage.HBaseConglomerate.newBuilder()
                 .setConglomerateFormatId(conglom_format_id)
                 .setTmpFlag(tmpFlag)
                 .setContainerId(containerId)
                 .addAllFormatIds(Arrays.stream(format_ids).boxed().collect(Collectors.toList()))
                 .addAllCollationIds(Arrays.stream(collation_ids).boxed().collect(Collectors.toList()))
-                .addAllColumnOrdering(Arrays.stream(columnOrdering).boxed().collect(Collectors.toList()))
-                .addAllKeyFormatIds(Arrays.stream(keyFormatIds).boxed().collect(Collectors.toList()))
-                .build();
+                .addAllColumnOrdering(Arrays.stream(columnOrdering).boxed().collect(Collectors.toList()));
+        if (keyFormatIds != null) {
+            hbaseConglomerate.addAllKeyFormatIds(Arrays.stream(keyFormatIds).boxed().collect(Collectors.toList()));
+        }
 
         List<Boolean> ascDescInfoList = Lists.newArrayList();
         for (boolean info : ascDescInfo) {
@@ -489,7 +490,7 @@ public class IndexConglomerate extends SpliceConglomerate{
         }
 
         TypeMessage.IndexConglomerate indexConglomerate = TypeMessage.IndexConglomerate.newBuilder()
-                .setBase(hbaseConglomerate)
+                .setBase(hbaseConglomerate.build())
                 .setUniqueWithDuplicateNulls(uniqueWithDuplicateNulls)
                 .setNKeyFields(nKeyFields)
                 .setNUniqueColumns(nUniqueColumns)

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/hbase/HBaseConglomerate.java
@@ -348,19 +348,20 @@ public class HBaseConglomerate extends SpliceConglomerate{
 
     @Override
     public TypeMessage.DataValueDescriptor toProtobuf() throws IOException {
-        TypeMessage.HBaseConglomerate hbaseConglomerate = TypeMessage.HBaseConglomerate.newBuilder()
+        TypeMessage.HBaseConglomerate.Builder hbaseConglomerate = TypeMessage.HBaseConglomerate.newBuilder()
                 .setConglomerateFormatId(conglom_format_id)
                 .setTmpFlag(tmpFlag)
                 .setContainerId(containerId)
                 .addAllFormatIds(Arrays.stream(format_ids).boxed().collect(Collectors.toList()))
                 .addAllCollationIds(Arrays.stream(collation_ids).boxed().collect(Collectors.toList()))
-                .addAllColumnOrdering(Arrays.stream(columnOrdering).boxed().collect(Collectors.toList()))
-                .addAllKeyFormatIds(Arrays.stream(keyFormatIds).boxed().collect(Collectors.toList()))
-                .build();
+                .addAllColumnOrdering(Arrays.stream(columnOrdering).boxed().collect(Collectors.toList()));
+        if (keyFormatIds != null) {
+            hbaseConglomerate.addAllKeyFormatIds(Arrays.stream(keyFormatIds).boxed().collect(Collectors.toList()));
+        }
 
         TypeMessage.SpliceConglomerate spliceConglomerate = TypeMessage.SpliceConglomerate.newBuilder()
                 .setType(TypeMessage.SpliceConglomerate.Type.HBaseConglomerate)
-                .setExtension(TypeMessage.HBaseConglomerate.hbaseConglomerate, hbaseConglomerate)
+                .setExtension(TypeMessage.HBaseConglomerate.hbaseConglomerate, hbaseConglomerate.build())
                 .build();
 
         TypeMessage.DataValueDescriptor dvd = TypeMessage.DataValueDescriptor.newBuilder()

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -24,7 +24,8 @@ public class SpliceCatalogUpgradeScriptsTest {
 
     String s2 = "VERSION4.1989: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToAddIndexColUseViewInSYSCAT\n" +
             "VERSION4.1992: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptForTablePriorities\n" +
-            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n";
+            "VERSION4.2003: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeStoredObjects\n" +
+            "VERSION4.2023: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeFixIndexDescriptors\n";
 
     // see DB-12144 / DB-11296 / DB-10193 Those scripts must run before other upgrade scripts
     String s3 = "VERSION4.2020: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeAddConglomerateNumberIndex\n" +


### PR DESCRIPTION
## Short description

Fix upgrade regression introduced by DB-9898 causing upgrades from 2021 to 2022 to fail.

## Long description

DB-9898 introduced a new field in `IndexDescriptorImpl`: `baseStorageColumnPositions`. From 2022 onward,  IndexDescriptorImpl contains both `baseStorageColumnPositions` and `baseColumnPosition`.
The protobuf message was also extended: on top of the already present `repeat baseColumnPositions`, DB-9898 introduced `repeat baseColumnLogicalPositions`.
This is already somewhat confusing and the mapping between `IndexDescriptorImpl` and the protobuf message should be as follow:
| Protobuf message          | IndexDescriptorImpl       |
|---------------------------|---------------------------|
| baseLogicalColumnPosition | baseColumnPosition        |
| baseColumnPosition        | baseStorageColumnPosition |

However, before 2022, the mapping was:
| Protobuf message   | IndexDescriptorImpl |
|--------------------|---------------------|
| baseColumnPosition | baseColumnPosition  |

This PR introduces an upgrade script to: 
1. Redirect protobuf's `baseColumnPosition` to the the logical column positions
2. Populate `baseStorageColumnPosition` properly.

Additionally, DB-9898 added `keyFormatIds` to both `IndexConglomerate` and `HBaseConglomerate`. Before 2022, we used to generate `keyFormatIds` during a scan operation, but we now take it directly from the conglomerate. However, conglomerates that were created and serialized before 2022 will not contain this field, and this led to `ArrayIndexOutOfBoundErrors` and `NullPointerExceptions`. The upgrade script now properly populates that field for every single conglomerate in the system (tables and indices). 

Until the upgrade script is run, indices with columns that differ in `baseColumnPositions` and `baseStorageColumnPositions` can behave incoherently. This however should not happen because: 
1. User tables will not be accessed until all upgrade scripts have run.
2. System tables never drop columns, so `baseColumnPositions == baseStorageColumnPositions`

This PR does **not** fix indexes that were already inconsistent before.

For example, the following example led to inconsistency on 2021:
```
create table foo (a int, b int, c int);
alter table foo drop column c;
alter table foo add column d int;
create index fooi on foo(a, d);
insert into foo values (1,2,3);
select a,d from foo;        -- We use an index scan
A          |D
-----------------------
1          |NULL              <-- Notice that NULL should be 3 instead
```
The only way to fix that index is to upgrade to 2023, drop and recreate the index.

## Tests

The upgrade was tested for the following versions:
`3.2.0.1995` -> `DB-12323`
`3.2.0.2021` -> `DB-12323`
`3.1.0.1995` -> `DB-12323-3.1`
`3.1.1.2021` -> `DB-12323-3.1` 

## All DB-12323 PRs

[spliceengine master](https://github.com/splicemachine/spliceengine/pull/5658)
[spliceengine branch-3.1](https://github.com/splicemachine/spliceengine/pull/5659)
