### PR TITLE
DB-11826 DB-12226 Fix time-travel returning incorrect results due to using temporal-inconsistent index (3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -2276,10 +2276,4 @@ public interface DataDictionary{
      * @throws StandardException In case of e.g. connection error to HBase admin.
      */
     long getConglomerateCreationTxId(long conglom) throws StandardException;
-
-    long getTxnAt(long ts) throws StandardException;
-
-    boolean txnWithin(long period, long pastTx) throws StandardException;
-
-    boolean txnWithin(long period, Timestamp pastTx) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -46,6 +46,8 @@ import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.impl.sql.catalog.DataDictionaryCache;
 import com.splicemachine.db.impl.sql.execute.TriggerEventDML;
 
+import java.io.IOException;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.*;
 
@@ -2266,4 +2268,18 @@ public interface DataDictionary{
     long getSystablesMinRetentionPeriod();
 
     boolean useTxnAwareCache();
+
+    /**
+     * Returns for a given conglomerate the ID of the transaction used to create it
+     * @param conglom the conglomerate ID.
+     * @return The ID of the transaction used to create it.
+     * @throws StandardException In case of e.g. connection error to HBase admin.
+     */
+    long getConglomerateCreationTxId(long conglom) throws StandardException;
+
+    long getTxnAt(long ts) throws StandardException;
+
+    boolean txnWithin(long period, long pastTx) throws StandardException;
+
+    boolean txnWithin(long period, Timestamp pastTx) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/execute/ResultSetFactory.java
@@ -1032,7 +1032,7 @@ public interface ResultSetFactory {
      * @param optimizerEstimatedRowCount    Estimated total # of rows by
                                     optimizer
      * @param optimizerEstimatedCost        Estimated total cost by optimizer
-     * @param pastTxFunctor                a functor that returns the id of a committed transaction for time-travel queries
+     * @param pastTxn                the id of a committed transaction for time-travel queries, -1 if not set.
      * @param minRetentionPeriod the minimum retention period for guaranteed correct time travel results.
 	 */
 	NoPutResultSet getTableScanResultSet(
@@ -1072,7 +1072,7 @@ public interface ResultSetFactory {
                         int partitionByRefItem,
                         GeneratedMethod defaultRowFunc,
                         int defaultValueMapItem,
-                        GeneratedMethod pastTxFunctor,
+                        long pastTxn,
                         long minRetentionPeriod,
                         int numUnusedLeadingIndexFields
                         )
@@ -1117,7 +1117,7 @@ public interface ResultSetFactory {
                         int partitionByRefItem,
                         GeneratedMethod defaultRowFunc,
                         int defaultValueMapItem,
-                        GeneratedMethod pastTxFunctor,
+                        long pastTxn,
                         long minRetentionPeriod,
                         int numUnusedLeadingIndexFields
                         )
@@ -1160,7 +1160,7 @@ public interface ResultSetFactory {
                         int partitionByRefItem,
                         GeneratedMethod defaultRowFunc,
                         int defaultValueMapItem,
-                        GeneratedMethod pastTxFunctor,
+                        long pastTxn,
                         long minRetentionPeriod
                         )
         throws StandardException;
@@ -1196,8 +1196,8 @@ public interface ResultSetFactory {
      * @param optimizerEstimatedRowCount     Estimated total # of rows by
      *                                       optimizer
      * @param optimizerEstimatedCost         Estimated total cost by optimizer
-     * @param pastTxFunctor                  a functor that returns the id of a committed transaction for time-travel queries
-     * @param minRetentionPeriod             the minimum retention period for guaranteed correct time travel results.
+     * @param pastTxn                        The id of a committed transaction for time-travel queries, -1 if not set.
+     * @param minRetentionPeriod             the minimum retention period for guaranteed correct time travel results
      * @return the table scan operation as a result set.
      * @throws StandardException thrown when unable to create the
      *                           result set
@@ -1230,7 +1230,7 @@ public interface ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod,
             int numUnusedLeadingIndexFields)
             throws StandardException;
@@ -1263,7 +1263,7 @@ public interface ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod)
             throws StandardException;
     /**
@@ -1320,7 +1320,7 @@ public interface ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod,
             int numUnusedLeadingIndexFields
     )
@@ -1367,7 +1367,7 @@ public interface ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod
     )
             throws StandardException;
@@ -2287,9 +2287,8 @@ public interface ResultSetFactory {
      * @param optimizerEstimatedRowCount     Estimated total # of rows by
      *                                       optimizer
      * @param optimizerEstimatedCost         Estimated total cost by optimizer
-     * @param pastTxFunctor                a functor that returns the id of a committed transaction for time-travel queries
-     * @param minRetentionPeriod the minimum retention period for guaranteed correct time travel results.
-     *
+     * @param pastTxn                        The id of a committed transaction for time-travel queries, -1 if not set.
+     * @param minRetentionPeriod             the minimum retention period for guaranteed correct time travel results.
      * @return the scan operation as a result set.
      * @throws StandardException thrown when unable to create the
      *                           result set
@@ -2311,7 +2310,7 @@ public interface ResultSetFactory {
             double optimizerEstimatedCost,
             String tableVersion,
             String explainPlan,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod,
             int numUnusedLeadingIndexFields
     ) throws StandardException;
@@ -2333,7 +2332,7 @@ public interface ResultSetFactory {
             double optimizerEstimatedCost,
             String tableVersion,
             String explainPlan,
-            GeneratedMethod pastTxFunctor,
+            long pastTxFunctor,
             long minRetentionPeriod
     ) throws StandardException;
 

--- a/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/store/access/TransactionController.java
@@ -41,6 +41,7 @@ import com.splicemachine.db.iapi.sql.dictionary.TableDescriptor;
 import com.splicemachine.db.iapi.store.access.conglomerate.Conglomerate;
 import com.splicemachine.db.iapi.types.DataValueDescriptor;
 
+import java.sql.Timestamp;
 import java.util.Properties;
 import java.util.Set;
 
@@ -264,6 +265,8 @@ public interface TransactionController
 	byte IS_TEMPORARY	=	(byte) 0x01; // conglom is temporary
 	byte IS_KEPT		=	(byte) 0x02; // no auto remove
 
+	int TIME_TRAVEL_OLDEST = -1;
+	int TIME_TRAVEL_UNSET  = -2;
 
 	/**************************************************************************
 	 * Interfaces previously defined in TcAccessIface:
@@ -1738,4 +1741,10 @@ public interface TransactionController
 	void rewritePropertyConglomerate() throws StandardException;
 
 	void recoverPropertyConglomerateIfNecessary() throws StandardException;
+
+	long getTxnAt(long ts) throws StandardException;
+
+	boolean txnWithin(long period, long pastTx) throws StandardException;
+
+	boolean txnWithin(long period, Timestamp pastTx) throws StandardException;
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -87,6 +87,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -11119,4 +11120,23 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
         return false;
     }
 
+    @Override
+    public long getConglomerateCreationTxId(long tableConglom) throws StandardException {
+        return -1;
+    }
+
+    @Override
+    public long getTxnAt(long ts) throws StandardException {
+        return -1;
+    }
+
+    @Override
+    public boolean txnWithin(long period, long pastTx) throws StandardException {
+        return false;
+    }
+
+    @Override
+    public boolean txnWithin(long period, Timestamp pastTx) throws StandardException {
+        return false;
+    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImpl.java
@@ -11124,19 +11124,4 @@ public abstract class DataDictionaryImpl extends BaseDataDictionary{
     public long getConglomerateCreationTxId(long tableConglom) throws StandardException {
         return -1;
     }
-
-    @Override
-    public long getTxnAt(long ts) throws StandardException {
-        return -1;
-    }
-
-    @Override
-    public boolean txnWithin(long period, long pastTx) throws StandardException {
-        return false;
-    }
-
-    @Override
-    public boolean txnWithin(long period, Timestamp pastTx) throws StandardException {
-        return false;
-    }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -305,7 +305,7 @@ public class FromBaseTable extends FromTable {
                     && (predList == null || !predList.canSupportIndexExcludedDefaults(tableNumber,currentConglomerateDescriptor, tableDescriptor))) {
                 return false;
             }
-            else if (pastTxnId != -1) {
+            else if (pastTxnId != -2) {
                 long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(currentConglomerateDescriptor.getConglomerateNumber());
                 return pastTxnId >= indexCreationTx;
             }
@@ -365,8 +365,8 @@ public class FromBaseTable extends FromTable {
                         String conglomerateName=currentConglomerateDescriptor.getConglomerateName();
                         if(conglomerateName!=null){
                             /* Have we found the desired index? */
-                            if(conglomerateName.equals(userSpecifiedIndexName)){
-                                if (pastTxnId != -1 && conglomDesc.isIndex()) {
+                            if(conglomerateName.equals(userSpecifiedIndexName)) {
+                                if (pastTxnId != -2 && conglomDesc.isIndex()) {
                                     long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(conglomDesc.getConglomerateNumber());
                                     if(pastTxnId < indexCreationTx) {
                                         throw StandardException.newException(SQLState.LANG_USER_INDEX_CREATED_AFTER_PAST_TRANSACTION,
@@ -1257,7 +1257,15 @@ public class FromBaseTable extends FromTable {
             if(!pastTxIdExpression.isConstantExpression()) {
                 throw StandardException.newException(SQLState.LANG_ILLEGAL_TIME_TRAVEL, "not-constant expression");
             }
-            pastTxnId = mapToTxId(pastTxIdExpression.evaluateConstantExpressions().getKnownConstantValue(), minRetentionPeriod);
+            ValueNode valueNode = pastTxIdExpression.evaluateConstantExpressions();
+            DataValueDescriptor dvd = valueNode.getKnownConstantValue();
+            if(dvd == null) {
+                throw StandardException.newException(SQLState.NOT_IMPLEMENTED, String.format("Evaluation of constant expression of type %s is not supported",
+                                                                                             valueNode.getClass().getSimpleName()));
+            }
+            pastTxnId = mapToTxId(dvd, minRetentionPeriod);
+        } else {
+            pastTxnId = -2;
         }
 
         if(tableDescriptor.getTableType()==TableDescriptor.VTI_TYPE){
@@ -4092,6 +4100,9 @@ public class FromBaseTable extends FromTable {
     }
 
     private long mapToTxId(DataValueDescriptor dataValue, long minRetentionPeriod) throws StandardException {
+        if(SanityManager.DEBUG) {
+            SanityManager.ASSERT(dataValue != null);
+        }
         if (dataValue instanceof SQLTimestamp) {
             Timestamp ts = ((SQLTimestamp) dataValue).getTimestamp(null);
             if (minRetentionPeriod != -1) {

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -66,7 +66,6 @@ import splice.com.google.common.base.Joiner;
 import splice.com.google.common.base.Predicates;
 import splice.com.google.common.collect.Lists;
 
-import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.sql.Timestamp;
 import java.util.*;
@@ -228,7 +227,7 @@ public class FromBaseTable extends FromTable {
 
     private ValueNode pastTxIdExpression = null;
 
-    private long pastTxnId = -1;
+    private long pastTxnId = TransactionController.TIME_TRAVEL_UNSET;
 
     private long minRetentionPeriod = -1;
 
@@ -305,7 +304,7 @@ public class FromBaseTable extends FromTable {
                     && (predList == null || !predList.canSupportIndexExcludedDefaults(tableNumber,currentConglomerateDescriptor, tableDescriptor))) {
                 return false;
             }
-            else if (pastTxnId != -2) {
+            else if (pastTxnId != TransactionController.TIME_TRAVEL_UNSET) {
                 long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(currentConglomerateDescriptor.getConglomerateNumber());
                 return pastTxnId >= indexCreationTx;
             }
@@ -366,7 +365,7 @@ public class FromBaseTable extends FromTable {
                         if(conglomerateName!=null){
                             /* Have we found the desired index? */
                             if(conglomerateName.equals(userSpecifiedIndexName)) {
-                                if (pastTxnId != -2 && conglomDesc.isIndex()) {
+                                if (pastTxnId != TransactionController.TIME_TRAVEL_UNSET && conglomDesc.isIndex()) {
                                     long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(conglomDesc.getConglomerateNumber());
                                     if(pastTxnId < indexCreationTx) {
                                         throw StandardException.newException(SQLState.LANG_USER_INDEX_CREATED_AFTER_PAST_TRANSACTION,
@@ -1265,7 +1264,7 @@ public class FromBaseTable extends FromTable {
             }
             pastTxnId = mapToTxId(dvd, minRetentionPeriod);
         } else {
-            pastTxnId = -2;
+            pastTxnId = TransactionController.TIME_TRAVEL_UNSET;
         }
 
         if(tableDescriptor.getTableType()==TableDescriptor.VTI_TYPE){
@@ -4103,16 +4102,17 @@ public class FromBaseTable extends FromTable {
         if(SanityManager.DEBUG) {
             SanityManager.ASSERT(dataValue != null);
         }
+        TransactionController tc = getLanguageConnectionContext().getTransactionCompile();
         if (dataValue instanceof SQLTimestamp) {
             Timestamp ts = ((SQLTimestamp) dataValue).getTimestamp(null);
             if (minRetentionPeriod != -1) {
-                if (getDataDictionary().txnWithin(minRetentionPeriod, ts)) {
-                    return getDataDictionary().getTxnAt(ts.getTime());
+                if (tc.txnWithin(minRetentionPeriod, ts)) {
+                    return tc.getTxnAt(ts.getTime());
                 } else {
                     throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_OUTSIDE_MIN_RETENTION_PERIOD, minRetentionPeriod);
                 }
             } else {
-                return getDataDictionary().getTxnAt(ts.getTime());
+                return tc.getTxnAt(ts.getTime());
             }
         } else if (dataValue instanceof SQLTinyint || dataValue instanceof SQLSmallint || dataValue instanceof SQLInteger || dataValue instanceof SQLLongint) {
             if (dataValue.isNull()) {
@@ -4120,7 +4120,7 @@ public class FromBaseTable extends FromTable {
             }
             long pastTx = dataValue.getLong();
             if (minRetentionPeriod != -1) {
-                if (getDataDictionary().txnWithin(minRetentionPeriod, pastTx)) {
+                if (tc.txnWithin(minRetentionPeriod, pastTx)) {
                     return pastTx;
                 } else {
                     throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_INVALID_PAST_TRANSACTION_ID, minRetentionPeriod);

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromBaseTable.java
@@ -52,9 +52,7 @@ import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
 import com.splicemachine.db.iapi.store.access.StaticCompiledOpenConglomInfo;
 import com.splicemachine.db.iapi.store.access.StoreCostController;
 import com.splicemachine.db.iapi.store.access.TransactionController;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.DataValueDescriptor;
-import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 import com.splicemachine.db.iapi.util.StringUtil;
@@ -68,7 +66,9 @@ import splice.com.google.common.base.Joiner;
 import splice.com.google.common.base.Predicates;
 import splice.com.google.common.collect.Lists;
 
+import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.sql.Timestamp;
 import java.util.*;
 
 import static com.splicemachine.db.impl.ast.RSUtils.isRSN;
@@ -228,6 +228,8 @@ public class FromBaseTable extends FromTable {
 
     private ValueNode pastTxIdExpression = null;
 
+    private long pastTxnId = -1;
+
     private long minRetentionPeriod = -1;
 
     // expressions in whole query referencing columns in this base table
@@ -303,6 +305,10 @@ public class FromBaseTable extends FromTable {
                     && (predList == null || !predList.canSupportIndexExcludedDefaults(tableNumber,currentConglomerateDescriptor, tableDescriptor))) {
                 return false;
             }
+            else if (pastTxnId != -1) {
+                long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(currentConglomerateDescriptor.getConglomerateNumber());
+                return pastTxnId >= indexCreationTx;
+            }
         }
         return true;
     }
@@ -360,6 +366,13 @@ public class FromBaseTable extends FromTable {
                         if(conglomerateName!=null){
                             /* Have we found the desired index? */
                             if(conglomerateName.equals(userSpecifiedIndexName)){
+                                if (pastTxnId != -1 && conglomDesc.isIndex()) {
+                                    long indexCreationTx = getDataDictionary().getConglomerateCreationTxId(conglomDesc.getConglomerateNumber());
+                                    if(pastTxnId < indexCreationTx) {
+                                        throw StandardException.newException(SQLState.LANG_USER_INDEX_CREATED_AFTER_PAST_TRANSACTION,
+                                                                             conglomDesc.getConglomerateName(), indexCreationTx, pastTxnId);
+                                    }
+                                }
                                 break;
                             }
                         }
@@ -1241,6 +1254,10 @@ public class FromBaseTable extends FromTable {
                 Long minRetentionPeriod = tableDescriptor.getMinRetentionPeriod();
                 this.minRetentionPeriod = minRetentionPeriod == null ? -1 : minRetentionPeriod;
             }
+            if(!pastTxIdExpression.isConstantExpression()) {
+                throw StandardException.newException(SQLState.LANG_ILLEGAL_TIME_TRAVEL, "not-constant expression");
+            }
+            pastTxnId = mapToTxId(pastTxIdExpression.evaluateConstantExpressions().getKnownConstantValue(), minRetentionPeriod);
         }
 
         if(tableDescriptor.getTableType()==TableDescriptor.VTI_TYPE){
@@ -2570,7 +2587,7 @@ public class FromBaseTable extends FromTable {
         mb.push(costEstimate.getEstimatedCost());
         mb.push(tableDescriptor.getVersion());
         mb.push(printExplainInformationForActivation());
-        generatePastTxFunc(acb, mb);
+        mb.push(pastTxnId);
         mb.push(minRetentionPeriod);
         mb.push(numUnusedLeadingIndexFields);
         mb.callMethod(VMOpcode.INVOKEINTERFACE,null,"getLastIndexKeyResultSet", ClassName.NoPutResultSet,18);
@@ -2652,25 +2669,11 @@ public class FromBaseTable extends FromTable {
         BaseJoinStrategy.pushNullableString(mb,tableDescriptor.getLocation());
         mb.push(partitionReferenceItem);
         generateDefaultRow((ActivationClassBuilder)acb, mb);
-        generatePastTxFunc(acb, mb);
+        mb.push(pastTxnId);
         mb.push(minRetentionPeriod);
         mb.push(numUnusedLeadingIndexFields);
         mb.callMethod(VMOpcode.INVOKEINTERFACE,null,"getDistinctScanResultSet",
                 ClassName.NoPutResultSet,30);
-    }
-
-    private void generatePastTxFunc(ExpressionClassBuilder acb, MethodBuilder mb) throws StandardException {
-        if(pastTxIdExpression != null) {
-            MethodBuilder pastTxExpr = acb.newUserExprFun();
-            pastTxIdExpression.generateExpression(acb, pastTxExpr);
-            pastTxExpr.methodReturn();
-            pastTxExpr.complete();
-            acb.pushMethodReference(mb, pastTxExpr);
-        }
-        else
-        {
-            mb.pushNull(ClassName.GeneratedMethod);
-        }
     }
 
     private int getScanArguments(ExpressionClassBuilder acb,
@@ -2766,7 +2769,7 @@ public class FromBaseTable extends FromTable {
         numArgs += generateDefaultRow((ActivationClassBuilder)acb, mb);
 
         // also add the past transaction id functor
-        generatePastTxFunc(acb, mb);
+        mb.push(pastTxnId);
         numArgs++;
 
         mb.push(minRetentionPeriod);
@@ -4086,5 +4089,35 @@ public class FromBaseTable extends FromTable {
         return !skipStats &&
                useRealTableStats &&
                currentIndexFirstColumnStats.getFirstIndexColumnCardinality() <= maxPrefixIteratorValues;
+    }
+
+    private long mapToTxId(DataValueDescriptor dataValue, long minRetentionPeriod) throws StandardException {
+        if (dataValue instanceof SQLTimestamp) {
+            Timestamp ts = ((SQLTimestamp) dataValue).getTimestamp(null);
+            if (minRetentionPeriod != -1) {
+                if (getDataDictionary().txnWithin(minRetentionPeriod, ts)) {
+                    return getDataDictionary().getTxnAt(ts.getTime());
+                } else {
+                    throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_OUTSIDE_MIN_RETENTION_PERIOD, minRetentionPeriod);
+                }
+            } else {
+                return getDataDictionary().getTxnAt(ts.getTime());
+            }
+        } else if (dataValue instanceof SQLTinyint || dataValue instanceof SQLSmallint || dataValue instanceof SQLInteger || dataValue instanceof SQLLongint) {
+            if (dataValue.isNull()) {
+                throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_INVALID_PAST_TRANSACTION_ID, "null");
+            }
+            long pastTx = dataValue.getLong();
+            if (minRetentionPeriod != -1) {
+                if (getDataDictionary().txnWithin(minRetentionPeriod, pastTx)) {
+                    return pastTx;
+                } else {
+                    throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_INVALID_PAST_TRANSACTION_ID, minRetentionPeriod);
+                }
+            }
+            return dataValue.getLong();
+        } else {
+            throw StandardException.newException(SQLState.NOT_IMPLEMENTED, dataValue.getClass().getSimpleName() + " can not be used with time travel query"); // fix me, we should read SqlTime as well.
+        }
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -1569,6 +1569,9 @@ public class TernaryOperatorNode extends OperatorNode
             if(operatorType == TIMESTAMPADD) {
                 DataValueFactory dvf = getLanguageConnectionContext().getDataValueFactory();
                 DataValueDescriptor sourceValue = (getReceiver()).evaluateConstantExpressions().getKnownConstantValue();
+                if(sourceValue == null) {// e.g. in case of CURRENT_TIMESTAMP
+                    return super.evaluateConstantExpressions();
+                }
                 DateTimeDataValue destValue = dvf.getNullTimestamp(null);
                 if (!sourceValue.isNull()) {
                     DataValueDescriptor leftDvd = getLeftOperand().evaluateConstantExpressions().getKnownConstantValue();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -44,9 +44,7 @@ import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.sql.compile.TypeCompiler;
 import com.splicemachine.db.iapi.sql.compile.Visitor;
 import com.splicemachine.db.iapi.store.access.Qualifier;
-import com.splicemachine.db.iapi.types.DataTypeDescriptor;
-import com.splicemachine.db.iapi.types.StringDataValue;
-import com.splicemachine.db.iapi.types.TypeId;
+import com.splicemachine.db.iapi.types.*;
 import com.splicemachine.db.iapi.util.JBitSet;
 import com.splicemachine.db.iapi.util.ReuseFactory;
 
@@ -67,8 +65,10 @@ import java.util.Set;
 
 public class TernaryOperatorNode extends OperatorNode
 {
+    private static final String TIMESTAMP_METHOD_NAME="getTimestamp";
     String        operator;
     String        methodName;
+
     int            operatorType;
     ValueNode    receiver;
 
@@ -1560,5 +1560,36 @@ public class TernaryOperatorNode extends OperatorNode
             cost += rightOperand.getBaseOperationCost();
         }
         return cost;
+    }
+
+    @Override
+    ValueNode evaluateConstantExpressions() throws StandardException {
+        if(getLeftOperand().isConstantExpression() && getRightOperand().isConstantExpression()) {
+            if(operatorType == TIMESTAMPADD) {
+                DataValueFactory dvf = getLanguageConnectionContext().getDataValueFactory();
+                DataValueDescriptor sourceValue = (getReceiver()).evaluateConstantExpressions().getKnownConstantValue();
+                DateTimeDataValue destValue = dvf.getNullTimestamp(null);
+                if (!sourceValue.isNull()) {
+                    DataValueDescriptor leftDvd = getLeftOperand().evaluateConstantExpressions().getKnownConstantValue();
+                    if(leftDvd == null) {
+                        throw StandardException.newException(SQLState.NOT_IMPLEMENTED, String.format("Evaluation of constant expression of type %s is not supported",
+                                                                                                     getLeftOperand().getClass().getSimpleName()));
+                    }
+                    DataValueDescriptor rightDvd = getRightOperand().evaluateConstantExpressions().getKnownConstantValue();
+                    if(rightDvd == null) {
+                        throw StandardException.newException(SQLState.NOT_IMPLEMENTED, String.format("Evaluation of constant expression of type %s is not supported",
+                                                                                                     getRightOperand().getClass().getSimpleName()));
+                    }
+                    int type = leftDvd.getInt();
+                    NumberDataValue count = dvf.getDataValue(rightDvd.getInt(), null);
+                    destValue = dvf.getNullTimestamp(null);
+                    dvf.getTimestamp(sourceValue).timestampAdd(type, count, null, destValue);
+                }
+                return (ValueNode) getNodeFactory().getNode(C_NodeTypes.USERTYPE_CONSTANT_NODE, destValue, getContextManager());
+            } else {
+                return super.evaluateConstantExpressions();
+            }
+        }
+        return super.evaluateConstantExpressions();
     }
 }

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/TernaryOperatorNode.java
@@ -1564,7 +1564,8 @@ public class TernaryOperatorNode extends OperatorNode
 
     @Override
     ValueNode evaluateConstantExpressions() throws StandardException {
-        if(getLeftOperand().isConstantExpression() && getRightOperand().isConstantExpression()) {
+        if(getLeftOperand() != null && getLeftOperand().isConstantExpression()
+           && getRightOperand() != null && getRightOperand().isConstantExpression()) {
             if(operatorType == TIMESTAMPADD) {
                 DataValueFactory dvf = getLanguageConnectionContext().getDataValueFactory();
                 DataValueDescriptor sourceValue = (getReceiver()).evaluateConstantExpressions().getKnownConstantValue();

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryDateTimestampOperatorNode.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/UnaryDateTimestampOperatorNode.java
@@ -41,6 +41,7 @@ import com.splicemachine.db.iapi.sql.compile.C_NodeTypes;
 import com.splicemachine.db.iapi.types.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.List;
 
@@ -141,19 +142,7 @@ public class UnaryDateTimestampOperatorNode extends UnaryOperatorNode{
         }
 
         if(operand instanceof ConstantNode){
-            DataValueFactory dvf=getLanguageConnectionContext().getDataValueFactory();
-            DataValueDescriptor sourceValue=((ConstantNode)operand).getValue();
-            DataValueDescriptor destValue=null;
-            if(sourceValue.isNull()){
-                destValue=(TIMESTAMP_METHOD_NAME.equals(methodName))
-                        ?dvf.getNullTimestamp((DateTimeDataValue)null)
-                        :dvf.getNullDate((DateTimeDataValue)null);
-            }else{
-                destValue=(TIMESTAMP_METHOD_NAME.equals(methodName))
-                        ?dvf.getTimestamp(sourceValue):dvf.getDate(sourceValue);
-            }
-            return (ValueNode)getNodeFactory().getNode(C_NodeTypes.USERTYPE_CONSTANT_NODE,
-                    destValue,getContextManager());
+            return evaluateConstantExpressions();
         }
 
         if(isIdentity)
@@ -194,5 +183,25 @@ public class UnaryDateTimestampOperatorNode extends UnaryOperatorNode{
         double localCost = SIMPLE_OP_COST * (operand == null ? 1.0 : 2.0);
         double callCost = SIMPLE_OP_COST * FN_CALL_COST_FACTOR;
         return lowerCost + localCost + callCost;
+    }
+
+    @Override
+    ValueNode evaluateConstantExpressions() throws StandardException {
+        if (getOperand() instanceof ConstantNode) {
+            DataValueFactory dvf = getLanguageConnectionContext().getDataValueFactory();
+            DataValueDescriptor sourceValue = ((ConstantNode) getOperand()).getValue();
+            DataValueDescriptor destValue = null;
+            if (sourceValue.isNull()) {
+                destValue = (TIMESTAMP_METHOD_NAME.equals(methodName))
+                        ? dvf.getNullTimestamp((DateTimeDataValue) null)
+                        : dvf.getNullDate((DateTimeDataValue) null);
+            } else {
+                destValue = (TIMESTAMP_METHOD_NAME.equals(methodName))
+                        ? dvf.getTimestamp(sourceValue) : dvf.getDate(sourceValue);
+            }
+            return (ValueNode) getNodeFactory().getNode(C_NodeTypes.USERTYPE_CONSTANT_NODE,
+                                                        destValue, getContextManager());
+        }
+        return this;
     }
 }

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/reference/SQLState.java
@@ -1072,6 +1072,7 @@ public interface SQLState {
     String LANG_UNTYPED                                                    = "42Z01.U";
     // TEMPORARY COMPILATION RESTRICTIONS
     String LANG_USER_AGGREGATE_MULTIPLE_DISTINCTS                          = "42Z02";
+    String LANG_USER_INDEX_CREATED_AFTER_PAST_TRANSACTION                  = "42Z03";
     String LANG_NO_AGGREGATES_IN_ON_CLAUSE                                 = "42Z07";
     String LANG_NO_BULK_INSERT_REPLACE_WITH_TRIGGER                        = "42Z08";
 

--- a/db-shared/src/main/java/com/splicemachine/db/shared/common/sql/Utils.java
+++ b/db-shared/src/main/java/com/splicemachine/db/shared/common/sql/Utils.java
@@ -28,4 +28,19 @@ public class Utils {
                  .replace("_", escapeCharacter + "_")
                  .replace("%", escapeCharacter + "%");
     }
+
+    public static String constructHbaseName(String tableName) {
+        if(tableName == null) {
+            return null;
+        }
+        try {
+            long conglomId = Long.parseLong(tableName);
+            return "splice:" + conglomId;
+        } catch(NumberFormatException nfe) {
+            if(!tableName.contains(":")) {
+                throw new IllegalArgumentException(String.format("improper HBase table name %s", tableName));
+            }
+        }
+        return tableName;
+    }
 }

--- a/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
+++ b/db-tools-i18n/src/main/resources/com/splicemachine/db/loc/messages.xml
@@ -2899,6 +2899,15 @@ Guide.
             </msg>
 
             <msg>
+                <name>42Z03</name>
+                <text>Specified index '{0}' is created at tx '{1}' which is after time-travel mapped past transaction id '{2}'.</text>
+                <arg>indexName</arg>
+                <arg>indexCreationTx</arg>
+                <arg>timeTravelTx</arg>
+            </msg>
+
+
+            <msg>
                 <name>42Z07</name>
                 <text>Aggregates are not permitted in the ON clause.</text>
             </msg>

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
@@ -25,6 +25,7 @@ import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.storage.Partition;
 import com.splicemachine.storage.SkeletonHBaseClientPartition;
 import com.splicemachine.utils.SpliceLogUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -57,6 +58,7 @@ public class BulkImportFunction implements VoidFunction<Iterator<BulkImportParti
     // serialization
     public BulkImportFunction() {}
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "this is intentional")
     public BulkImportFunction(String bulkImportDirectory, byte[] token) {
         this.bulkImportDirectory = bulkImportDirectory;
         this.token = token;
@@ -73,9 +75,9 @@ public class BulkImportFunction implements VoidFunction<Iterator<BulkImportParti
         FileSystem fs = FileSystem.get(URI.create(bulkImportDirectory), conf);
         PartitionFactory tableFactory= SIDriver.driver().getTableFactory();
 
-        for (Long conglomId : partitionMap.keySet()) {
-            Partition partition=tableFactory.getTable(Long.toString(conglomId));
-            List<BulkImportPartition> partitionList = partitionMap.get(conglomId);
+        for (Map.Entry<Long, List<BulkImportPartition>> mapEntry : partitionMap.entrySet()) {
+            Partition partition=tableFactory.getTable(Long.toString(mapEntry.getKey()));
+            List<BulkImportPartition> partitionList = mapEntry.getValue();
             // For each batch of BulkImportPartition, use the first partition as staging area
             Path path = new Path(partitionList.get(0).getFilePath());
             if (!fs.exists(path)) {

--- a/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
+++ b/hbase_sql/src/main/java/com/splicemachine/derby/stream/function/BulkImportFunction.java
@@ -19,6 +19,7 @@ import com.clearspring.analytics.util.Lists;
 import com.splicemachine.access.HConfiguration;
 import com.splicemachine.access.api.PartitionFactory;
 import com.splicemachine.db.iapi.services.io.ArrayUtil;
+import com.splicemachine.db.shared.common.sql.Utils;
 import com.splicemachine.derby.impl.SpliceSpark;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.storage.Partition;
@@ -98,7 +99,7 @@ public class BulkImportFunction implements VoidFunction<Iterator<BulkImportParti
                 }
             }
             writeToken(fs, path);
-            HBasePlatformUtils.bulkLoad(conf, loader, path.getParent(), "splice:" + partition.getTableName());
+            HBasePlatformUtils.bulkLoad(conf, loader, path.getParent(), Utils.constructHbaseName(partition.getTableName()));
             fs.delete(path.getParent(), true);
         }
     }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -72,7 +72,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.*;
 import java.util.function.Function;
@@ -2033,42 +2032,14 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
             if(SanityManager.DEBUG) {
                 SanityManager.ASSERT(descriptor != null);
             }
-            return Long.parseLong(descriptor.getTransactionId());
+            String txId = descriptor.getTransactionId();
+            if(null == txId) {
+                return 0; // some old indexes and tables do not have transaction id.
+            }
+            return Long.parseLong(txId);
         } catch(IOException | IllegalArgumentException ex) {
             throw StandardException.plainWrapException(ex);
         }
-    }
-
-    @Override
-    public long getTxnAt(long ts) throws StandardException {
-        try {
-            return SIDriver.driver().getTxnStore().getTxnAt(ts);
-        } catch (IOException e) {
-            throw Exceptions.parseException(e);
-        }
-    }
-
-    @Override
-    public boolean txnWithin(long period, long pastTx) throws StandardException {
-        if(pastTx < SIConstants.OLDEST_TIME_TRAVEL_TX) {
-            return false;
-        }
-        long mrpTx = 0;
-        try {
-            mrpTx = SIDriver.driver().getTxnStore().getTxnAt(System.currentTimeMillis() - period * 1000);
-        } catch (IOException e) {
-            throw Exceptions.parseException(e);
-        }
-        return mrpTx <= pastTx;
-    }
-
-    @Override
-    public boolean txnWithin(long period, Timestamp pastTx) throws StandardException {
-        Timestamp currentTs = new Timestamp(System.currentTimeMillis());
-        if(pastTx.after(currentTs)) { // future time travel is no-op anyway
-            return true;
-        }
-        return ((System.currentTimeMillis() - pastTx.getTime()) / 1000) <= period;
     }
 
     public void rewriteDescriptors(int catalogNum, long cloned_conglomerate) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/SpliceGenericResultSetFactory.java
@@ -448,7 +448,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                 int partitionByRefItem,
                                                 GeneratedMethod defaultRowFunc,
                                                 int defaultValueMapItem,
-                                                GeneratedMethod pastTxFunctor,
+                                                long pastTxn,
                                                 long minRetentionPeriod)
             throws StandardException {
 
@@ -488,7 +488,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                 partitionByRefItem,
                                                 defaultRowFunc,
                                                 defaultValueMapItem,
-                                                pastTxFunctor,
+                                                pastTxn,
                                                 minRetentionPeriod,
                                                 0);
     }
@@ -530,7 +530,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                 int partitionByRefItem,
                                                 GeneratedMethod defaultRowFunc,
                                                 int defaultValueMapItem,
-                                                GeneratedMethod pastTxFunctor,
+                                                long pastTxn,
                                                 long minRetentionPeriod,
                                                 int numUnusedLeadingIndexFields )
             throws StandardException {
@@ -575,7 +575,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     partitionByRefItem,
                     defaultRowFunc,
                     defaultValueMapItem,
-                    pastTxFunctor,
+                    pastTxn,
                     minRetentionPeriod,
                     numUnusedLeadingIndexFields);
             op.setExplainPlan(explainPlan);
@@ -625,7 +625,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                                                 int partitionByRefItem,
                                                 GeneratedMethod defaultRowFunc,
                                                 int defaultValueMapItem,
-                                                GeneratedMethod pastTxFunctor,
+                                                long pastTxn,
                                                 long minRetentionPeriod,
                                                 int numUnusedLeadingIndexFields )
             throws StandardException {
@@ -673,7 +673,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     partitionByRefItem,
                     defaultRowFunc,
                     defaultValueMapItem,
-                    pastTxFunctor,
+                    pastTxn,
                     minRetentionPeriod,
                     numUnusedLeadingIndexFields);
             op.setExplainPlan(explainPlan);
@@ -949,8 +949,8 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             partitionByRefItem,
             defaultRowFunc,
             defaultValueMapItem,
-            null,
-            -1 );
+            -1,
+            -1);
     }
 
     @Override
@@ -982,7 +982,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod ) throws StandardException {
         return getDistinctScanResultSet(
             activation,
@@ -1012,7 +1012,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             partitionByRefItem,
             defaultRowFunc,
             defaultValueMapItem,
-            pastTxFunctor,
+            pastTxn,
             minRetentionPeriod,
             0);
     }
@@ -1046,7 +1046,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod,
             int numUnusedLeadingIndexFields) throws StandardException {
         try{
@@ -1078,7 +1078,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     partitionByRefItem,
                     defaultRowFunc,
                     defaultValueMapItem,
-                    pastTxFunctor,
+                    pastTxn,
                     minRetentionPeriod,
                     numUnusedLeadingIndexFields);
             op.setExplainPlan(explainPlan);
@@ -1352,7 +1352,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod )
         throws StandardException {
 
@@ -1378,7 +1378,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             partitionByRefItem,
             defaultRowFunc,
             defaultValueMapItem,
-            pastTxFunctor, minRetentionPeriod, 0 );
+            pastTxn, minRetentionPeriod, 0 );
 
     }
 
@@ -1406,7 +1406,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
             int partitionByRefItem,
             GeneratedMethod defaultRowFunc,
             int defaultValueMapItem,
-            GeneratedMethod pastTxFunctor,
+            long pastTxn,
             long minRetentionPeriod,
             int numUnusedLeadingIndexFields)
             throws StandardException {
@@ -1454,7 +1454,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     partitionByRefItem,
                     defaultRowFunc,
                     defaultValueMapItem,
-                    pastTxFunctor,
+                    pastTxn,
                     minRetentionPeriod,
                     numUnusedLeadingIndexFields
                     );
@@ -2492,7 +2492,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     double optimizerEstimatedCost,
                     String tableVersion,
                     String explainPlan,
-                    GeneratedMethod pastTxFunctor,
+                    long pastTxFunctor,
                     long minRetentionPeriod
             ) throws StandardException {
         return getLastIndexKeyResultSet
@@ -2533,7 +2533,7 @@ public class SpliceGenericResultSetFactory implements ResultSetFactory {
                     double optimizerEstimatedCost,
                     String tableVersion,
                     String explainPlan,
-                    GeneratedMethod pastTxFunctor,
+                    long pastTxFunctor,
                     long minRetentionPeriod,
                     int numUnusedLeadingIndexFields
             ) throws StandardException {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/DistinctScanOperation.java
@@ -117,7 +117,7 @@ public class DistinctScanOperation extends ScanOperation {
                                  int partitionByRefItem,
                                  GeneratedMethod defaultRowFunc,
                                  int defaultValueMapItem,
-                                 GeneratedMethod pastTxFunctor,
+                                 long pastTxn,
                                  Long minRetentionPeriod,
                                  int numUnusedLeadingIndexFields) throws StandardException {
         super(conglomId,
@@ -141,7 +141,7 @@ public class DistinctScanOperation extends ScanOperation {
                 optimizerEstimatedCost,
                 tableVersion,
                 splits,delimited,escaped,lines,storedAs,location,partitionByRefItem,defaultRowFunc,defaultValueMapItem,
-                pastTxFunctor,
+                pastTxn,
                 minRetentionPeriod,
                 numUnusedLeadingIndexFields);
         this.hashKeyItem = hashKeyItem;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexPrefixIteratorOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/IndexPrefixIteratorOperation.java
@@ -118,7 +118,7 @@ public class IndexPrefixIteratorOperation extends TableScanOperation{
                               int partitionByRefItem,
                               GeneratedMethod defaultRowFunc,
                               int defaultValueMapItem,
-                              GeneratedMethod pastTxFunctor,
+                              long pastTxn,
                               long minRetentionPeriod,
                               int numUnusedLeadingIndexFields) throws StandardException{
                 super(conglomId, scoci, activation, resultRowAllocator, resultSetNumber, startKeyGetter,
@@ -128,7 +128,7 @@ public class IndexPrefixIteratorOperation extends TableScanOperation{
                       isolationLevel, rowsPerRead, oneRowScan, optimizerEstimatedRowCount,
                       optimizerEstimatedCost, tableVersion, splits, delimited, escaped,
                       lines, storedAs, location, partitionByRefItem, defaultRowFunc,
-                      defaultValueMapItem, pastTxFunctor, minRetentionPeriod, numUnusedLeadingIndexFields);
+                      defaultValueMapItem, pastTxn, minRetentionPeriod, numUnusedLeadingIndexFields);
         SpliceLogUtils.trace(LOG,"instantiated for tablename %s or indexName %s with conglomerateID %d",
                 tableName,indexName,conglomId);
         this.sourceResultSet = sourceResultSet;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/LastIndexKeyOperation.java
@@ -59,13 +59,13 @@ public class LastIndexKeyOperation extends ScanOperation {
         double optimizerEstimatedRowCount,
         double optimizerEstimatedCost,
         String tableVersion,
-        GeneratedMethod pastTxFunctor,
+        long pastTxn,
         long minRetentionPeriod,
         int numUnusedLeadingIndexFields) throws StandardException {
         super(conglomId, activation, resultSetNumber, null, -1, null, -1,
                 true, false, null, resultRowAllocator, lockMode, tableLocked, isolationLevel,
                 colRefItem, -1, false, optimizerEstimatedRowCount, optimizerEstimatedCost, tableVersion,
-                0, null, null, null, null, null, -1, null, -1, pastTxFunctor, minRetentionPeriod, numUnusedLeadingIndexFields);
+                0, null, null, null, null, null, -1, null, -1, pastTxn, minRetentionPeriod, numUnusedLeadingIndexFields);
         this.tableName = Long.toString(scanInformation.getConglomerateId());
         this.tableDisplayName = tableName;
         this.indexName = indexName;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/MultiProbeTableScanOperation.java
@@ -124,7 +124,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
                                         int partitionByRefItem,
                                         GeneratedMethod defaultRowFunc,
                                         int defaultValueMapItem,
-                                        GeneratedMethod pastTxFunctor,
+                                        long pastTxn,
                                         Long minRetentionPeriod,
                                         int numUnusedLeadingIndexFields)
             throws StandardException
@@ -167,7 +167,7 @@ public class MultiProbeTableScanOperation extends TableScanOperation  {
             partitionByRefItem,
             defaultRowFunc,
             defaultValueMapItem,
-            pastTxFunctor,
+            pastTxn,
             minRetentionPeriod,
             numUnusedLeadingIndexFields);
         this.inlistPosition = inlistPosition;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -134,7 +134,14 @@ public abstract class ScanOperation extends SpliceBaseOperation {
                 defaultValueMapItem,
                 numUnusedLeadingIndexFields
         );
-        this.pastTx = pastTxn;
+        if(pastTxn != -2) {
+            this.pastTx = pastTxn;
+            if(this.pastTx == -1) {
+                this.pastTx = SIConstants.OLDEST_TIME_TRAVEL_TX; // force going back to the oldest transaction instead of ignoring it.
+            }
+        } else {
+            this.pastTx = -1; // nothing is set, go ahead and use the latest transaction.
+        }
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9844")

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -101,7 +101,7 @@ public abstract class ScanOperation extends SpliceBaseOperation {
                          double optimizerEstimatedCost, String tableVersion,
                          int splits, String delimited, String escaped, String lines,
                          String storedAs, String location, int partitionRefItem, GeneratedMethod defaultRowFunc,
-                         int defaultValueMapItem, GeneratedMethod pastTxFunctor, long minRetentionPeriod,
+                         int defaultValueMapItem, long pastTxn, long minRetentionPeriod,
                          int numUnusedLeadingIndexFields
     ) throws StandardException{
         super(activation,resultSetNumber,optimizerEstimatedRowCount,optimizerEstimatedCost);
@@ -134,14 +134,7 @@ public abstract class ScanOperation extends SpliceBaseOperation {
                 defaultValueMapItem,
                 numUnusedLeadingIndexFields
         );
-        if(pastTxFunctor != null) {
-            this.pastTx = mapToTxId((DataValueDescriptor)pastTxFunctor.invoke(activation), minRetentionPeriod);
-            if(pastTx == -1){
-                pastTx = OLDEST_TIME_TRAVEL_TX; // force going back to the oldest transaction instead of ignoring it.
-            }
-        } else {
-            this.pastTx = -1; // nothing is set, go ahead and use the latest transaction.
-        }
+        this.pastTx = pastTxn;
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "DB-9844")
@@ -435,58 +428,6 @@ public abstract class ScanOperation extends SpliceBaseOperation {
     @Override
     public FormatableBitSet getAccessedColumns() throws StandardException{
         return scanInformation.getAccessedColumns();
-    }
-
-    private long mapToTxId(DataValueDescriptor dataValue, long minRetentionPeriod) throws StandardException {
-        try {
-            if (dataValue instanceof SQLTimestamp) {
-                Timestamp ts = ((SQLTimestamp) dataValue).getTimestamp(null);
-                SpliceLogUtils.trace(LOG, "time travel ts=%s", ts.toString());
-                if (minRetentionPeriod != -1) {
-                    if (within(minRetentionPeriod, ts)) {
-                        return SIDriver.driver().getTxnStore().getTxnAt(ts.getTime());
-                    } else {
-                        throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_OUTSIDE_MIN_RETENTION_PERIOD, minRetentionPeriod);
-                    }
-                } else {
-                    return SIDriver.driver().getTxnStore().getTxnAt(ts.getTime());
-                }
-            } else if (dataValue instanceof SQLTinyint || dataValue instanceof SQLSmallint || dataValue instanceof SQLInteger || dataValue instanceof SQLLongint) {
-                if(dataValue.isNull()) {
-                    throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_INVALID_PAST_TRANSACTION_ID, "null");
-                }
-                long pastTx = dataValue.getLong();
-                if(minRetentionPeriod != -1) {
-                    if(within(minRetentionPeriod, pastTx)) {
-                        return pastTx;
-                    } else {
-                        throw StandardException.newException(SQLState.LANG_TIME_TRAVEL_INVALID_PAST_TRANSACTION_ID, minRetentionPeriod);
-                    }
-                }
-                return dataValue.getLong();
-            } else {
-                throw StandardException.newException(SQLState.NOT_IMPLEMENTED, dataValue.getClass().getSimpleName() + " can not be used with time travel query"); // fix me, we should read SqlTime as well.
-            }
-        } catch (IOException e) {
-            throw Exceptions.parseException(e);
-        }
-    }
-
-    private static boolean within(long period, long pastTx) throws IOException {
-        if(pastTx < OLDEST_TIME_TRAVEL_TX) {
-            return false;
-        }
-        long mrpTx = SIDriver.driver().getTxnStore().getTxnAt(System.currentTimeMillis() - period * 1000);
-        return mrpTx <= pastTx;
-    }
-
-    private static boolean within(long period, Timestamp ts) {
-        // should we handle different calendars?
-        Timestamp currentTs = new Timestamp(System.currentTimeMillis());
-        if(ts.after(currentTs)) { // future time travel is no-op anyway
-            return true;
-        }
-        return ((System.currentTimeMillis() - ts.getTime()) / 1000) <= period;
     }
 
     /**

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/ScanOperation.java
@@ -134,9 +134,9 @@ public abstract class ScanOperation extends SpliceBaseOperation {
                 defaultValueMapItem,
                 numUnusedLeadingIndexFields
         );
-        if(pastTxn != -2) {
+        if(pastTxn != TransactionController.TIME_TRAVEL_UNSET) {
             this.pastTx = pastTxn;
-            if(this.pastTx == -1) {
+            if(this.pastTx == TransactionController.TIME_TRAVEL_OLDEST) {
                 this.pastTx = SIConstants.OLDEST_TIME_TRAVEL_TX; // force going back to the oldest transaction instead of ignoring it.
             }
         } else {

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/operations/TableScanOperation.java
@@ -168,14 +168,14 @@ public class TableScanOperation extends ScanOperation{
                               int partitionByRefItem,
                               GeneratedMethod defaultRowFunc,
                               int defaultValueMapItem,
-                              GeneratedMethod pastTxFunctor,
+                              long pastTxn,
                               long minRetentionPeriod,
                               int numUnusedLeadingIndexFields) throws StandardException{
         super(conglomId,activation,resultSetNumber,startKeyGetter,startSearchOperator,stopKeyGetter,stopSearchOperator,
                 sameStartStopPosition,rowIdKey,qualifiersField,resultRowAllocator,lockMode,tableLocked,isolationLevel,
                 colRefItem,indexColItem,oneRowScan,optimizerEstimatedRowCount,optimizerEstimatedCost,tableVersion,
                 splits,delimited,escaped,lines,storedAs,location,partitionByRefItem,defaultRowFunc,defaultValueMapItem,
-                pastTxFunctor, minRetentionPeriod, numUnusedLeadingIndexFields);
+              pastTxn, minRetentionPeriod, numUnusedLeadingIndexFields);
         SpliceLogUtils.trace(LOG,"instantiated for tablename %s or indexName %s with conglomerateID %d",
                 tableName,indexName,conglomId);
         this.forUpdate=forUpdate;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/store/access/SpliceTransactionManager.java
@@ -34,9 +34,11 @@ import com.splicemachine.db.impl.store.access.conglomerate.ConglomerateUtil;
 import com.splicemachine.derby.ddl.DDLUtils;
 import com.splicemachine.derby.impl.stats.StoreCostControllerImpl;
 import com.splicemachine.derby.utils.ConglomerateUtils;
+import com.splicemachine.pipeline.Exceptions;
 import com.splicemachine.primitives.Bytes;
 import com.splicemachine.si.api.txn.Txn;
 import com.splicemachine.si.api.txn.TxnView;
+import com.splicemachine.si.constants.SIConstants;
 import com.splicemachine.si.impl.driver.SIDriver;
 import com.splicemachine.si.impl.txn.ReadOnlyTxn;
 import com.splicemachine.utils.SpliceLogUtils;
@@ -45,6 +47,7 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.sql.Timestamp;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -2038,5 +2041,37 @@ public class SpliceTransactionManager implements XATransactionController,
     @Override
     public void recoverPropertyConglomerateIfNecessary() throws StandardException {
         accessmanager.getTransactionalProperties().recoverPropertyConglomerateIfNecessary(this);
+    }
+
+    @Override
+    public long getTxnAt(long ts) throws StandardException {
+        try {
+            return SIDriver.driver().getTxnStore().getTxnAt(ts);
+        } catch (IOException e) {
+            throw Exceptions.parseException(e);
+        }
+    }
+
+    @Override
+    public boolean txnWithin(long period, long pastTx) throws StandardException {
+        if(pastTx < SIConstants.OLDEST_TIME_TRAVEL_TX) {
+            return false;
+        }
+        long mrpTx = 0;
+        try {
+            mrpTx = SIDriver.driver().getTxnStore().getTxnAt(System.currentTimeMillis() - period * 1000);
+        } catch (IOException e) {
+            throw Exceptions.parseException(e);
+        }
+        return mrpTx <= pastTx;
+    }
+
+    @Override
+    public boolean txnWithin(long period, Timestamp pastTx) throws StandardException {
+        Timestamp currentTs = new Timestamp(System.currentTimeMillis());
+        if (pastTx.after(currentTs)) { // future time travel is no-op anyway
+            return true;
+        }
+        return ((System.currentTimeMillis() - pastTx.getTime()) / 1000) <= period;
     }
 }

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
@@ -566,23 +566,6 @@ public class SelectTimeTravelIT {
         }
     }
 
-    @Test
-    public void testTimeTravelFailsWithProperErrorMessageIfAsOfExpressionConstantEvaluationIsNotSupportedYet() throws Exception {
-        String someTable = generateTableName();
-        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
-        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
-        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
-        try {
-            watcher.executeQuery(String.format("SELECT * FROM %s AS OF TIMESTAMPADD(SQL_TSI_MONTH, 1+1, TIMESTAMP('2020-12-12 01:02:03.45678')) ORDER BY a1 ASC", someTable));
-            Assert.fail();
-        } catch(Exception e) {
-            Assert.assertTrue(e instanceof SQLException);
-            SQLException sqlException = (SQLException)e;
-            Assert.assertEquals("0A000", sqlException.getSQLState());
-            Assert.assertTrue(e.getMessage().contains("Evaluation of constant expression of type BinaryArithmeticOperatorNode is not supported"));
-        }
-    }
-
     @Test // see DB-12236
     public void testTimeTravelFailsWithProperErrorMessageIfAsOfExpressionContainingCurrentTimestampIsNotSupportedYet() throws Exception {
         String someTable = generateTableName();

--- a/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/impl/sql/execute/operations/SelectTimeTravelIT.java
@@ -531,4 +531,111 @@ public class SelectTimeTravelIT {
             Assert.assertFalse(rs.next());
         }
     }
+
+    @Test
+    public void testTimeTravelWithTimestampAddFunction() throws Exception {
+        String someTable = generateTableName();
+        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
+        String initialTime = serverTimestamp();
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
+        try(ResultSet rs = watcher.executeQuery(String.format("SELECT * FROM %s AS " +
+                                                              "OF TIMESTAMPADD(SQL_TSI_MONTH, 1, TIMESTAMP('%s')) ORDER BY a1 ASC", someTable, initialTime))) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(1, rs.getInt(1));
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(2, rs.getInt(1));
+            Assert.assertFalse(rs.next());
+        }
+    }
+
+    @Test
+    public void testTimeTravelFailsWithProperErrorMessageIfAsOfExpressionIsNotConstant() throws Exception {
+        String someTable = generateTableName();
+        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
+        try {
+            watcher.executeQuery(String.format("SELECT * FROM %s AS OF CURRENT_TIMESTAMP ORDER BY a1 ASC", someTable));
+            Assert.fail();
+        } catch(Exception e) {
+            Assert.assertTrue(e instanceof SQLException);
+            SQLException sqlException = (SQLException)e;
+            Assert.assertEquals("42ZD2", sqlException.getSQLState());
+            Assert.assertTrue(e.getMessage().contains("Using time travel clause with not-constant expression is not allowed"));
+        }
+    }
+
+    @Test
+    public void testTimeTravelFailsWithProperErrorMessageIfAsOfExpressionConstantEvaluationIsNotSupportedYet() throws Exception {
+        String someTable = generateTableName();
+        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
+        try {
+            watcher.executeQuery(String.format("SELECT * FROM %s AS OF TIMESTAMPADD(SQL_TSI_MONTH, 1+1, TIMESTAMP('2020-12-12 01:02:03.45678')) ORDER BY a1 ASC", someTable));
+            Assert.fail();
+        } catch(Exception e) {
+            Assert.assertTrue(e instanceof SQLException);
+            SQLException sqlException = (SQLException)e;
+            Assert.assertEquals("0A000", sqlException.getSQLState());
+            Assert.assertTrue(e.getMessage().contains("Evaluation of constant expression of type BinaryArithmeticOperatorNode is not supported"));
+        }
+    }
+
+    @Test
+    public void testTimeTravelWithIndexWorksProperly() throws Exception {
+        String someTable = generateTableName();
+        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
+        int mrp = 20; // seconds
+        watcher.execute(String.format("CALL SYSCS_UTIL.SET_MIN_RETENTION_PERIOD('%s', '%s', %d)", SCHEMA, someTable, mrp));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        String initialTime = serverTimestamp();
+        watcher.executeUpdate(String.format("DELETE FROM %s", someTable));
+        String someIndex = generateTableName();
+        Thread.sleep(1000);
+        watcher.executeUpdate(String.format("CREATE INDEX %s ON %s(a1)", someIndex, someTable));
+        try(ResultSet rs = watcher.executeQuery(String.format("SELECT * FROM %s AS " +
+                                                              "OF TIMESTAMP('%s') WHERE a1 > 1 ORDER BY a1 ASC", someTable, initialTime))) {
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(2, rs.getInt(1));
+            Assert.assertFalse(rs.next());
+        }
+        // the optimizer must not select IndexLookup here
+        try(ResultSet rs = watcher.executeQuery(String.format("EXPLAIN SELECT * FROM %s AS " +
+                                                                      "OF TIMESTAMP('%s') WHERE a1 > 1 ORDER BY a1 ASC", someTable, initialTime))) {
+            while(rs.next()) {
+                Assert.assertFalse(rs.getString(1).contains("IndexLookup"));
+            }
+        }
+    }
+
+    @Test
+    public void testTimeTravelFailsWithProperErrorMessageIfAttemptedToForceUseIndexWithTemporalInconsistency() throws Exception {
+        String someTable = generateTableName();
+        watcher.executeUpdate(String.format("CREATE TABLE %s(a1 INT)", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 2", someTable));
+        int mrp = 20; // seconds
+        watcher.execute(String.format("CALL SYSCS_UTIL.SET_MIN_RETENTION_PERIOD('%s', '%s', %d)", SCHEMA, someTable, mrp));
+        watcher.executeUpdate(String.format("INSERT INTO %s VALUES 1", someTable));
+        String initialTime = serverTimestamp();
+        watcher.executeUpdate(String.format("DELETE FROM %s", someTable));
+        String someIndex = generateTableName();
+        Thread.sleep(1000);
+        watcher.executeUpdate(String.format("CREATE INDEX %s ON %s(a1)", someIndex, someTable));
+        try {
+            watcher.executeQuery(String.format("EXPLAIN SELECT * FROM %s AS " +
+                                                       "OF TIMESTAMP('%s') --splice-properties index=%s\n", someTable, initialTime, someIndex));
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof SQLException);
+            SQLException sqlException = (SQLException) e;
+            Assert.assertEquals("42Z03", sqlException.getSQLState());
+            Assert.assertTrue(e.getMessage().contains(String.format("Specified index '%s' is created at tx", someIndex)));
+            Assert.assertTrue(e.getMessage().contains("which is after time-travel mapped past transaction id"));
+        }
+    }
 }


### PR DESCRIPTION
## Short Description
In this PR, we target a subtle inconsistency caused by time-travel allowing the optimizer to choose a temporal-inconsistent index, causing wrong results to be returned.

## Long Description

With time-travel, the user view the historical data of a table within a min. retention period. It could happen that the optimizer prefers an AccessPath involving an index conglomerate that is created _after_ the past transaction ID which is dangerous, because the base table could have changed between the past transaction ID and the index creation time (e.g. some rows are deleted before the index was created), if the optimizer chooses that index conglomerate we will get empty results because the index does not have any data at the past transaction ID since it was created after it.

To fix this issue we make sure, during optimization and when deciding whether an index access path is eligible or not, that the index's creation time precedes the past transaction ID, and only accept it in that case.

To achieve this, I implemented the following changes in this PR:

1. Add API extensions to `DataDictionary` that allows, for a given conglomerate, to return its creation transaction ID from the conglomerate's metadata.
2. Move `AS OF` expression evaluation from execution time to binding phase, since it is crucial to know upfront the past transaction ID during optimization to figure out whether an index is eligible or not by comparing it to the index's creation transaction ID.
3. Limit `AS OF` to expressions that can be evaluated at binding phase, for now, we limit to the subset of constant expressions, but in the future we can extend it to more expressions.
4. Implement constant evaluation for expressions that are used quite often with `AS OF`, i.e. the `TIMESTAMP` expression (in `UnaryDateTimestampOperatorNode`) and `TIMESTAMPADD` expression (in `TernaryOperatorNode`).
5. Throw a proper error message if the user attempts to force a temporal-inconsistent index.

With this fix, the optimizer is able now to choose valid indices that are temporal-consistent if an `AS OF` expression is present.

## How to test

Here is a quick example:

```sql


create table t1(col1 int);
insert into t1 values 42, 42;
CALL SYSCS_UTIL.SYSCS_GET_CURRENT_TRANSACTION();
txnId
----

19200

delete from t1;
alter table t1 add constraint c1  unique(col1);

select * from t1 as of 19200;
COL1
-----------
42
42

select * from t1 as of 19200 where col1 >= 42; –- wrong result
COL1
-----------

-– because we are using the newly introduced index, which is empty
explain select * from t1 as of 19200> where col1 >= 42;
Plan
-------------------------------------------------------------------
Cursor(n=3,rows=18,updateMode=READ_ONLY (1),engine=OLTP (default))
   ->  ScrollInsensitive(n=3,totalCost=8.216,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1)
    ->  IndexScan[SQLA35EC2CE0178AC35AAF500000B960C28(1729)] (n=0,totalCost=4.036,scannedRows=18,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1,baseTable=T1(1712),preds=[(COL1[0:1] >= 42)]) 
    
-- with the fix we get the correct results, since the index was not chosen!
select * from t1 as of 19200 where col1 >= 42;
COL1
-----------
42
42

explain select * from t1 as of 19200 where col1 >= 42;

Cursor(n=3,rows=18,updateMode=READ_ONLY (1),engine=OLTP (default))
  ->  ScrollInsensitive(n=3,totalCost=8.22,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1)
    ->  TableScan[T1(2512)](n=0,totalCost=4.04,scannedRows=20,outputRows=18,outputHeapSize=18 B,partitions=1,parallelTasks=1,preds=[(COL1[0:1] >= 42)])
Table statistics are missing or skipped for the following tables:
SPLICE.T1

-- moreover, force-using the index throws an error now:

select * from t1 as of 19200 --splice-properties index=i1
where col1 >= 42;
ERROR 42Z03: Specified index 'I1' is created at tx '21042' which is after time-travel mapped past transaction id '19200'.
```
