### PR TITLE
DB-12306: fix a drop column regression - drop columns doesn't drop related trigger

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -756,7 +756,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
 
         int maxStoragePosition = tableDescriptor.getColumnDescriptorList().maxStoragePosition();
         int size = tableDescriptor.getColumnDescriptorList().size();
-        int droppedColumnPosition = columnDescriptor.getStoragePosition();
+        int droppedColumnPosition = columnDescriptor.getPosition();
 
         FormatableBitSet toDrop = new FormatableBitSet(maxStoragePosition + 1);
         toDrop.set(droppedColumnPosition);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Fix a regression caused by DB-9898

## Long Description
DB-9898 incorrectly tries to find out whether column is referenced by a trigger by using storage position. The reference column number is a relative position and being updated if other columns are dropped. This PR reverts previous change and use relative position instead.

## How to test
create table m(id int, col1 int, col2 int, col3 int, col4 char(50), col5 varchar(100));
create table s(id int ,description varchar(100),tm_time timestamp);

CREATE TRIGGER tr1 AFTER UPDATE of col1,col2 ON m FOR EACH STATEMENT insert into s values(7,'TR1',CURRENT_TIMESTAMP);
CREATE TRIGGER tr2 AFTER UPDATE of col2 ON m FOR EACH STATEMENT insert into s values(6,'TR2',CURRENT_TIMESTAMP);

alter table m drop col1;
alter table m drop col2;

-- Verify the above two DDL drops triggers

select count(TRIGGERNAME) FROM SYS.SYSTRIGGERS WHERE TABLEID=(select tableid from sys.systables where tablename='M' and schemaid=(select schemaid from sys.sysschemas where schemaname='SPLICE'));