### PR TITLE
DB-12133 Fix predicate packing logic for multiple IN lists MultiProbeScan

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/PredicateList.java
@@ -1374,13 +1374,13 @@ public class PredicateList extends QueryTreeNodeVector<Predicate> implements Opt
                     // Pack the remaining useful preds in usefulPredicates so
                     // there are no gaps.
                     int j = firstPred + 1;
-                    for (int i = firstPred + 1; i < usefulCount; i++) {
+                    for (int i = firstPred + 1; i < usefulCount && j < usefulCount; i++) {
                         while(i < usefulCount && foundPred[i])
                             i++;
                         if (i != j && i < usefulCount) {
                             usefulPredicates[j] = usefulPredicates[i];
-                            j++;
                         }
+                        j++;
                     }
                     usefulCount -= (predsForNewInList.size() - 1);
                 }


### PR DESCRIPTION
                        j++;## Short Description
Fixes loss of a predicate during packing of useful MultiProbeScan predicates

## Long Description
When we have a tables such as:
    create table t1
    (a1 int, b1 int, c1 int, primary key (a1, b1, c1));
    create table t2
    (a2 int, b2 int, c2 int, primary key (a2, b2, c2));

...and a query such as :
    select a1, t2.a2 from t1 INNER JOIN t2 on t1.a1=t2.a2 
    where a1=(SELECT MAX(a2) FROM t2   )   and  a1 in (0,1,2) 
    and b1 in (0,1,2,3,4,5) and c1 in (0,1,2,3,4,5,6,7,8) order by t2.a2;

The 3 IN list predicates may be collected into a usefulPredicates array, along with pushable predicate t1.a1=t2.a2.
The IN list predicates are then combined into one a single multicolumn IN list, and the usefulPredicates is packed into a smaller size, removing the original IN predicates.  This logic is faulty and does not increment variable "j" when the source and destination position in usefulPredicates are identical, so the predicate t1.a1=t2.a2 which enables a hashable join is lost:

>                     for (int i = firstPred + 1; i < usefulCount && j < usefulCount; i++) {
>                         while(i < usefulCount && foundPred[i])
>                             i++;
>                         if (i != j && i < usefulCount) {
>                             usefulPredicates[j] = usefulPredicates[i];
>                             j++;
>                         }

The solution is to move the incrementing of j outside of the conditional code which skips NoOp assignments.

## How to test
The following test case should not error out:

>     create table t1
>     (a1 int, b1 int, c1 int, primary key (a1, b1, c1));
> 
>     create table t2
>     (a2 int, b2 int, c2 int, primary key (a2, b2, c2));
> 
>     select a1, t2.a2 from t1 INNER JOIN t2 on t1.a1=t2.a2 
>     where a1=(SELECT MAX(a2) FROM t2   )   and  a1 in (0,1,2) 
>     and b1 in (0,1,2,3,4,5) and c1 in (0,1,2,3,4,5,6,7,8) order by t2.a2;
> 