### PR TITLE
DB-12350 fix build error in ModifyColumnConstantOperation (3.1)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -1453,7 +1453,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
         }
 
         for (ViewDescriptor vd : views) {
-            TableDescriptor viewTd = dd.getTableDescriptor(vd.getUUID());
+            TableDescriptor viewTd = dd.getTableDescriptor(vd.getUUID(), activation.getTransactionController());
 
             if (viewTd == null) {
                 // already dropped via another dependency


### PR DESCRIPTION
DB-12224 changed the API for DataDictionary.getTableDescriptor, and DB-12158 still used the old API, so this is fixing this build error.