### PR TITLE
DB-12129 support showing region info in SpliceCK

### DIFF
--- a/splice_ck/src/main/java/com/splicemachine/ck/Constants.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/Constants.java
@@ -69,4 +69,15 @@ public class Constants {
 
     public static final String HBASE_CONFIGURATION_ZOOKEEPER_QUORUM = "hbase.zookeeper.quorum";
     public static final String HBASE_CONFIGURATION_ZOOKEEPER_CLIENTPORT = "hbase.zookeeper.property.clientPort";
+
+    public final static String TBL_REGION_COL0 = "index";
+    public final static String TBL_REGION_COL1 = "name";
+    public final static String TBL_REGION_COL2 = "offline";
+    public final static String TBL_REGION_COL3 = "start";
+    public final static String TBL_REGION_COL4 = "stop";
+    public final static String TBL_REGION_COL5 = "host";
+    public final static String TBL_REGION_COL6 = "HFile count";
+    public final static String TBL_REGION_COL7 = "HFile size";
+    public final static String TBL_REGION_COL8 = "MemStore size";
+    public final static String TBL_REGION_COL9 = "last major compaction";
 }

--- a/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/HBaseInspector.java
@@ -258,9 +258,9 @@ public class HBaseInspector {
             throw new IOException(String.format("could not find region information for table %s.%s", schemaName, tableName));
         }
         regions.sort((lhs, rhs) -> Bytes.compareTo(lhs.getStartKey(), rhs.getStartKey()));
-        Utils.Tabular tabular = new Utils.Tabular(Utils.Tabular.SortHint.AsInteger, "Index", "RegionName",
-                                                  "Offline?", "Start", "Stop", "Host", "HFile count", "HFile size",
-                                                  "MemStore size", "Latest Major Compaction");
+        Utils.Tabular tabular = new Utils.Tabular(Utils.Tabular.SortHint.AsInteger, TBL_REGION_COL0, TBL_REGION_COL1,
+                                                  TBL_REGION_COL2, TBL_REGION_COL3, TBL_REGION_COL4, TBL_REGION_COL5,
+                                                  TBL_REGION_COL6, TBL_REGION_COL7, TBL_REGION_COL8, TBL_REGION_COL9);
         int i = 0;
         for (RegionInfo region : regions) {
             Pair<ServerName, RegionMetrics> regionMetrics = regionMetrices.get(region.getRegionNameAsString());

--- a/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/Utils.java
@@ -83,8 +83,6 @@ public class Utils {
                 this.cols = Arrays.asList(cols);
             }
 
-
-
             @Override
             public int compareTo(Row o) {
                 if(o == null) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/ConglomOfCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/ConglomOfCommand.java
@@ -22,12 +22,12 @@ import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
-@CommandLine.Command(name = "regionof",
+@CommandLine.Command(name = "conglomof",
         descriptionHeading = "Description:%n",
-        description = "retrieve HBase region(s) of SpliceMachine table",
+        description = "retrieve HBase conglomerate of SpliceMachine table",
         parameterListHeading = "Parameters:%n",
         optionListHeading = "Options:%n")
-public class RegionOfCommand extends CommonOptions implements Callable<Integer> {
+public class ConglomOfCommand extends CommonOptions implements Callable<Integer> {
 
     @CommandLine.Parameters(index = "0", description = "SpliceMachine schema name")
     String schema;
@@ -40,7 +40,7 @@ public class RegionOfCommand extends CommonOptions implements Callable<Integer> 
             HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
             table = EngineUtils.validateTable(table);
             schema = EngineUtils.validateSchema(schema);
-            System.out.println(hbaseInspector.regionsOf(schema, table));
+            System.out.println(hbaseInspector.conglomOf(schema, table));
             return 0;
         } catch (Exception e) {
             System.out.println(Utils.checkException(e, table));

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/RootCommand.java
@@ -27,8 +27,8 @@ import java.util.Scanner;
 @Command(mixinStandardHelpOptions = true, name = "spliceck", description = "SpliceMachine check command suite",
         descriptionHeading = "Description:%n",
         optionListHeading = "Options:%n", subcommands = {TListCommand.class,
-        TColsCommand.class, RegionOfCommand.class, TableOfCommand.class, RGetCommand.class, RPutCommand.class,
-        TxListCommand.class, SListCommand.class})
+        TColsCommand.class, ConglomOfCommand.class, RegionOfCommand.class, TableOfCommand.class, RGetCommand.class,
+        RPutCommand.class, TxListCommand.class, SListCommand.class})
 class RootCommand {
     @SuppressFBWarnings("DM_DEFAULT_ENCODING") // intentional
     public static void main(String... args) {

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/TColsCommand.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/TColsCommand.java
@@ -37,7 +37,7 @@ public class TColsCommand extends CommonOptions implements Callable<Integer> {
             HBaseInspector hbaseInspector = new HBaseInspector(Utils.constructConfig(zkq, port));
             table = EngineUtils.validateTable(table);
             schema = EngineUtils.validateSchema(schema);
-            System.out.println(Utils.printTabularResults(hbaseInspector.columnsOf(hbaseInspector.regionOf(schema, table))));
+            System.out.println(Utils.printTabularResults(hbaseInspector.columnsOf(hbaseInspector.conglomOf(schema, table))));
             return 0;
         } catch (Exception e) {
             System.out.println(Utils.checkException(e, table));

--- a/splice_ck/src/main/java/com/splicemachine/ck/command/common/TableNameGroup.java
+++ b/splice_ck/src/main/java/com/splicemachine/ck/command/common/TableNameGroup.java
@@ -5,8 +5,6 @@ import com.splicemachine.derby.utils.EngineUtils;
 import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
 
-import java.sql.SQLException;
-
 public class TableNameGroup {
     @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
     public OptionallyQualifiedTableName qualifiedTableName;
@@ -18,7 +16,7 @@ public class TableNameGroup {
         if(qualifiedTableName != null) {
             qualifiedTableName.table = EngineUtils.validateTable(qualifiedTableName.table);
             qualifiedTableName.schema = EngineUtils.validateSchema(qualifiedTableName.schema);
-            return hbaseInspector.regionOf(qualifiedTableName.schema, qualifiedTableName.table);
+            return hbaseInspector.conglomOf(qualifiedTableName.schema, qualifiedTableName.table);
         } else {
             if(StringUtils.isNumeric(region)) {
                 return "splice:" + region;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
In this PR we introduce a new command that views information of table regions.

## Long Description
The previous command `regionof` is repurposed to show table region information such as HFiles, byte size, start, stop, host, ... etc (check the example output below for more information), the old command semantics are put in a new command called `conglomof`.

## How to test

Here is an example output of the command:

```
spliceck> regionof splice t1
index     name                                 offline     start     stop     host                HFile count     HFile size     MemStore size     last major compaction
===============================================================================================================================================================================
0         d46dafc2990b31d68982c902e8c1d923     false                 C096     localhost:52747     0               0.0MB          0.0MB             never compacted
1         55a59e79a89b48e86cc2add774453712     false       C096      C2A4     localhost:52747     0               0.0MB          0.0MB             never compacted
2         98ec6c22fece60bccab5f8a23d000dc9     false       C2A4               localhost:52747     1               1.0MB          0.0MB             2021-07-15 18:37:13.783
```
