### PR TITLE
Add artifact stage (2.8)

### DIFF
--- a/pipelines/spot-bugs/Jenkinsfile
+++ b/pipelines/spot-bugs/Jenkinsfile
@@ -2,6 +2,99 @@ def vault_addr="https://vault.build.splicemachine-dev.io"
 def branch = ""
 def source_branch = ""
 
+
+def stages = [failFast: true]
+
+def generateStage(platform) { 
+    return {
+
+        def artifact_values  = [
+            [$class: 'VaultSecret', path: "secret/aws/jenkins/colo_jenkins", secretValues: [
+                [$class: 'VaultSecretValue', envVar: 'ARTIFACT_USER', vaultKey: 'user'],
+                [$class: 'VaultSecretValue', envVar: 'ARTIFACT_PASSWORD', vaultKey: 'pass']]]
+        ]
+
+        stage("Artifact: ${platform}") {
+        node('splice-standalone'){
+            try {
+                source_branch = "${CHANGE_BRANCH}"
+            } catch (Exception e) {
+                source_branch = "${BRANCH_NAME}"
+            }
+            checkout([  
+                $class: 'GitSCM', 
+                branches: [[name: source_branch]], 
+                doGenerateSubmoduleConfigurations: false, 
+                extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine']], 
+                submoduleCfg: [], 
+                userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/spliceengine.git']]
+            ])
+            try{
+                checkout([  
+                    $class: 'GitSCM', 
+                    branches: [[name: source_branch]],
+                    doGenerateSubmoduleConfigurations: false, 
+                    extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
+                    submoduleCfg: [], 
+                    userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/spliceengine-ee.git']]
+                ])
+            } catch (Exception e) {
+                dir('spliceengine'){
+                    branch = source_branch[-2..-1]
+                    
+                    if ( "$branch" == ".7" ) {
+                        branch = "branch-2.7"
+                    } else if ( "$branch" == ".8" ) {
+                        branch = "branch-2.8"
+                    } else if ( "$branch" == ".0" ) {
+                        branch = "branch-3.0"
+                    } else if ( "$branch" == ".1" ) {
+                        branch = "branch-3.1"
+                    } else {
+                        branch = "master"
+                    }
+                    sh "cd .."
+                }
+                checkout([  
+                    $class: 'GitSCM', 
+                    branches: [[name: branch]], 
+                    doGenerateSubmoduleConfigurations: false, 
+                    extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'spliceengine-ee']], 
+                    submoduleCfg: [], 
+                    userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/spliceengine-ee.git']]
+                ])
+            }
+
+            wrap([$class: 'VaultBuildWrapper', vaultSecrets: artifact_values]) {
+                    // Run Maven on a Unix agent.
+                    dir('spliceengine'){
+                        sh """
+                        export MAVEN_OPTS="-Xmx4096m -Djava.awt.headless=true -Xms64m -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=30 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=YYYY-MM-dd|HH:mm:ss,SSS"
+                        mvn -B -e --fail-at-end clean install -DskipTests
+                        cp pipelines/template/settings.xml ~/.m2/settings.xml
+                        sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
+                        sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
+
+                        if [[ "${platform}" =~ ^mem ]] ; then
+                            profiles="core,mem"
+                        elif [[ "${platform}" =~ ^cdh ]] ; then
+                            profiles="core,ee,parcel,${platform}"
+                        elif [[ "${platform}" =~ ^hdp ]] ; then
+                            profiles="core,ee,hdp_service,${platform}"
+                        else
+                            profiles="core,ee,${platform}"
+                        fi
+
+                        mvn -B -e --fail-at-end package -P\$profiles -DskipTests
+                        """
+                    }
+                }
+            }
+        }
+    }
+}
+
+
 // Launch the docker container
 node('splice-standalone') {
 
@@ -19,6 +112,23 @@ node('splice-standalone') {
         source_branch = "${CHANGE_BRANCH}"
     } catch (Exception e) {
         source_branch = "${BRANCH_NAME}"
+    }
+    def releases = []
+    def artifact_branch = source_branch[-2..-1]
+    if ( "$artifact_branch" == ".7" ) {
+        releases = ["cdh5.16.1","hdp2.6.5"]
+    } else if ( "$artifact_branch" == ".8" ) {
+        releases = ["cdh5.16.1","hdp2.6.5"]
+    } else if ( "$artifact_branch" == ".0" ) {
+        releases = ["cdh6.3.0","dbaas3.0","dbaas3.1","hdp3.1.0","hdp3.1.5"]
+    } else if ( "$artifact_branch" == ".1" ) {
+        releases = ["cdh6.3.0","dbaas3.0","dbaas3.1","hdp3.1.0","hdp3.1.5"]
+    } else {
+        releases = ["cdh6.3.0","dbaas3.0","dbaas3.1","hdp3.1.0","hdp3.1.5"]
+    }
+
+    def parallelStagesMap = releases.collectEntries {
+        ["${it}" : generateStage(it)]
     }
 
     echo source_branch
@@ -47,14 +157,16 @@ node('splice-standalone') {
                 branch = source_branch[-2..-1]
                 
                 if ( "$branch" == ".7" ) {
-                        branch = "branch-2.7"
-                    } else if ( "$branch" == ".8" ) {
-                        branch = "branch-2.8"
-                    } else if ( "$branch" == ".0" ) {
-                        branch = "branch-3.0"
-                    } else {
-                        branch = "master"
-                    }
+                    branch = "branch-2.7"
+                } else if ( "$branch" == ".8" ) {
+                    branch = "branch-2.8"
+                } else if ( "$branch" == ".0" ) {
+                    branch = "branch-3.0"
+                } else if ( "$branch" == ".1" ) {
+                    branch = "branch-3.1"
+                } else {
+                    branch = "master"
+                }
                 sh "cd .."
             }
             checkout([  
@@ -74,23 +186,26 @@ node('splice-standalone') {
                 if ( "$branch" == ".7" ) {
                             platforms = "cdh5.14.2"
                             branch = "branch-2.7"
-                        } else if ( "$branch" == ".8" ) {
-                            platforms = "cdh5.14.2"
-                            branch = "branch-2.8"
-                        } else if ( "$branch" == ".0" ) {
-                            platforms = "cdh6.3.0"
-                            branch = "branch-3.0"
-                        } else {
-                            platforms = "cdh5.14.2"
-                            branch = "master"
-                        }
-                sh "mvn -B clean install -Pcore -DskipTests"
-                sh '''
+                } else if ( "$branch" == ".8" ) {
+                    platforms = "cdh5.14.2"
+                    branch = "branch-2.8"
+                } else if ( "$branch" == ".0" ) {
+                    platforms = "cdh6.3.0"
+                    branch = "branch-3.0"
+                } else if ( "$branch" == ".1" ) {
+                    platforms = "cdh6.3.0"
+                    branch = "branch-3.1"
+                } else {
+                    platforms = "cdh6.3.0"
+                    branch = "master"
+                }
+                sh "mvn -B clean install -DskipTests"
+                sh """
                 cp pipelines/template/settings.xml ~/.m2/settings.xml
                 sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                 sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
-                '''
-                sh "mvn -B clean install -Pmem,$platforms,ee -DskipTests"
+                """
+                sh "mvn -B clean install -Pmem,core,$platforms,ee -DskipTests"
             }
         }
       }
@@ -101,17 +216,20 @@ node('splice-standalone') {
           branch = source_branch[-2..-1]
 
           if ( "$branch" == ".7" ) {
-                        platforms = "cdh5.14.2"
-                        branch = "branch-2.7"
-                    } else if ( "$branch" == ".8" ) {
-                        platforms = "cdh5.14.2"
-                        branch = "branch-2.8"
-                    } else if ( "$branch" == ".0" ) {
-                        platforms = "cdh6.3.0"
-                        branch = "branch-3.0"
-                    } else {
-                        platforms = "cdh5.14.2"
-                        branch = "master"
+                platforms = "cdh5.14.2"
+                branch = "branch-2.7"
+            } else if ( "$branch" == ".8" ) {
+                platforms = "cdh5.14.2"
+                branch = "branch-2.8"
+            } else if ( "$branch" == ".0" ) {
+                platforms = "cdh6.3.0"
+                branch = "branch-3.0"
+            } else if ( "$branch" == ".1" ) {
+                platforms = "cdh6.3.0"
+                branch = "branch-3.1"
+            } else {
+                platforms = "cdh6.3.0"
+                branch = "master"
             }
 
           def errors = sh "./pipelines/spot-bugs/runSpotbugs.sh $platforms $branch"
@@ -120,6 +238,13 @@ node('splice-standalone') {
             }
           }
       }
+    
+    stage('Check Artifacts') {
+      dir('spliceengine'){
+          parallel parallelStagesMap
+      }
+    }
+
     } catch (any) {
         // if there was an exception thrown, the build failed
         currentBuild.result = "FAILED"

--- a/pipelines/spot-bugs/Jenkinsfile
+++ b/pipelines/spot-bugs/Jenkinsfile
@@ -74,7 +74,11 @@ def generateStage(platform) {
                         cp pipelines/template/settings.xml ~/.m2/settings.xml
                         sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                         sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
-
+                        wget https://repository.mapr.com/nexus/content/groups/mapr-public/conjars/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar
+                        wget https://repository.mapr.com/nexus/content/groups/mapr-public/conjars/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom
+                        mvn install:install-file -Dfile=pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar -DgroupId=org.pentaho -DartifactId=pentaho-aggdesigner-algorithm -Dversion=5.1.5-jhyde -Dpackaging=jar
+                        mvn install:install-file -Dfile=pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom -DgroupId=org.pentaho -DartifactId=pentaho-aggdesigner-algorithm -Dversion=5.1.5-jhyde -Dpackaging=pom
+                        
                         if [[ "${platform}" =~ ^mem ]] ; then
                             profiles="core,mem"
                         elif [[ "${platform}" =~ ^cdh ]] ; then
@@ -204,6 +208,10 @@ node('splice-standalone') {
                 cp pipelines/template/settings.xml ~/.m2/settings.xml
                 sed  -i "s/REPLACE_USER/$ARTIFACT_USER/" ~/.m2/settings.xml
                 sed  -i "s/REPLACE_PASS/$ARTIFACT_PASSWORD/" ~/.m2/settings.xml
+                wget https://repository.mapr.com/nexus/content/groups/mapr-public/conjars/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar
+                wget https://repository.mapr.com/nexus/content/groups/mapr-public/conjars/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom
+                mvn install:install-file -Dfile=pentaho-aggdesigner-algorithm-5.1.5-jhyde.jar -DgroupId=org.pentaho -DartifactId=pentaho-aggdesigner-algorithm -Dversion=5.1.5-jhyde -Dpackaging=jar
+                mvn install:install-file -Dfile=pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom -DgroupId=org.pentaho -DartifactId=pentaho-aggdesigner-algorithm -Dversion=5.1.5-jhyde -Dpackaging=pom
                 """
                 sh "mvn -B clean install -Pmem,core,$platforms,ee -DskipTests"
             }


### PR DESCRIPTION
## Short Description
Add an artifact check stage in order for a quick smoke test of whether all the versions can be built from a PR or not. If the artifacts can't be built, then the PR should be rejected.

## Long Description
This PR adds an additional stage to check if artifacts can be built or not. It runs the initial build check and then the spotbug stages in a single node. Then it dynamically generates the new stages depending on the branch. There is some duplicate needed since the new node cannot inherit the environment variables from the pipeline, so it needs to check the correct source_branch again along with doing another checkout. Once the spotbugs stage is completed, the artifact build stage is all run in parllel, so the normal case of dbaas3,dbaas3.1,cdh6.3.0,hdp3.1.0, and hdp3.1.5 are all run at the same time once triggered.

## How to test
Hooked up to the spotbugs pipeline, so any commits will trigger a build.