### PR TITLE
DB-12352 Fix auto view refreshing mode for view on top of view

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -48,6 +48,7 @@ import com.splicemachine.pipeline.ErrorState;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -1456,6 +1457,30 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                 views.add((ViewDescriptor) d);
             }
         }
+
+        // assuming no circle dependencies
+        views.sort((v1, v2) -> {
+            try {
+                List<Dependency> v2deps = dm.getDependents(v2);
+                for (Dependency v2dep : v2deps) {
+                    Dependent d = v2dep.getDependent();
+                    if (d == v1) {
+                        return 1;
+                    }
+                }
+            } catch (StandardException ignored) {}
+            try {
+                List<Dependency> v1deps = dm.getDependents(v1);
+                for (Dependency v1dep : v1deps) {
+                    Dependent d = v1dep.getDependent();
+                    if (d == v2) {
+                        return -1;
+                    }
+                }
+            } catch (StandardException ignored) {}
+
+            return 0;
+        });
 
         for (ViewDescriptor vd : views) {
             TableDescriptor viewTd = dd.getTableDescriptor(vd.getUUID(), activation.getTransactionController());


### PR DESCRIPTION
## Short Description
This change fixes an issue that in automatic view refreshing mode, views defined on top of other views sometimes are not refreshed properly.

3.1 PR: https://github.com/splicemachine/spliceengine/pull/5684
3.0 PR: https://github.com/splicemachine/spliceengine/pull/5685

## Long Description
Suppose we have views defined as the following:
```
create table T (c int, d int);
create view v as select * from T;
create view vv as select * from v;
```

Usually, when getting dependencies of table `T`, dependency manager returns a list of dependent items in their added order. Since view `VV` is defined after `V`, its dependencies to `T` and `V` are added after dependency from `V` to `T` is added. This should be the case because internally, dependency manager uses a `List` storing dependent items of an object. Also, `V` has to be defined before `VV`. It cannot be the other way around.

In refreshing views defined on `T`, we need to follow this order because we have to refresh `V` first. If we refresh `VV` first, then effectively `VV` is not refreshed because it's still defined on the outdated definition of `V`. `V` will be refreshed correctly later, potentially making `VV` an outdated or invalid view.

However, `dm.getDependents()` method could return dependent items in a different order with a low chance. Not sure how this can happen under the hood. But on caller site, it seems we cannot make any assumption on the returned order. For this reason, I added a sorting process to sort the returned dependent items so that for any pair (v1, v2), if v1 depends on v2, put v1 after v2. This assumes that we cannot have circle in dependencies.

With this fix, `testAutomaticViewRefreshingOn_SecondLevelSelectStarView` passed 1000+ consecutive runs when tested against a standalone cluster. Without this fix, we could see it fail once in about 60 - 300 runs.

## How to test
`testAutomaticViewRefreshingOn_SecondLevelSelectStarView` should not fail sporadically anymore.
