### PR TITLE
DB-12364: update zookeeper property if a core system table index is recreated(3.1)

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -42,7 +42,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value="MS_PKGPROTECT")
 public abstract class BaseDataDictionary implements DataDictionary, ModuleControl, ModuleSupportable,java.security.PrivilegedAction {
     protected static final String       CFG_SYSTABLES_ID = "SystablesIdentifier";
-    protected static final String       CFG_SYSTABLES_INDEX1_ID = "SystablesIndex1Identifier";
+    public    static final String       CFG_SYSTABLES_INDEX1_ID = "SystablesIndex1Identifier";
     protected static final String       CFG_SYSTABLES_INDEX2_ID = "SystablesIndex2Identifier";
     protected static final String       CFG_SYSCOLUMNS_ID = "SyscolumnsIdentifier";
     protected static final String       CFG_SYSCOLUMNS_INDEX1_ID = "SyscolumnsIndex1Identifier";
@@ -56,7 +56,7 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
     protected static final String       CFG_SYSSCHEMAS_INDEX1_ID = "SysschemasIndex1Identifier";
     protected static final String       CFG_SYSSCHEMAS_INDEX2_ID = "SysschemasIndex2Identifier";
     protected static final int          SYSCONGLOMERATES_CORE_NUM = 0;
-    protected static final int          SYSTABLES_CORE_NUM = 1;
+    public    static final int          SYSTABLES_CORE_NUM = 1;
     protected static final int          SYSCOLUMNS_CORE_NUM = 2;
     protected static final int          SYSSCHEMAS_CORE_NUM = 3;
     protected static final int          NUM_CORE = 4;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -70,16 +70,17 @@ public class SpliceCatalogUpgradeScripts{
 
     static final public Splice_DD_Version baseVersion1 = new Splice_DD_Version(null, 2, 8, 0);
     static final public Splice_DD_Version baseVersion2 = new Splice_DD_Version(null, 3, 1, 0);
+    static final public Splice_DD_Version baseVersion5 = new Splice_DD_Version(null, 3, 1, 1);
     static final public Splice_DD_Version baseVersion3 = baseVersion2;
     static final public Splice_DD_Version baseVersion4 = baseVersion2;
 
-    public SpliceCatalogUpgradeScripts(SpliceDataDictionary sdd, TransactionController tc){
+    public SpliceCatalogUpgradeScripts(SpliceDataDictionary sdd, TransactionController tc, Properties startParams){
         this.sdd=sdd;
         this.tc=tc;
 
         scripts = new ArrayList<>();
-        addUpgradeScript(baseVersion4, 2020, new UpgradeAddConglomerateNumberIndex(sdd, tc));
-        addUpgradeScript(baseVersion4, 2024, new UpgradeScriptToPrioritizeSchemaIdInSystemIndices(sdd, tc));
+        addUpgradeScript(baseVersion5, 2020, new UpgradeAddConglomerateNumberIndex(sdd, tc));
+        addUpgradeScript(baseVersion5, 2024, new UpgradeScriptToPrioritizeSchemaIdInSystemIndices(sdd, tc, startParams));
         // DB-11296: UpgradeConglomerateTable has to be executed first, because it adds a system table
         // CONGLOMERATE_SI_TABLE_NAME that is from then on needed to create tables, e.g.
         // in UpgradeScriptToAddSysNaturalNumbersTable. If UpgradeConglomerateTable is at the end,

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToPrioritizeSchemaIdInSystemIndices.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToPrioritizeSchemaIdInSystemIndices.java
@@ -18,13 +18,20 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.sql.catalog.*;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
-import com.splicemachine.utils.SpliceLogUtils;
 
 import java.util.Properties;
 
+import static com.splicemachine.db.impl.sql.catalog.BaseDataDictionary.CFG_SYSTABLES_INDEX1_ID;
+
 public class UpgradeScriptToPrioritizeSchemaIdInSystemIndices extends UpgradeScriptBase {
-    public UpgradeScriptToPrioritizeSchemaIdInSystemIndices(SpliceDataDictionary sdd, TransactionController tc) {
+
+    private Properties startParams;
+
+    public UpgradeScriptToPrioritizeSchemaIdInSystemIndices(SpliceDataDictionary sdd,
+                                                            TransactionController tc,
+                                                            Properties startParams) {
         super(sdd, tc);
+        this.startParams = startParams;
     }
 
     @Override
@@ -34,6 +41,9 @@ public class UpgradeScriptToPrioritizeSchemaIdInSystemIndices extends UpgradeScr
                 DataDictionary.SYSTABLES_CATALOG_NUM,
                 new int[]{SYSTABLESRowFactory.SYSTABLES_INDEX1_ID}
         );
+
+        sdd.updateBootstrapProperty(startParams, BaseDataDictionary.SYSTABLES_CORE_NUM,
+                CFG_SYSTABLES_INDEX1_ID, SYSTABLESRowFactory.SYSTABLES_INDEX1_ID);
 
         sdd.upgradeRecreateIndexesOfSystemTable(
                 tc,

--- a/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
+++ b/splice_machine/src/test/java/com/splicemachine/derby/utils/SpliceCatalogUpgradeScriptsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 public class SpliceCatalogUpgradeScriptsTest {
     String s1 =
@@ -36,22 +37,23 @@ public class SpliceCatalogUpgradeScriptsTest {
             "VERSION4.2023: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeFixIndexDescriptors\n";
 
     // Those scripts must run before other upgrade scripts
-    String s3 = "VERSION4.2020: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeAddConglomerateNumberIndex\n" +
-            "VERSION4.2024: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToPrioritizeSchemaIdInSystemIndices\n" +
+    String s3 = "VERSION5.2020: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeAddConglomerateNumberIndex\n" +
+            "VERSION5.2024: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeScriptToPrioritizeSchemaIdInSystemIndices\n" +
             "VERSION4.1996: com.splicemachine.derby.impl.sql.catalog.upgrade.UpgradeConglomerateTable\n";
     // add more scripts here
 
     private String replaceVersions(String s) {
         return s.replace("VERSION2", SpliceCatalogUpgradeScripts.baseVersion2.toString())
                 .replace("VERSION3", SpliceCatalogUpgradeScripts.baseVersion3.toString())
-                .replace("VERSION4", SpliceCatalogUpgradeScripts.baseVersion4.toString());
+                .replace("VERSION4", SpliceCatalogUpgradeScripts.baseVersion4.toString())
+                .replace("VERSION5", SpliceCatalogUpgradeScripts.baseVersion5.toString());
         // add more base versions here.
     }
 
     @Test
     public void test_since_1933()
     {
-        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null, new Properties());
         Splice_DD_Version version = new Splice_DD_Version(null, 3,1,0, 1933);
         List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
                 SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
@@ -61,7 +63,7 @@ public class SpliceCatalogUpgradeScriptsTest {
     @Test
     public void test_since_1987()
     {
-        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null, new Properties());
         Splice_DD_Version version = new Splice_DD_Version(null, 3,1,0, 1987);
         List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
                 SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);
@@ -71,7 +73,7 @@ public class SpliceCatalogUpgradeScriptsTest {
     @Test
     public void test_since_2000_upgrade_empty()
     {
-        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null);
+        SpliceCatalogUpgradeScripts s = new SpliceCatalogUpgradeScripts(null, null, new Properties());
         Splice_DD_Version version = new Splice_DD_Version(null, 4,0,0, 2000);
         List<SpliceCatalogUpgradeScripts.VersionAndUpgrade> list =
                 SpliceCatalogUpgradeScripts.getScriptsToUpgrade(s.getScripts(), version);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
(e.g. short description of the PR)

## Long Description
(e.g. why in detail, how, potential further work)

## How to test
(e.g. if bugfix: how to reproduce bug / impact)
(if feature: a easy example of how to check the feature)
(if feature is a configuration: an example to see different behavior with different configuration)
