### PR TITLE
DB-12364: update zookeeper property if a core system table index is recreated

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/catalog/BaseDataDictionary.java
@@ -43,7 +43,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value="MS_PKGPROTECT")
 public abstract class BaseDataDictionary implements DataDictionary, ModuleControl, ModuleSupportable,java.security.PrivilegedAction {
     protected static final String       CFG_SYSTABLES_ID = "SystablesIdentifier";
-    protected static final String       CFG_SYSTABLES_INDEX1_ID = "SystablesIndex1Identifier";
+    public    static final String       CFG_SYSTABLES_INDEX1_ID = "SystablesIndex1Identifier";
     protected static final String       CFG_SYSTABLES_INDEX2_ID = "SystablesIndex2Identifier";
     protected static final String       CFG_SYSCOLUMNS_ID = "SyscolumnsIdentifier";
     protected static final String       CFG_SYSCOLUMNS_INDEX1_ID = "SyscolumnsIndex1Identifier";
@@ -61,7 +61,7 @@ public abstract class BaseDataDictionary implements DataDictionary, ModuleContro
     protected static final String        CFG_SYSDATABASES_INDEX2_ID = "SysdatabasesIndex2Identifier";
     public static final String           CFG_ALLOW_MULTIDATABASE = "AllowMultidatabase";
     protected static final int          SYSCONGLOMERATES_CORE_NUM = 0;
-    protected static final int          SYSTABLES_CORE_NUM = 1;
+    public    static final int          SYSTABLES_CORE_NUM = 1;
     protected static final int          SYSCOLUMNS_CORE_NUM = 2;
     protected static final int          SYSSCHEMAS_CORE_NUM = 3;
     protected static final int           SYSDATABASES_CORE_NUM = 4;

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -1873,4 +1873,12 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
                     cd.getDescriptorName(), tabInfo.getTableName());
         }
     }
+
+    public void updateBootstrapProperty(Properties startParams, int catalogNum, String indexName, int indexId) {
+        if (catalogNum > NUM_CORE)
+            return;
+
+        startParams.put(indexName,Long.toString(
+                coreInfo[catalogNum].getIndexConglomerate(indexId)));
+    }
 }

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/SpliceCatalogUpgradeScripts.java
@@ -81,7 +81,7 @@ public class SpliceCatalogUpgradeScripts{
 
         scripts = new ArrayList<>();
         addUpgradeScript(baseVersion4, 2020, new UpgradeAddConglomerateNumberIndex(sdd, tc));
-        addUpgradeScript(baseVersion4, 2024, new UpgradeScriptToPrioritizeSchemaIdInSystemIndices(sdd, tc));
+        addUpgradeScript(baseVersion4, 2024, new UpgradeScriptToPrioritizeSchemaIdInSystemIndices(sdd, tc, startParams));
         // DB-11296: UpgradeConglomerateTable has to be executed first, because it adds a system table
         // CONGLOMERATE_SI_TABLE_NAME that is from then on needed to create tables, e.g.
         // in UpgradeScriptToAddSysNaturalNumbersTable. If UpgradeConglomerateTable is at the end,

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToPrioritizeSchemaIdInSystemIndices.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/upgrade/UpgradeScriptToPrioritizeSchemaIdInSystemIndices.java
@@ -18,13 +18,20 @@ import com.splicemachine.db.iapi.sql.dictionary.DataDictionary;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.impl.sql.catalog.*;
 import com.splicemachine.derby.impl.sql.catalog.SpliceDataDictionary;
-import com.splicemachine.utils.SpliceLogUtils;
 
 import java.util.Properties;
 
+import static com.splicemachine.db.impl.sql.catalog.BaseDataDictionary.CFG_SYSTABLES_INDEX1_ID;
+
 public class UpgradeScriptToPrioritizeSchemaIdInSystemIndices extends UpgradeScriptBase {
-    public UpgradeScriptToPrioritizeSchemaIdInSystemIndices(SpliceDataDictionary sdd, TransactionController tc) {
+
+    private Properties startParams;
+
+    public UpgradeScriptToPrioritizeSchemaIdInSystemIndices(SpliceDataDictionary sdd,
+                                                            TransactionController tc,
+                                                            Properties startParams) {
         super(sdd, tc);
+        this.startParams = startParams;
     }
 
     @Override
@@ -34,6 +41,9 @@ public class UpgradeScriptToPrioritizeSchemaIdInSystemIndices extends UpgradeScr
                 DataDictionary.SYSTABLES_CATALOG_NUM,
                 new int[]{SYSTABLESRowFactory.SYSTABLES_INDEX1_ID}
         );
+
+        sdd.updateBootstrapProperty(startParams, BaseDataDictionary.SYSTABLES_CORE_NUM,
+                CFG_SYSTABLES_INDEX1_ID, SYSTABLESRowFactory.SYSTABLES_INDEX1_ID);
 
         sdd.upgradeRecreateIndexesOfSystemTable(
                 tc,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Fixes a regression from DB-12224

## Long Description
DB-12224 introduced an upgrade scripts that recreate some system table indexes. For core system tables and indexes, splice stores their conglomerate number in zookeeper. The upgrade scripts needs to update them.

## How to test
Deploy a pre-2024 build to create a splice database. Deploy 2025 build to upgrade database. Restart and run simple queries, such as show tables, select count(*) from sys.systable, from sqlshell.