### PR TITLE
DB-12303 Fix corrupted trigger after NSDS DML: DB-6516 regression

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
+++ b/db-engine/src/main/java/com/splicemachine/db/iapi/sql/dictionary/DataDictionary.java
@@ -39,6 +39,8 @@ import com.splicemachine.db.iapi.services.uuid.UUIDFactory;
 import com.splicemachine.db.iapi.sql.compile.Visitable;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
 import com.splicemachine.db.iapi.sql.depend.DependencyManager;
+import com.splicemachine.db.iapi.sql.depend.Dependent;
+import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionFactory;
 import com.splicemachine.db.iapi.store.access.TransactionController;
@@ -2261,7 +2263,7 @@ public interface DataDictionary{
 
     void deleteSnapshot(String snapshotName, long conglomeratenumber, TransactionController tc) throws StandardException;
 
-    boolean canUseDependencyManager();
+    boolean canUseDependencyManager(Dependent d, Provider p);
 
     /**
      * Get default roles granted to a user

--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/depend/BasicDependencyManager.java
@@ -125,7 +125,7 @@ public class BasicDependencyManager implements DependencyManager {
         @exception StandardException thrown if something goes wrong
      */
     public void addDependency(Dependent d, Provider p, ContextManager cm) throws StandardException {
-        if (dd.canUseDependencyManager()) {
+        if (dd.canUseDependencyManager(d, p)) {
             addDependency(d, p, cm, null);
         }
     }
@@ -147,11 +147,23 @@ public class BasicDependencyManager implements DependencyManager {
      */
     private void addDependency(Dependent d, Provider p, ContextManager cm, TransactionController tc) throws StandardException {
         // Dependencies are either in-memory or stored, but not both.
-        if (! d.isPersistent() || ! p.isPersistent()) {
+        if (!isPersistentDependency(d, p)) {
             addInMemoryDependency(d, p, cm);
         } else {
             addStoredDependency(d, p, cm, tc);
         }
+    }
+
+    /**
+     * Tests whether a dependency is stored in the data dictionary
+     * or in the in-memory dependency map.
+     *
+     * @param d the dependent
+     * @param p the provider
+     * @return true if the dependent d, is stored in the data dictionary.
+     */
+    public static boolean isPersistentDependency(Dependent d, Provider p) {
+        return d.isPersistent() && p.isPersistent();
     }
 
     /**

--- a/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
+++ b/db-engine/src/test/java/com/splicemachine/db/impl/sql/catalog/DataDictionaryImplTest.java
@@ -33,6 +33,8 @@ package com.splicemachine.db.impl.sql.catalog;
 
 import com.splicemachine.db.catalog.UUID;
 import com.splicemachine.db.iapi.error.StandardException;
+import com.splicemachine.db.iapi.sql.depend.Dependent;
+import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.store.access.TransactionController;
 import com.splicemachine.db.iapi.types.DataTypeDescriptor;
@@ -100,7 +102,7 @@ public class DataDictionaryImplTest {
         }
 
         @Override
-        public boolean canUseDependencyManager() {
+        public boolean canUseDependencyManager(Dependent d, Provider p) {
             return false;
         }
 

--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/catalog/SpliceDataDictionary.java
@@ -34,6 +34,8 @@ import com.splicemachine.db.iapi.services.io.FormatableBitSet;
 import com.splicemachine.db.iapi.services.monitor.Monitor;
 import com.splicemachine.db.iapi.services.sanity.SanityManager;
 import com.splicemachine.db.iapi.sql.conn.LanguageConnectionContext;
+import com.splicemachine.db.iapi.sql.depend.Dependent;
+import com.splicemachine.db.iapi.sql.depend.Provider;
 import com.splicemachine.db.iapi.sql.dictionary.*;
 import com.splicemachine.db.iapi.sql.execute.ExecRow;
 import com.splicemachine.db.iapi.sql.execute.ExecutionContext;
@@ -73,6 +75,8 @@ import java.sql.Types;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.splicemachine.db.impl.sql.depend.BasicDependencyManager.isPersistentDependency;
 
 /**
  * @author Scott Fines
@@ -955,8 +959,8 @@ public class SpliceDataDictionary extends DataDictionaryImpl{
     }
 
     @Override
-    public boolean canUseDependencyManager() {
-        return !SpliceClient.isClient();
+    public boolean canUseDependencyManager(Dependent d, Provider p) {
+        return !SpliceClient.isClient() || isPersistentDependency(d, p);
     }
 
     @Override

--- a/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/triggers/TriggerIT.scala
+++ b/splice_spark/src/test/scala/com/splicemachine/spark/splicemachine/triggers/TriggerIT.scala
@@ -70,8 +70,12 @@ class TriggerIT extends FunSuite with TestContext with Matchers {
   test("Test Insert with Trigger") {  // Added for DB-10707
     truncateTables
     createInsertTrigger
+    createUpdateStatementTrigger
+    splicemachineContext.insert( df, t1 )
+    truncateTables
     splicemachineContext.insert( df, t1 )
     dropInsertTrigger
+    dropUpdateStatementTrigger
     org.junit.Assert.assertEquals( contentOf(t1), contentOf(t2) )
   }
 

--- a/splice_spark2/src/test/scala/com/splicemachine/spark2/splicemachine/triggers/TriggerIT.scala
+++ b/splice_spark2/src/test/scala/com/splicemachine/spark2/splicemachine/triggers/TriggerIT.scala
@@ -70,8 +70,12 @@ class TriggerIT extends FunSuite with TestContext with Matchers {
   test("Test Insert with Trigger") {  // Added for DB-10707
     truncateTables
     createInsertTrigger
+    createUpdateStatementTrigger
+    splicemachineContext.insert( df, t1 )
+    truncateTables
     splicemachineContext.insert( df, t1 )
     dropInsertTrigger
+    dropUpdateStatementTrigger
     org.junit.Assert.assertEquals( contentOf(t1), contentOf(t2) )
   }
 


### PR DESCRIPTION
## Short Description
A DML statement run in NSDS which fires a trigger may corrupt data dictionary dependencies.  Subsequent DDL statements, such as TRUNCATE involving trigger tables corrupts the trigger, which may cause trigger rows to be written to the wrong table and/or be written incorrectly.

## Long Description
Whenever a trigger needs recompilation due to some dictionary modification which the trigger may depend on, it is marked as invalid in the sys.sysstatements system table.  For example, if the target table of the trigger is altered or another trigger is added to the same target table, the previous trigger is marked invalid.  The next statement which fires the trigger causes recompilation of the trigger.  First BasicDependencyManager.clearDependencies is called to remove the row in sys.sysdepends for the old version of the trigger SPSDecriptor.  Then GenericTriggerExecutor.compile is called to build the new trigger SPSDecriptor and store a persistent representation of it in sys.sysstatements.  Then BasicDependencyManager.addDependency is called to add the UUID of the new SPSDecriptor in sys.sysdepends, so that future DDLs know which stored statement to invalidate or clear.  

The problem is that [DB-6516](https://splicemachine.atlassian.net/browse/DB-6516) added a check in the addDependency method, called canUseDependencyManager, to skip adding the dependency if running NSDS.  This causes any futureDDL statements to not detect the trigger dependency and not recompile the trigger.  When a truncate is done on the table, this should invalidate the trigger because the new table will have a new conglomerate number, but the old trigger statement still refer to the old conglomerate.  When the trigger is later fired, it writes rows into a defunct table.  This shows up as rows simply not appearing in the proper target table, as they are supposed to, or sometimes we hit a duplicate primary key violation, because the old table, invisible to the user, still exists in HBase, and still has rows in it (if Vacuum has not been run).

DB-6516 was trying to avoid memory leaks in the in-memory dependency manager because anything addDependency adds to the DependencyManager in NSDS was not getting released.  However, if both the provider (TableDescriptor) and the dependent (SPSDescriptor) are persistent, then addDependency writes to the sys.sysdepends table and not the in-memory DependencyManager.  We never want to skip writing persistent dependencies, so, the fix is to have canUseDependencyManager return true when the dependency is to be written to disk, no matter if we are running on NSDS or not.

## How to test
```
CREATE TABLE ECOMMERCE_FS.TEST (
CUSTOMER_ID INTEGER NOT NULL GENERATED BY DEFAULT AS IDENTITY (START WITH 1, INCREMENT BY 1)
,LAST_UPDATE_TS TIMESTAMP NOT NULL
,FEATURE_1 INTEGER
,FEATURE_2 INTEGER
, PRIMARY KEY(CUSTOMER_ID)) ;

CREATE TABLE ECOMMERCE_FS.TEST_HISTORY (
CUSTOMER_ID INTEGER NOT NULL
,ASOF_TS TIMESTAMP NOT NULL
,INGEST_TS TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
,FEATURE_1 INTEGER
,FEATURE_2 INTEGER
, CONSTRAINT SQLA6D10249017A67F3B7620004DDAD2420 PRIMARY KEY(CUSTOMER_ID,ASOF_TS));

CREATE TRIGGER TEST_HISTORY_INSERT AFTER INSERT ON ECOMMERCE_FS.TEST REFERENCING NEW_TABLE AS NEWW FOR EACH STATEMENT
  INSERT INTO ECOMMERCE_FS.TEST_history (ASOF_TS, INGEST_TS, CUSTOMER_ID, feature_1,feature_2)
        SELECT NEWW.LAST_UPDATE_TS, CURRENT_TIMESTAMP, NEWW.CUSTOMER_ID, NEWW.feature_1,NEWW.feature_2 FROM NEWW;

CREATE TRIGGER TEST_HISTORY_UPDATE AFTER  UPDATE ON ECOMMERCE_FS.TEST REFERENCING NEW_TABLE AS NEWW FOR EACH STATEMENT INSERT INTO ECOMMERCE_FS.TEST_history (ASOF_TS, INGEST_TS, CUSTOMER_ID, feature_1,feature_2)
        SELECT NEWW.LAST_UPDATE_TS, CURRENT_TIMESTAMP, NEWW.CUSTOMER_ID, NEWW.feature_1,NEWW.feature_2 FROM NEWW;

set schema splice;
drop table if exists test;

create table test(
    customer_id int,
    LAST_UPDATE_TS timestamp,
    feature_1 int,
    feature_2 int);

insert into test values(1, '2020-01-01 00:00:00', 1,1);
insert into test values(2, '2020-01-01 00:00:00', 1,1);

/* Now, in NSDS, run the following: */
import com.splicemachine.derby.utils._
import com.splicemachine.spark.splicemachine._
import com.splicemachine.derby.impl.SpliceSpark
val spliceJDBC = "jdbc:splice://localhost:1527/splicedb;user=splice;password=admin"
val spc = new SplicemachineContext(spliceJDBC)
val df = spc.df("select * from test")
spc.insert(df, "ecommerce_fs.test")
 
/* Now, back in sqlshell, run the following, which should not hit a duplicate PK constraint violation: */
truncate table ecommerce_fs.test;
truncate table ECOMMERCE_FS.TEST_history;
insert into ECOMMERCE_FS.TEST values(1, '2020-01-01 00:00:00', 1,1);
insert into ECOMMERCE_FS.TEST values(2, '2020-01-01 00:00:00', 1,1);
```

