### PR TITLE
DB-12373 fix SqlshellIT.testCustomFormatsOption sporadic

### DIFF
--- a/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
+++ b/hbase_sql/src/test/java/com/splicemachine/derby/utils/SqlshellIT.java
@@ -530,7 +530,8 @@ public class SqlshellIT {
                             rowsSelected(1));
 
             // e.g. 2021-07-09 15:34:36.474536
-            String timestampFormat = dateFormat + " " + timeFormat + ".\\d\\d\\d\\d\\d\\d";
+            // note: trailing zeros are cut, so you might get for 15:34:36.474000 -> 15:34:36.474
+            String timestampFormat = dateFormat + " " + timeFormat + ".[\\d]*";
             executeR("values current_timestamp;\n",
                      timestampFormat + "[ ]*\n" +
                      rowsSelected(1));


### PR DESCRIPTION
we test the current time against `\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\d\d\d` which is mostly correct,
however, if we’re unlucky and the current time is like `2021-07-19 17:55:24.500000`, it would be displayed
as `2021-07-19 17:55:24.5` , and we get a failed test. This fixes that.