### PR TITLE
DB-12365 Fix a regression caused by DB-12158

### DIFF
--- a/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
+++ b/db-engine/src/main/java/com/splicemachine/db/impl/sql/compile/FromSubquery.java
@@ -323,15 +323,6 @@ public class FromSubquery extends FromTable
             } else if (resultColumns.size() > subqueryRCL.size()) {
                 // columns dropped from underlying table
                 throw StandardException.newException(SQLState.LANG_DERIVED_COLUMN_LIST_MISMATCH, correlationName);
-            } else {
-                // number of columns is OK, check column names
-                for (int i = 0; i < resultColumns.size(); ++i) {
-                    ResultColumn thisRC = resultColumns.elementAt(i);
-                    ResultColumn subqRC = subqueryRCL.elementAt(i);
-                    if (thisRC.getName() != null && !thisRC.getName().equals(subqRC.getName())) {
-                        throw StandardException.newException(SQLState.LANG_DERIVED_COLUMN_NAME_USE, thisRC.getName());
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
## Short Description
This change fixes a regression caused by DB-12158.

## Long Description
DB-12158 adds a new check on matching column names in binding `FromSubquery`. It was added for cases where column count matches, but concrete columns do not because of previous add/drop column operations.

It turned out that the check has to be removed due to the possibility of renaming columns names in defining views. In select statement, there is no way to tell if the column names are different due to alter table operations or just renaming in view definition. Checking column positions are also not possible because view columns are always 1, 2, 3, .... It has to be this way because underlying select could have generated columns that do no exists in any base tables at all. As a result, when automatic view refreshing mode is off, selecting an obsolete view may return a result with wrong column names. This is the same behavior as before DB-12158 and wanted to be fixed, but now just falls back to previous behavior again.

## How to test

See modification of `testAutomaticViewRefreshingOff`. Also, see new test on views with renamed columns in `testAutomaticViewRefreshingOn_SelectStarViewWithRenamedColumns`.