### PR TITLE
DB-12363: fix drop column and constraints(3.1)

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -763,7 +763,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
         int maxStoragePosition = tableDescriptor.getColumnDescriptorList().maxStoragePosition();
         int size = tableDescriptor.getColumnDescriptorList().size();
         int droppedColumnPosition = columnDescriptor.getPosition();
-
+        int droppedStoragePosition = columnDescriptor.getStoragePosition();
         FormatableBitSet toDrop = new FormatableBitSet(maxStoragePosition + 1);
         toDrop.set(droppedColumnPosition);
         tableDescriptor.setReferencedColumnMap(toDrop);
@@ -781,7 +781,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
 
         // Now handle constraints
         List<ConstantAction> newCongloms = handleConstraints(activation, tableDescriptor, columnName, lcc, dd, dm, cascade, tc,
-                                                             droppedColumnPosition);
+                                                             droppedStoragePosition);
 
         /* If there are new backing conglomerates which must be
          * created to replace a dropped shared conglomerate
@@ -940,7 +940,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                                                    DependencyManager dm,
                                                    boolean cascade,
                                                    TransactionController tc,
-                                                   int droppedColumnPosition) throws StandardException {
+                                                   int droppedStoragePosition) throws StandardException {
         ConstraintDescriptorList csdl = dd.getConstraintDescriptors(td);
         int csdl_size = csdl.size();
 
@@ -959,16 +959,16 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
             int numRefCols = referencedColumns.length, j;
             boolean changed = false;
             for (j = 0; j < numRefCols; j++) {
-                if (referencedColumns[j] > droppedColumnPosition)
+                if (referencedColumns[j] > droppedStoragePosition)
                     changed = true;
-                if (referencedColumns[j] == droppedColumnPosition)
+                if (referencedColumns[j] == droppedStoragePosition)
                     break;
             }
             if (j == numRefCols) {// column not referenced
                 if ((cd instanceof CheckConstraintDescriptor) && changed) {
                     dd.dropConstraintDescriptor(cd, tc);
                     for (j = 0; j < numRefCols; j++) {
-                        if (referencedColumns[j] > droppedColumnPosition)
+                        if (referencedColumns[j] > droppedStoragePosition)
                             referencedColumns[j]--;
                     }
                     ((CheckConstraintDescriptor) cd).setReferencedColumnsDescriptor(new ReferencedColumnsDescriptorImpl(referencedColumns));


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Fixes a regression from DB-12224

## Long Description
DB-12224 introduced an upgrade scripts that recreate some system table indexes. For core system tables and indexes, splice stores their conglomerate number in zookeeper. The upgrade scripts needs to update them.

## How to test
Deploy a pre-2024 build to create a splice database. Deploy 2025 build to upgrade database. Restart and run simple queries, such as show tables, select count(*) from sys.systable, from sqlshell.