### PR TITLE
DB-12363: fix drop column and constraints

### DIFF
--- a/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
+++ b/splice_machine/src/main/java/com/splicemachine/derby/impl/sql/execute/actions/ModifyColumnConstantOperation.java
@@ -768,7 +768,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
         int maxStoragePosition = tableDescriptor.getColumnDescriptorList().maxStoragePosition();
         int size = tableDescriptor.getColumnDescriptorList().size();
         int droppedColumnPosition = columnDescriptor.getPosition();
-
+        int droppedStoragePosition = columnDescriptor.getStoragePosition();
         FormatableBitSet toDrop = new FormatableBitSet(maxStoragePosition + 1);
         toDrop.set(droppedColumnPosition);
         tableDescriptor.setReferencedColumnMap(toDrop);
@@ -786,7 +786,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
 
         // Now handle constraints
         List<ConstantAction> newCongloms = handleConstraints(activation, tableDescriptor, columnName, lcc, dd, dm, cascade, tc,
-                                                             droppedColumnPosition);
+                                                             droppedStoragePosition);
 
         /* If there are new backing conglomerates which must be
          * created to replace a dropped shared conglomerate
@@ -945,7 +945,7 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
                                                    DependencyManager dm,
                                                    boolean cascade,
                                                    TransactionController tc,
-                                                   int droppedColumnPosition) throws StandardException {
+                                                   int droppedStoragePosition) throws StandardException {
         ConstraintDescriptorList csdl = dd.getConstraintDescriptors(td);
         int csdl_size = csdl.size();
 
@@ -964,16 +964,16 @@ public class ModifyColumnConstantOperation extends AlterTableConstantOperation{
             int numRefCols = referencedColumns.length, j;
             boolean changed = false;
             for (j = 0; j < numRefCols; j++) {
-                if (referencedColumns[j] > droppedColumnPosition)
+                if (referencedColumns[j] > droppedStoragePosition)
                     changed = true;
-                if (referencedColumns[j] == droppedColumnPosition)
+                if (referencedColumns[j] == droppedStoragePosition)
                     break;
             }
             if (j == numRefCols) {// column not referenced
                 if ((cd instanceof CheckConstraintDescriptor) && changed) {
                     dd.dropConstraintDescriptor(cd, tc);
                     for (j = 0; j < numRefCols; j++) {
-                        if (referencedColumns[j] > droppedColumnPosition)
+                        if (referencedColumns[j] > droppedStoragePosition)
                             referencedColumns[j]--;
                     }
                     ((CheckConstraintDescriptor) cd).setReferencedColumnsDescriptor(new ReferencedColumnsDescriptorImpl(referencedColumns));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Short Description
Fix a regression from DB-12306.

## Long Description
If a constraint is defined on a column, the constraint should be dropped when the column is being dropped. The column reference stored in constraint is storage position, so we should get storage position of the dropped column to check whether a constraint is defined on the column. 

DB-12306 tried to fix a similar issue for triggers, which store relative column position. We need to check triggers using relative position, and check constraints using storage position 

## How to test
CREATE TABLE PLAIN_ALTER_SQL.float_alter2 ( VAL1 FLOAT);
ALTER TABLE PLAIN_ALTER_SQL.float_alter2 ADD COLUMN VAL5 FLOAT;
ALTER TABLE PLAIN_ALTER_SQL.float_alter2 DROP COLUMN VAL5;

ALTER TABLE PLAIN_ALTER_SQL.float_alter2 ADD COLUMN VAL6 FLOAT NOT NULL DEFAULT 111  CONSTRAINT float_VAL6 PRIMARY KEY;
ALTER TABLE PLAIN_ALTER_SQL.float_alter2 DROP VAL6; --  this should drop the PK constraint

SELECT * FROM SYS.SYSCONSTRAINTS; 
